### PR TITLE
#23 Chore: 베이스 엔티티 Generic 사용하도록 업데이트

### DIFF
--- a/common/src/main/java/dukku/common/global/jpa/entity/BaseEntity.java
+++ b/common/src/main/java/dukku/common/global/jpa/entity/BaseEntity.java
@@ -18,14 +18,16 @@ import java.time.LocalDateTime;
 @SuperBuilder
 @Getter
 // 모든 엔티티들의 조상
-public abstract class BaseEntity implements CanGetModelTypeCode {
+public abstract class BaseEntity<T> implements CanGetModelTypeCode {
 
     protected void publishEvent(Object event) {
         GlobalConfig.getEventPublisher().publish(event);
     }
 
-    public abstract int getId();
+    public abstract T getId();
+
     public abstract LocalDateTime getCreatedAt();
+
     public abstract LocalDateTime getUpdatedAt();
 
     @Override

--- a/common/src/main/java/dukku/common/global/jpa/entity/BaseIdAndTime.java
+++ b/common/src/main/java/dukku/common/global/jpa/entity/BaseIdAndTime.java
@@ -16,12 +16,14 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-public abstract class BaseIdAndTime extends BaseEntity {
+public abstract class BaseIdAndTime extends BaseEntity<Integer> {
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    private int id;
+    private Integer id;
+
     @CreatedDate
-    private LocalDateTime createDate;
+    private LocalDateTime createdAt;
+
     @LastModifiedDate
-    private LocalDateTime modifyDate;
+    private LocalDateTime updatedAt;
 }

--- a/common/src/main/java/dukku/common/global/jpa/entity/BaseIdAndUUIDAndTime.java
+++ b/common/src/main/java/dukku/common/global/jpa/entity/BaseIdAndUUIDAndTime.java
@@ -24,10 +24,10 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @AllArgsConstructor
 @Getter
 @SuperBuilder
-public abstract class BaseIdAndUUIDAndTime extends BaseEntity {
+public abstract class BaseIdAndUUIDAndTime extends BaseEntity<Integer> {
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    private int id;
+    private Integer id;
     @JdbcTypeCode(SqlTypes.UUID)
     @Column(columnDefinition = "uuid", updatable = false, nullable = false, unique = true, comment = "유저 UUID")
     private UUID uuid;

--- a/common/src/main/java/dukku/common/global/jpa/entity/BaseManualIdAndTime.java
+++ b/common/src/main/java/dukku/common/global/jpa/entity/BaseManualIdAndTime.java
@@ -15,15 +15,17 @@ import java.time.LocalDateTime;
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor
-public abstract class BaseManualIdAndTime extends BaseEntity {
+public abstract class BaseManualIdAndTime extends BaseEntity<Integer> {
     @Id
-    private int id;
-    @CreatedDate
-    private LocalDateTime createDate;
-    @LastModifiedDate
-    private LocalDateTime modifyDate;
+    private Integer id;
 
-    protected BaseManualIdAndTime(int id) {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    protected BaseManualIdAndTime(Integer id) {
         this.id = id;
     }
 }

--- a/common/src/test/java/dukku/common/global/common/handler/GlobalExceptionHandlerTest.java
+++ b/common/src/test/java/dukku/common/global/common/handler/GlobalExceptionHandlerTest.java
@@ -78,7 +78,7 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getReasonPhrase());
         assertThat(response.getBody().getMessage()).isEqualTo("리소스를 찾을 수 없습니다.");
         assertThat(response.getBody().getStatus()).isEqualTo(404);
-        assertThat(response.getBody().getDetails()).isEqualTo("요청한 리소스를 찾을 수 없습니다.");
+        assertThat(response.getBody().getDetails()).isEqualTo("리소스를 찾을 수 없습니다.");
     }
 
     @Test

--- a/semicolon/src/main/java/dukku/semicolon/Application.java
+++ b/semicolon/src/main/java/dukku/semicolon/Application.java
@@ -1,4 +1,4 @@
-package dukku.user;
+package dukku.semicolon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @EnableJpaAuditing
 @SpringBootApplication(
         scanBasePackages = {
-                "dukku.user",
+                "dukku.semicolon",
                 "dukku.common"
         }
 )

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/ChangePasswordUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/ChangePasswordUseCase.java
@@ -1,11 +1,11 @@
-package dukku.user.boundedContext.user.app;
+package dukku.semicolon.boundedContext.user.app;
 
 import dukku.common.global.eventPublisher.EventPublisher;
-import dukku.user.shared.user.dto.PasswordUpdateRequest;
-import dukku.user.boundedContext.user.entity.User;
-import dukku.user.shared.user.event.UserModifiedEvent;
-import dukku.user.shared.user.exception.UserNotFoundException;
-import dukku.user.boundedContext.user.out.UserRepository;
+import dukku.semicolon.shared.user.dto.PasswordUpdateRequest;
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.shared.user.event.UserModifiedEvent;
+import dukku.semicolon.shared.user.exception.UserNotFoundException;
+import dukku.semicolon.boundedContext.user.out.UserRepository;
 import dukku.common.global.UserUtil;
 import dukku.common.global.exception.UnauthorizedException;
 import lombok.RequiredArgsConstructor;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/FindUserUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/FindUserUseCase.java
@@ -1,8 +1,8 @@
-package dukku.user.boundedContext.user.app;
+package dukku.semicolon.boundedContext.user.app;
 
-import dukku.user.boundedContext.user.entity.User;
-import dukku.user.shared.user.exception.UserNotFoundException;
-import dukku.user.boundedContext.user.out.UserRepository;
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.shared.user.exception.UserNotFoundException;
+import dukku.semicolon.boundedContext.user.out.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/RegisterUserUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/RegisterUserUseCase.java
@@ -1,12 +1,12 @@
-package dukku.user.boundedContext.user.app;
+package dukku.semicolon.boundedContext.user.app;
 
-import dukku.user.shared.user.dto.UserRegisterRequest;
-import dukku.user.boundedContext.user.entity.User;
-import dukku.user.boundedContext.user.entity.type.Role;
-import dukku.user.boundedContext.user.entity.type.UserStatus;
-import dukku.user.shared.user.exception.UserConflictException;
+import dukku.semicolon.shared.user.dto.UserRegisterRequest;
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.boundedContext.user.entity.type.UserStatus;
+import dukku.semicolon.shared.user.exception.UserConflictException;
 import dukku.common.global.eventPublisher.EventPublisher;
-import dukku.user.shared.user.event.UserJoinedEvent;
+import dukku.semicolon.shared.user.event.UserJoinedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/UpdateUserUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/UpdateUserUseCase.java
@@ -1,11 +1,11 @@
-package dukku.user.boundedContext.user.app;
+package dukku.semicolon.boundedContext.user.app;
 
 import dukku.common.global.eventPublisher.EventPublisher;
-import dukku.user.shared.user.dto.UserUpdateRequest;
-import dukku.user.boundedContext.user.entity.User;
-import dukku.user.shared.user.event.UserModifiedEvent;
-import dukku.user.shared.user.exception.UserNotFoundException;
-import dukku.user.boundedContext.user.out.UserRepository;
+import dukku.semicolon.shared.user.dto.UserUpdateRequest;
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.shared.user.event.UserModifiedEvent;
+import dukku.semicolon.shared.user.exception.UserNotFoundException;
+import dukku.semicolon.boundedContext.user.out.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/UserFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/UserFacade.java
@@ -1,11 +1,11 @@
-package dukku.user.boundedContext.user.app;
+package dukku.semicolon.boundedContext.user.app;
 
-import dukku.user.shared.user.dto.PasswordUpdateRequest;
-import dukku.user.shared.user.dto.UserRegisterRequest;
-import dukku.user.shared.user.dto.UserResponse;
-import dukku.user.shared.user.dto.UserUpdateRequest;
-import dukku.user.boundedContext.user.entity.User;
-import dukku.user.boundedContext.user.entity.type.Role;
+import dukku.semicolon.shared.user.dto.PasswordUpdateRequest;
+import dukku.semicolon.shared.user.dto.UserRegisterRequest;
+import dukku.semicolon.shared.user.dto.UserResponse;
+import dukku.semicolon.shared.user.dto.UserUpdateRequest;
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.boundedContext.user.entity.type.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/UserSupport.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/UserSupport.java
@@ -1,7 +1,7 @@
-package dukku.user.boundedContext.user.app;
+package dukku.semicolon.boundedContext.user.app;
 
-import dukku.user.boundedContext.user.entity.User;
-import dukku.user.boundedContext.user.out.UserRepository;
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.boundedContext.user.out.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/entity/User.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/entity/User.java
@@ -1,12 +1,12 @@
-package dukku.user.boundedContext.user.entity;
+package dukku.semicolon.boundedContext.user.entity;
 
-import dukku.user.shared.user.dto.UserRegisterRequest;
-import dukku.user.shared.user.dto.UserResponse;
-import dukku.user.shared.user.dto.UserUpdateRequest;
-import dukku.user.boundedContext.user.entity.type.Role;
-import dukku.user.boundedContext.user.entity.type.UserStatus;
-import dukku.user.shared.user.domain.SourceUser;
-import dukku.user.shared.user.dto.UserDto;
+import dukku.semicolon.shared.user.dto.UserRegisterRequest;
+import dukku.semicolon.shared.user.dto.UserResponse;
+import dukku.semicolon.shared.user.dto.UserUpdateRequest;
+import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.boundedContext.user.entity.type.UserStatus;
+import dukku.semicolon.shared.user.domain.SourceUser;
+import dukku.semicolon.shared.user.dto.UserDto;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/entity/type/Role.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/entity/type/Role.java
@@ -1,4 +1,4 @@
-package dukku.user.boundedContext.user.entity.type;
+package dukku.semicolon.boundedContext.user.entity.type;
 
 import lombok.Getter;
 

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/entity/type/UserStatus.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/entity/type/UserStatus.java
@@ -1,4 +1,4 @@
-package dukku.user.boundedContext.user.entity.type;
+package dukku.semicolon.boundedContext.user.entity.type;
 
 public enum UserStatus {
     ACTIVE,

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/in/UserController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/in/UserController.java
@@ -1,13 +1,13 @@
-package dukku.user.boundedContext.user.in;
+package dukku.semicolon.boundedContext.user.in;
 
-import dukku.user.boundedContext.user.app.UserFacade;
-import dukku.user.shared.user.dto.PasswordUpdateRequest;
-import dukku.user.shared.user.dto.UserRegisterRequest;
-import dukku.user.shared.user.dto.UserResponse;
-import dukku.user.shared.user.dto.UserUpdateRequest;
-import dukku.user.boundedContext.user.entity.type.Role;
+import dukku.semicolon.boundedContext.user.app.UserFacade;
+import dukku.semicolon.shared.user.dto.PasswordUpdateRequest;
+import dukku.semicolon.shared.user.dto.UserRegisterRequest;
+import dukku.semicolon.shared.user.dto.UserResponse;
+import dukku.semicolon.shared.user.dto.UserUpdateRequest;
+import dukku.semicolon.boundedContext.user.entity.type.Role;
 import dukku.common.global.UserUtil;
-import dukku.user.shared.user.docs.UserApiDocs;
+import dukku.semicolon.shared.user.docs.UserApiDocs;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/out/UserRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/out/UserRepository.java
@@ -1,6 +1,6 @@
-package dukku.user.boundedContext.user.out;
+package dukku.semicolon.boundedContext.user.out;
 
-import dukku.user.boundedContext.user.entity.User;
+import dukku.semicolon.boundedContext.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/semicolon/src/main/java/dukku/semicolon/global/auth/jwt/AuthTokenIssuer.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/auth/jwt/AuthTokenIssuer.java
@@ -1,4 +1,4 @@
-package dukku.user.global.auth.jwt;
+package dukku.semicolon.global.auth.jwt;
 
 import dukku.common.global.auth.jwt.JwtTokenUtil;
 import dukku.common.global.exception.UnauthorizedException;

--- a/semicolon/src/main/java/dukku/semicolon/global/config/SecurityConfig.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package dukku.user.global.config;
+package dukku.semicolon.global.config;
 
 import dukku.common.global.auth.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/docs/UserApiDocs.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/docs/UserApiDocs.java
@@ -1,4 +1,4 @@
-package dukku.user.shared.user.docs;
+package dukku.semicolon.shared.user.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/domain/BaseUser.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/domain/BaseUser.java
@@ -1,7 +1,7 @@
-package dukku.user.shared.user.domain;
+package dukku.semicolon.shared.user.domain;
 
-import dukku.user.boundedContext.user.entity.type.Role;
-import dukku.user.boundedContext.user.entity.type.UserStatus;
+import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.boundedContext.user.entity.type.UserStatus;
 import dukku.common.global.jpa.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EnumType;

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/domain/SourceUser.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/domain/SourceUser.java
@@ -1,7 +1,7 @@
-package dukku.user.shared.user.domain;
+package dukku.semicolon.shared.user.domain;
 
 import com.github.f4b6a3.uuid.UuidCreator;
-import dukku.user.boundedContext.user.entity.type.UserStatus;
+import dukku.semicolon.boundedContext.user.entity.type.UserStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/dto/PasswordUpdateRequest.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/dto/PasswordUpdateRequest.java
@@ -1,4 +1,4 @@
-package dukku.user.shared.user.dto;
+package dukku.semicolon.shared.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserDto.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserDto.java
@@ -1,7 +1,7 @@
-package dukku.user.shared.user.dto;
+package dukku.semicolon.shared.user.dto;
 
-import dukku.user.boundedContext.user.entity.type.Role;
-import dukku.user.boundedContext.user.entity.type.UserStatus;
+import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.boundedContext.user.entity.type.UserStatus;
 
 import java.util.UUID;
 

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserRegisterRequest.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserRegisterRequest.java
@@ -1,4 +1,4 @@
-package dukku.user.shared.user.dto;
+package dukku.semicolon.shared.user.dto;
 
 import jakarta.validation.constraints.*;
 import lombok.*;

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserResponse.java
@@ -1,7 +1,7 @@
-package dukku.user.shared.user.dto;
+package dukku.semicolon.shared.user.dto;
 
-import dukku.user.boundedContext.user.entity.type.Role;
-import dukku.user.boundedContext.user.entity.type.UserStatus;
+import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.boundedContext.user.entity.type.UserStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserUpdateRequest.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserUpdateRequest.java
@@ -1,4 +1,4 @@
-package dukku.user.shared.user.dto;
+package dukku.semicolon.shared.user.dto;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/event/UserJoinedEvent.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/event/UserJoinedEvent.java
@@ -1,6 +1,6 @@
-package dukku.user.shared.user.event;
+package dukku.semicolon.shared.user.event;
 
-import dukku.user.shared.user.dto.UserDto;
+import dukku.semicolon.shared.user.dto.UserDto;
 
 public record UserJoinedEvent(UserDto member) {
 }

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/event/UserModifiedEvent.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/event/UserModifiedEvent.java
@@ -1,6 +1,6 @@
-package dukku.user.shared.user.event;
+package dukku.semicolon.shared.user.event;
 
-import dukku.user.shared.user.dto.UserDto;
+import dukku.semicolon.shared.user.dto.UserDto;
 
 public record UserModifiedEvent(UserDto member) {
 }

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/exception/UserConflictException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/exception/UserConflictException.java
@@ -1,4 +1,4 @@
-package dukku.user.shared.user.exception;
+package dukku.semicolon.shared.user.exception;
 
 import dukku.common.global.exception.ConflictException;
 

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/exception/UserNotFoundException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/exception/UserNotFoundException.java
@@ -1,4 +1,4 @@
-package dukku.user.shared.user.exception;
+package dukku.semicolon.shared.user.exception;
 
 
 import dukku.common.global.exception.NotFoundException;

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/out/UserApiClient.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/out/UserApiClient.java
@@ -1,4 +1,4 @@
-package dukku.user.shared.user.out;
+package dukku.semicolon.shared.user.out;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;

--- a/semicolon/src/main/java/dukku/semicolon/standard/modelType/CanGetModelTypeCode.java
+++ b/semicolon/src/main/java/dukku/semicolon/standard/modelType/CanGetModelTypeCode.java
@@ -1,4 +1,4 @@
-package dukku.user.standard.modelType;
+package dukku.semicolon.standard.modelType;
 
 public interface CanGetModelTypeCode {
     String getModelTypeCode();

--- a/semicolon/src/main/java/dukku/semicolon/standard/resultType/ResultType.java
+++ b/semicolon/src/main/java/dukku/semicolon/standard/resultType/ResultType.java
@@ -1,4 +1,4 @@
-package dukku.user.standard.resultType;
+package dukku.semicolon.standard.resultType;
 
 
 public interface ResultType {

--- a/semicolon/src/test/java/dukku/semicolon/ApplicationTests.java
+++ b/semicolon/src/test/java/dukku/semicolon/ApplicationTests.java
@@ -1,4 +1,4 @@
-package dukku.user;
+package dukku.semicolon;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
## 개요
#23 베이스 엔티티 수정 변경사항 적용

## 상세 내용
- 기존 BaseEntity에서 getId 호출 시 int형을 반환하도록 되어 있었음
- UUID형, Long형 등 다른 타입으로 PK 선언 시 대응이 필요
- 팀 내 논의 결과 BaseEntity 확장하는 방향으로 결론
- 기존 테스트 코드 중 일부가 빌드에러 발생하고 있어 발생하지 않도록 수정처리 (본 기능과 상관없는 임시 대응)

## 필요 후속 조치
- BaseEntity를 상속받는 클래스들의 jpa 엔티티들의 id를 primitive 

## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI/UX 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 빌드/패키지 수정
- [ ] 파일/폴더 제거

## PR Checklist
- [ ] 커밋 메시지가 규칙에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?
