### PR TITLE
#8 예치금 도메인 엔티티 생성 및 기본 세팅

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/entity/Deposit.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/entity/Deposit.java
@@ -1,0 +1,108 @@
+package dukku.semicolon.boundedContext.deposit.entity;
+
+import dukku.common.global.jpa.entity.BaseEntity;
+import dukku.semicolon.shared.deposit.dto.DepositDto;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 예치금 잔액 엔티티
+ * 
+ * <p>
+ * 사용자별 예치금 잔액을 관리하는 엔티티.
+ * user_uuid를 PK로 사용하여 사용자당 하나의 예치금 계좌를 운영한다.
+ */
+@Entity
+@Table(name = "deposits")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Deposit extends BaseEntity<UUID> {
+
+    @Id
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(updatable = false, nullable = false, columnDefinition = "uuid", comment = "사용자 UUID (PK이자 소유자 식별자)")
+    private UUID userUuid;
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(updatable = false, nullable = false, unique = true, columnDefinition = "uuid", comment = "예치금 계좌 UUID")
+    private UUID depositUuid;
+
+    @Builder.Default
+    @Column(nullable = false, columnDefinition = "integer default 0", comment = "예치금 잔액")
+    private Integer balance = 0;
+
+    @Version
+    @Builder.Default
+    @Column(nullable = false, comment = "낙관적 락 버전")
+    private Integer version = 0;
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false, comment = "생성일")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(comment = "최종 수정일")
+    private LocalDateTime updatedAt;
+
+    @Override
+    public UUID getId() {
+        return userUuid;
+    }
+
+    // === 정적 팩토리 메서드 ===
+
+    public static Deposit create(UUID userUuid) {
+        return Deposit.builder()
+                .userUuid(userUuid)
+                .depositUuid(UUID.randomUUID())
+                .balance(0)
+                .build();
+    }
+
+    // === 도메인 로직 ===
+
+    /**
+     * 잔액 증가 (충전/환불 등)
+     */
+    public void addBalance(Integer amount) {
+        if (amount == null || amount < 0)
+            return;
+        this.balance += amount;
+    }
+
+    /**
+     * 잔액 차감 (사용/출금 등)
+     */
+    public void subtractBalance(Integer amount) {
+        if (amount == null || amount < 0)
+            return;
+        if (this.balance < amount) {
+            throw new RuntimeException("예치금이 부족합니다."); // TODO: Custom Exception 전환
+        }
+        this.balance -= amount;
+    }
+
+    // === DTO 변환 ===
+
+    public DepositDto toDto() {
+        return DepositDto.builder()
+                .userUuid(this.userUuid)
+                .depositUuid(this.depositUuid)
+                .balance(this.balance)
+                .createdAt(this.createdAt)
+                .updatedAt(this.updatedAt)
+                .build();
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/entity/DepositHistory.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/entity/DepositHistory.java
@@ -1,0 +1,98 @@
+package dukku.semicolon.boundedContext.deposit.entity;
+
+import dukku.common.global.jpa.entity.BaseEntity;
+import dukku.semicolon.boundedContext.deposit.entity.enums.DepositHistoryType;
+import dukku.semicolon.shared.deposit.dto.DepositHistoryDto;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+/**
+ * 예치금 변동 이력 엔티티
+ * 
+ * <p>
+ * 예치금의 모든 변동 내역을 기록한다.
+ * 이력 엔티티는 생성 후 수정되지 않는다 (Immutable).
+ */
+@Entity
+@Table(name = "deposit_histories")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DepositHistory extends BaseEntity<Integer> {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(updatable = false, nullable = false)
+    private Integer id;
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(updatable = false, nullable = false, columnDefinition = "uuid", comment = "사용자 UUID")
+    private UUID userUuid;
+
+    @Column(updatable = false, nullable = false, comment = "변동 금액 (+/-)")
+    private Integer amount;
+
+    @Column(updatable = false, nullable = false, comment = "변동 후 잔액 스냅샷")
+    private Integer balanceSnapshot;
+
+    @Enumerated(EnumType.STRING)
+    @Column(updatable = false, nullable = false, comment = "변동 유형")
+    private DepositHistoryType type;
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(updatable = false, columnDefinition = "uuid", comment = "관련 주문 상품 UUID (nullable)")
+    private UUID orderItemUuid;
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false, comment = "생성일")
+    private LocalDateTime createdAt;
+
+    @Override
+    public Integer getId() {
+        return this.id;
+    }
+
+    @Override
+    public LocalDateTime getUpdatedAt() {
+        return null; // 이력 엔티티는 수정되지 않음
+    }
+
+    // === 정적 팩토리 메서드 ===
+
+    public static DepositHistory create(UUID userUuid, Integer amount, Integer balanceSnapshot,
+            DepositHistoryType type, UUID orderItemUuid) {
+        return DepositHistory.builder()
+                .userUuid(userUuid)
+                .amount(amount)
+                .balanceSnapshot(balanceSnapshot)
+                .type(type)
+                .orderItemUuid(orderItemUuid)
+                .build();
+    }
+
+    // === DTO 변환 ===
+
+    public DepositHistoryDto toDto() {
+        return DepositHistoryDto.builder()
+                .id(this.id)
+                .userUuid(this.userUuid)
+                .amount(this.amount)
+                .balanceSnapshot(this.balanceSnapshot)
+                .type(this.type)
+                .orderItemUuid(this.orderItemUuid)
+                .createdAt(this.createdAt)
+                .build();
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/entity/enums/DepositHistoryType.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/entity/enums/DepositHistoryType.java
@@ -1,0 +1,15 @@
+package dukku.semicolon.boundedContext.deposit.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 예치금 변동 유형
+ */
+public enum DepositHistoryType {
+    CHARGE, // 충전
+    USE, // 사용
+    REFUND, // 환불
+    WITHDRAW, // 출금
+    ADJUST // 조정
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/out/DepositHistoryRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/out/DepositHistoryRepository.java
@@ -1,0 +1,17 @@
+package dukku.semicolon.boundedContext.deposit.out;
+
+import dukku.semicolon.boundedContext.deposit.entity.DepositHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 예치금 이력 Repository
+ */
+public interface DepositHistoryRepository extends JpaRepository<DepositHistory, Integer> {
+
+    List<DepositHistory> findByUserUuidOrderByCreatedAtDesc(UUID userUuid);
+
+    List<DepositHistory> findByOrderItemUuid(UUID orderItemUuid);
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/out/DepositRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/out/DepositRepository.java
@@ -1,0 +1,17 @@
+package dukku.semicolon.boundedContext.deposit.out;
+
+import dukku.semicolon.boundedContext.deposit.entity.Deposit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * 예치금 Repository
+ */
+public interface DepositRepository extends JpaRepository<Deposit, UUID> {
+
+    Optional<Deposit> findByUserUuid(UUID userUuid);
+
+    Optional<Deposit> findByDepositUuid(UUID depositUuid);
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/deposit/dto/DepositDto.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/deposit/dto/DepositDto.java
@@ -1,0 +1,24 @@
+package dukku.semicolon.shared.deposit.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 예치금 범용 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DepositDto {
+    private UUID userUuid;
+    private UUID depositUuid;
+    private Integer balance;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/deposit/dto/DepositHistoryDto.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/deposit/dto/DepositHistoryDto.java
@@ -1,0 +1,27 @@
+package dukku.semicolon.shared.deposit.dto;
+
+import dukku.semicolon.boundedContext.deposit.entity.enums.DepositHistoryType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 예치금 이력 범용 DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DepositHistoryDto {
+    private Integer id;
+    private UUID userUuid;
+    private Integer amount;
+    private Integer balanceSnapshot;
+    private DepositHistoryType type;
+    private UUID orderItemUuid;
+    private LocalDateTime createdAt;
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/domain/BaseUser.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/domain/BaseUser.java
@@ -15,7 +15,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public abstract class BaseUser extends BaseEntity {
+public abstract class BaseUser extends BaseEntity<Integer> {
 
     @Column(length = 100, unique = true, nullable = false, comment = "이메일 (로그인 ID)")
     private String email;

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/domain/SourceUser.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/domain/SourceUser.java
@@ -26,7 +26,7 @@ public abstract class SourceUser extends BaseUser {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    private int id;
+    private Integer id;
 
     @JdbcTypeCode(SqlTypes.UUID)
     @Column(columnDefinition = "uuid", updatable = false, nullable = false, unique = true, comment = "유저 UUID")


### PR DESCRIPTION
## 개요
- 예치금 BC를 위한 엔티티 생성 (#8)

## 상세 내용
- 예치금 BC를 위한 JPA 엔티티 생성
- 예치금 엔티티에 대한 레포지토리 생성
- 범용 DTO 생성
- User 엔티티의 PK Integer 타입으로 수정 (빌드를 위한 임시 대응)
  : 단순 타입변경이므로 User 엔티티 변경 반영 시 conflict 발생 안할것 예상

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI/UX 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 빌드/패키지 수정
- [ ] 파일/폴더 제거

## PR Checklist
- [x] 커밋 메시지가 규칙에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?
