### PR TITLE
feat: 정산 도메인 dto, usecase, facade, controller 추가

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/app/GetSettlementListUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/app/GetSettlementListUseCase.java
@@ -1,0 +1,25 @@
+package dukku.semicolon.boundedContext.settlement.app;
+
+import dukku.semicolon.shared.settlement.dto.SettlementSearchCondition;
+import dukku.semicolon.boundedContext.settlement.entity.Settlement;
+import dukku.semicolon.boundedContext.settlement.out.SettlementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class GetSettlementListUseCase {
+
+    private final SettlementRepository settlementRepository;
+
+    /**
+     * 정산 목록 조회 (검색 조건 + 페이징)
+     */
+    @Transactional(readOnly = true)
+    public Page<Settlement> execute(SettlementSearchCondition condition, Pageable pageable) {
+        return settlementRepository.search(condition, pageable);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/app/GetSettlementStatisticsUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/app/GetSettlementStatisticsUseCase.java
@@ -1,0 +1,135 @@
+package dukku.semicolon.boundedContext.settlement.app;
+
+import com.querydsl.core.Tuple;
+import dukku.semicolon.boundedContext.settlement.entity.type.SettlementStatus;
+import dukku.semicolon.boundedContext.settlement.out.SettlementRepository;
+import dukku.semicolon.shared.settlement.dto.SettlementStatisticsCondition;
+import dukku.semicolon.shared.settlement.dto.SettlementStatisticsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import static dukku.semicolon.boundedContext.settlement.entity.QSettlement.settlement;
+
+@Component
+@RequiredArgsConstructor
+public class GetSettlementStatisticsUseCase {
+
+    private final SettlementRepository settlementRepository;
+
+    /**
+     * 정산 통계 조회 (동적 조건)
+     * 전체 통계 + 상태별 통계 + 기간 내 완료
+     */
+    @Transactional(readOnly = true)
+    public SettlementStatisticsResponse execute(SettlementStatisticsCondition condition) {
+        TotalStatistics total = toTotalStatistics(settlementRepository.getTotalStatistics());
+
+        StatusStatisticsMap statusStats = StatusStatisticsMap.from(
+                settlementRepository.getStatisticsByStatus()
+        );
+
+        CompletedInPeriod completed = getCompletedInPeriod(condition);
+
+        return new SettlementStatisticsResponse(
+                total.totalCount(),
+                total.totalAmount(),
+                total.totalSettlementAmount(),
+                total.totalFeeAmount(),
+
+                statusStats.count(SettlementStatus.CREATED),
+                statusStats.count(SettlementStatus.PROCESSING),
+                statusStats.count(SettlementStatus.PENDING),
+                statusStats.count(SettlementStatus.SUCCESS),
+                statusStats.count(SettlementStatus.FAILED),
+
+                statusStats.amount(SettlementStatus.CREATED),
+                statusStats.amount(SettlementStatus.PROCESSING),
+                statusStats.amount(SettlementStatus.PENDING),
+                statusStats.amount(SettlementStatus.SUCCESS),
+                statusStats.amount(SettlementStatus.FAILED),
+
+                completed.count(),
+                completed.amount()
+        );
+    }
+
+    private TotalStatistics toTotalStatistics(Tuple tuple) {
+        return new TotalStatistics(
+                tuple.get(settlement.count()),
+                tuple.get(settlement.totalAmount.sum().coalesce(0)),
+                tuple.get(settlement.settlementAmount.sum().coalesce(0)),
+                tuple.get(settlement.feeAmount.sum().coalesce(0))
+        );
+    }
+
+    private CompletedInPeriod getCompletedInPeriod(SettlementStatisticsCondition condition) {
+        SettlementStatisticsCondition completedCondition = new SettlementStatisticsCondition(
+                SettlementStatus.SUCCESS,
+                condition.sellerUuid(),
+                condition.startDate(),
+                condition.endDate()
+        );
+
+        return new CompletedInPeriod(
+                settlementRepository.countByCondition(completedCondition),
+                settlementRepository.sumSettlementAmountByCondition(completedCondition)
+        );
+    }
+
+    /**
+     * 전체 통계
+     */
+    private record TotalStatistics(long totalCount, long totalAmount, long totalSettlementAmount, long totalFeeAmount) {
+    }
+
+    /**
+     * 기간 내 완료된 정산 통계
+     */
+    private record CompletedInPeriod(long count, long amount) {
+    }
+
+    /**
+     * 상태별 통계 단건
+     */
+    private record StatusStatistics(SettlementStatus status, long count, long settlementAmount) {
+        static final StatusStatistics EMPTY = new StatusStatistics(null, 0L, 0L);
+    }
+
+    /**
+     * 상태별 통계 일급 컬렉션
+     */
+    private static class StatusStatisticsMap {
+
+        private final Map<SettlementStatus, StatusStatistics> map;
+
+        private StatusStatisticsMap(Map<SettlementStatus, StatusStatistics> map) {
+            this.map = map;
+        }
+
+        static StatusStatisticsMap from(List<Tuple> tuples) {
+            Map<SettlementStatus, StatusStatistics> map = new EnumMap<>(SettlementStatus.class);
+            for (Tuple tuple : tuples) {
+                SettlementStatus status = tuple.get(settlement.settlementStatus);
+                map.put(status, new StatusStatistics(
+                        status,
+                        tuple.get(settlement.count()),
+                        tuple.get(settlement.settlementAmount.sum().coalesce(0))
+                ));
+            }
+            return new StatusStatisticsMap(map);
+        }
+
+        long count(SettlementStatus status) {
+            return map.getOrDefault(status, StatusStatistics.EMPTY).count();
+        }
+
+        long amount(SettlementStatus status) {
+            return map.getOrDefault(status, StatusStatistics.EMPTY).settlementAmount();
+        }
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/app/SettlementFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/app/SettlementFacade.java
@@ -1,0 +1,46 @@
+package dukku.semicolon.boundedContext.settlement.app;
+
+import dukku.semicolon.shared.settlement.dto.SettlementResponse;
+import dukku.semicolon.shared.settlement.dto.SettlementSearchCondition;
+import dukku.semicolon.shared.settlement.dto.SettlementStatisticsCondition;
+import dukku.semicolon.shared.settlement.dto.SettlementStatisticsResponse;
+import dukku.semicolon.boundedContext.settlement.entity.Settlement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SettlementFacade {
+
+    private final GetSettlementListUseCase getSettlements;
+    private final GetSettlementStatisticsUseCase getStatistics;
+
+
+    @Transactional(readOnly = true)
+    public Page<SettlementResponse> getSettlements(SettlementSearchCondition condition, Pageable pageable) {
+        Page<Settlement> settlements = getSettlements.execute(condition, pageable);
+        return settlements.map(this::toResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public SettlementStatisticsResponse getStatistics(SettlementStatisticsCondition condition) {
+        return getStatistics.execute(condition);
+    }
+
+    /**
+     * TODO: 외부 서비스 호출로 sellerNickname, productName, bankName, accountNumber 조회
+     */
+    private SettlementResponse toResponse(Settlement settlement) {
+        return SettlementResponse.of(
+                settlement,
+                null,  // sellerNickname - 추후 외부 서비스 연동
+                null,  // productName - 추후 외부 서비스 연동
+                null,  // bankName - 추후 외부 서비스 연동
+                null   // accountNumber - 추후 외부 서비스 연동
+        );
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/in/SettlementController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/in/SettlementController.java
@@ -1,0 +1,50 @@
+package dukku.semicolon.boundedContext.settlement.in;
+
+import dukku.semicolon.boundedContext.settlement.app.SettlementFacade;
+import dukku.semicolon.shared.settlement.docs.SettlementApiDocs;
+import dukku.semicolon.shared.settlement.dto.SettlementResponse;
+import dukku.semicolon.shared.settlement.dto.SettlementSearchRequest;
+import dukku.semicolon.shared.settlement.dto.SettlementStatisticsRequest;
+import dukku.semicolon.shared.settlement.dto.SettlementStatisticsResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/settlements")
+@RequiredArgsConstructor
+@SettlementApiDocs.SettlementTag
+public class SettlementController {
+
+    private final SettlementFacade settlementFacade;
+
+
+    /**
+     * 정산 목록 조회
+     * GET /admin/settlements
+     */
+    @GetMapping
+    @SettlementApiDocs.GetSettlements
+    public Page<SettlementResponse> getSettlements(
+            @Valid @ModelAttribute SettlementSearchRequest request,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return settlementFacade.getSettlements(request.toCondition(), pageable);
+    }
+
+    /**
+     * 정산 통계 조회
+     * GET /admin/settlements/statistics
+     */
+    @GetMapping("/statistics")
+    @SettlementApiDocs.GetSettlementStatistics
+    public SettlementStatisticsResponse getStatistics(
+            @Valid @ModelAttribute SettlementStatisticsRequest request
+    ) {
+        return settlementFacade.getStatistics(request.toCondition());
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/out/SettlementRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/out/SettlementRepository.java
@@ -9,13 +9,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface SettlementRepository extends JpaRepository<Settlement, Long>{
+public interface SettlementRepository extends JpaRepository<Settlement, Long>, SettlementRepositoryCustom {
 
     Optional<Settlement> findByUuid(UUID settlementUuid);
 
-    // 판매자별 정산 목록 조회
     Page<Settlement> findBySellerUuid(UUID sellerUuid, Pageable pageable);
 
-    // 상태별 정산 목록 조회
     Page<Settlement> findBySettlementStatus(SettlementStatus status, Pageable pageable);
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/out/SettlementRepositoryCustom.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/out/SettlementRepositoryCustom.java
@@ -1,0 +1,37 @@
+package dukku.semicolon.boundedContext.settlement.out;
+
+import com.querydsl.core.Tuple;
+import dukku.semicolon.boundedContext.settlement.entity.Settlement;
+import dukku.semicolon.shared.settlement.dto.SettlementSearchCondition;
+import dukku.semicolon.shared.settlement.dto.SettlementStatisticsCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface SettlementRepositoryCustom {
+
+    Page<Settlement> search(SettlementSearchCondition condition, Pageable pageable);
+
+    /**
+     * 전체 통계 조회
+     * @return Tuple: [count, totalAmount합계, settlementAmount합계, feeAmount합계]
+     */
+    Tuple getTotalStatistics();
+
+    /**
+     * 상태별 통계 조회 (groupBy)
+     * @return List<Tuple>: 각 Tuple은 [status, count, settlementAmount합계]
+     */
+    List<Tuple> getStatisticsByStatus();
+
+    /**
+     * 동적 조건에 따른 정산 건수 조회
+     */
+    long countByCondition(SettlementStatisticsCondition condition);
+
+    /**
+     * 동적 조건에 따른 정산 금액 합계 조회
+     */
+    long sumSettlementAmountByCondition(SettlementStatisticsCondition condition);
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/out/SettlementRepositoryImpl.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/out/SettlementRepositoryImpl.java
@@ -1,0 +1,144 @@
+package dukku.semicolon.boundedContext.settlement.out;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dukku.semicolon.boundedContext.settlement.entity.Settlement;
+import dukku.semicolon.boundedContext.settlement.entity.type.SettlementStatus;
+import dukku.semicolon.shared.settlement.dto.SettlementSearchCondition;
+import dukku.semicolon.shared.settlement.dto.SettlementStatisticsCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static dukku.semicolon.boundedContext.settlement.entity.QSettlement.settlement;
+
+@RequiredArgsConstructor
+public class SettlementRepositoryImpl implements SettlementRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Settlement> search(SettlementSearchCondition condition, Pageable pageable) {
+        List<Settlement> content = queryFactory
+                .selectFrom(settlement)
+                .where(
+                        statusEq(condition.status()),
+                        sellerUuidEq(condition.sellerUuid()),
+                        createdAtGoe(condition.startDate()),
+                        createdAtLt(condition.endDate())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(settlement.createdAt.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(settlement.count())
+                .from(settlement)
+                .where(
+                        statusEq(condition.status()),
+                        sellerUuidEq(condition.sellerUuid()),
+                        createdAtGoe(condition.startDate()),
+                        createdAtLt(condition.endDate())
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    /**
+     * 전체 통계 조회
+     * @return Tuple: [count, totalAmount합계, settlementAmount합계, feeAmount합계]
+     */
+    @Override
+    public Tuple getTotalStatistics() {
+        return queryFactory
+                .select(
+                        settlement.count(),
+                        settlement.totalAmount.sum().coalesce(0),
+                        settlement.settlementAmount.sum().coalesce(0),
+                        settlement.feeAmount.sum().coalesce(0)
+                )
+                .from(settlement)
+                .fetchOne();
+    }
+
+    /**
+     * 상태별 통계 조회 (groupBy)
+     * @return List<Tuple>: 각 Tuple은 [status, count, settlementAmount합계]
+     */
+    @Override
+    public List<Tuple> getStatisticsByStatus() {
+        return queryFactory
+                .select(
+                        settlement.settlementStatus,
+                        settlement.count(),
+                        settlement.settlementAmount.sum().coalesce(0)
+                )
+                .from(settlement)
+                .groupBy(settlement.settlementStatus)
+                .fetch();
+    }
+
+    @Override
+    public long countByCondition(SettlementStatisticsCondition condition) {
+        Long count = queryFactory
+                .select(settlement.count())
+                .from(settlement)
+                .where(
+                        statusEq(condition.status()),
+                        sellerUuidEq(condition.sellerUuid()),
+                        completedAtGoe(condition.startDate()),
+                        completedAtLt(condition.endDate())
+                )
+                .fetchOne();
+
+        return count != null ? count : 0L;
+    }
+
+    @Override
+    public long sumSettlementAmountByCondition(SettlementStatisticsCondition condition) {
+        Long sum = queryFactory
+                .select(settlement.settlementAmount.sum().longValue())
+                .from(settlement)
+                .where(
+                        statusEq(condition.status()),
+                        sellerUuidEq(condition.sellerUuid()),
+                        completedAtGoe(condition.startDate()),
+                        completedAtLt(condition.endDate())
+                )
+                .fetchOne();
+
+        return sum != null ? sum : 0L;
+    }
+
+    private BooleanExpression statusEq(SettlementStatus status) {
+        return status != null ? settlement.settlementStatus.eq(status) : null;
+    }
+
+    private BooleanExpression sellerUuidEq(UUID sellerUuid) {
+        return sellerUuid != null ? settlement.sellerUuid.eq(sellerUuid) : null;
+    }
+
+    private BooleanExpression createdAtGoe(LocalDate startDate) {
+        return startDate != null ? settlement.createdAt.goe(startDate.atStartOfDay()) : null;
+    }
+
+    private BooleanExpression createdAtLt(LocalDate endDate) {
+        return endDate != null ? settlement.createdAt.lt(endDate.plusDays(1).atStartOfDay()) : null;
+    }
+
+    private BooleanExpression completedAtGoe(LocalDate startDate) {
+        return startDate != null ? settlement.completedAt.goe(startDate.atStartOfDay()) : null;
+    }
+
+    private BooleanExpression completedAtLt(LocalDate endDate) {
+        return endDate != null ? settlement.completedAt.lt(endDate.plusDays(1).atStartOfDay()) : null;
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/settlement/docs/SettlementApiDocs.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/settlement/docs/SettlementApiDocs.java
@@ -1,0 +1,163 @@
+package dukku.semicolon.shared.settlement.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * 정산(Settlement) 관련 Swagger 전용 Meta-Annotation 모음
+ */
+public final class SettlementApiDocs {
+
+    private SettlementApiDocs() {
+    }
+
+    // =============== 공통 태그 ===============
+    @Documented
+    @Target(TYPE)
+    @Retention(RUNTIME)
+    @Tag(name = "정산 API", description = "정산 목록 조회, 통계 조회 관련 기능 (관리자 전용)")
+    public @interface SettlementTag {
+    }
+
+    // =============== 1) 정산 목록 조회 ===============
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(summary = "정산 목록 조회", description = """
+            관리자가 정산 내역을 검색 조건에 따라 조회합니다.
+
+            - 정산 상태(status)로 필터링할 수 있습니다.
+            - 특정 판매자(sellerUuid)의 정산만 조회할 수 있습니다.
+            - 기간별(startDate ~ endDate) 정산 내역을 조회할 수 있습니다.
+            - 페이징을 지원하며, 기본값은 20개씩 최신순으로 정렬됩니다.
+            """, parameters = {
+            @Parameter(name = "status", description = "정산 상태 (CREATED, PROCESSING, PENDING, SUCCESS, FAILED)", example = "SUCCESS"),
+            @Parameter(name = "sellerUuid", description = "판매자 UUID", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+            @Parameter(name = "startDate", description = "조회 시작일 (yyyy-MM-dd)", example = "2026-01-01"),
+            @Parameter(name = "endDate", description = "조회 종료일 (yyyy-MM-dd)", example = "2026-01-31"),
+            @Parameter(name = "page", description = "페이지 번호 (0부터 시작)", example = "0"),
+            @Parameter(name = "size", description = "페이지 크기", example = "20"),
+            @Parameter(name = "sort", description = "정렬 기준", example = "createdAt,desc")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Settlement List Response", value = """
+                    {
+                      "content": [
+                        {
+                          "settlementUuid": "f1e2d3c4-b5a6-7890-cdef-1234567890ab",
+                          "status": "SUCCESS",
+                          "sellerUuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                          "sellerNickname": "홍길동상점",
+                          "productName": "무선 이어폰",
+                          "totalAmount": 50000,
+                          "fee": 0.03,
+                          "feeAmount": 1500,
+                          "settlementAmount": 48500,
+                          "settlementReservationDate": "2026-01-25T00:00:00+09:00",
+                          "bankName": "국민은행",
+                          "accountNumber": "123-456-789012",
+                          "orderUuid": "b2f0f6d3-9c4f-44d1-9f1f-8c2b3c7b1a11"
+                        },
+                        {
+                          "settlementUuid": "e2d3c4b5-a6f7-8901-bcde-234567890abc",
+                          "status": "PROCESSING",
+                          "sellerUuid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                          "sellerNickname": "홍길동상점",
+                          "productName": "스마트 워치",
+                          "totalAmount": 120000,
+                          "fee": 0.03,
+                          "feeAmount": 3600,
+                          "settlementAmount": 116400,
+                          "settlementReservationDate": "2026-01-26T00:00:00+09:00",
+                          "bankName": "국민은행",
+                          "accountNumber": "123-456-789012",
+                          "orderUuid": "c3e1f7d4-0d5f-55e2-af2f-9d3c4d8c2b22"
+                        }
+                      ],
+                      "pageable": {
+                        "pageNumber": 0,
+                        "pageSize": 20,
+                        "sort": {
+                          "sorted": true,
+                          "unsorted": false,
+                          "empty": false
+                        },
+                        "offset": 0,
+                        "paged": true,
+                        "unpaged": false
+                      },
+                      "totalElements": 42,
+                      "totalPages": 3,
+                      "last": false,
+                      "size": 20,
+                      "number": 0,
+                      "sort": {
+                        "sorted": true,
+                        "unsorted": false,
+                        "empty": false
+                      },
+                      "numberOfElements": 20,
+                      "first": true,
+                      "empty": false
+                    }
+                    """))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"INVALID_PARAMETER\", \"message\": \"시작일은 현재 또는 과거 날짜여야 합니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (관리자 전용)", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"FORBIDDEN\", \"message\": \"관리자만 접근 가능합니다.\"}")))
+    })
+    public @interface GetSettlements {
+    }
+
+    // =============== 2) 정산 통계 조회 ===============
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(summary = "정산 통계 조회", description = """
+            관리자가 정산 통계를 조회합니다.
+
+            - 전체 정산 건수, 금액, 수수료, 정산액 통계를 제공합니다.
+            - 상태별 건수와 금액 통계를 제공합니다.
+            - 조회 기간 내 완료된 정산 통계를 제공합니다.
+            - startDate와 endDate로 조회 기간을 지정할 수 있습니다.
+            """, parameters = {
+            @Parameter(name = "status", description = "정산 상태 필터 (CREATED, PROCESSING, PENDING, SUCCESS, FAILED)", example = "SUCCESS"),
+            @Parameter(name = "sellerUuid", description = "판매자 UUID 필터", example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+            @Parameter(name = "startDate", description = "조회 시작일 (yyyy-MM-dd)", example = "2026-01-01"),
+            @Parameter(name = "endDate", description = "조회 종료일 (yyyy-MM-dd)", example = "2026-01-31")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Settlement Statistics Response", value = """
+                    {
+                      "totalCount": 150,
+                      "totalAmount": 7500000,
+                      "totalSettlementAmount": 7275000,
+                      "totalFeeAmount": 225000,
+                      "createdCount": 10,
+                      "processingCount": 25,
+                      "pendingCount": 15,
+                      "successCount": 95,
+                      "failedCount": 5,
+                      "createdAmount": 500000,
+                      "processingAmount": 1250000,
+                      "pendingAmount": 750000,
+                      "successAmount": 4750000,
+                      "failedAmount": 250000,
+                      "completedCountInPeriod": 95,
+                      "completedAmountInPeriod": 4750000
+                    }
+                    """))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"INVALID_PARAMETER\", \"message\": \"시작일은 현재 또는 과거 날짜여야 합니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (관리자 전용)", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"FORBIDDEN\", \"message\": \"관리자만 접근 가능합니다.\"}")))
+    })
+    public @interface GetSettlementStatistics {
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementResponse.java
@@ -1,0 +1,56 @@
+package dukku.semicolon.shared.settlement.dto;
+
+import dukku.semicolon.boundedContext.settlement.entity.Settlement;
+import dukku.semicolon.boundedContext.settlement.entity.type.SettlementStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 정산 단건 응답 DTO
+ * GET /admin/settlements 목록 조회용
+ */
+public record SettlementResponse(
+        UUID settlementUuid,
+        SettlementStatus status,
+        UUID sellerUuid,
+        String sellerNickname,
+        String productName,
+        Integer totalAmount,
+        BigDecimal fee,
+        Integer feeAmount,
+        Integer settlementAmount,
+        LocalDateTime settlementReservationDate,
+        String bankName,
+        String accountNumber,
+        UUID orderUuid
+) {
+    /**
+     * 엔티티 + 외부 도메인 정보를 조합하여 응답 생성
+     * record + of() 조합
+     */
+    public static SettlementResponse of(
+            Settlement settlement,
+            String sellerNickname,
+            String productName,
+            String bankName,
+            String accountNumber
+    ) {
+        return new SettlementResponse(
+                settlement.getUuid(),
+                settlement.getSettlementStatus(),
+                settlement.getSellerUuid(),
+                sellerNickname,
+                productName,
+                settlement.getTotalAmount(),
+                settlement.getFee(),
+                settlement.getFeeAmount(),
+                settlement.getSettlementAmount(),
+                settlement.getSettlementReservationDate(),
+                bankName,
+                accountNumber,
+                settlement.getOrderId()
+        );
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementSearchCondition.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementSearchCondition.java
@@ -1,0 +1,21 @@
+package dukku.semicolon.shared.settlement.dto;
+
+import dukku.semicolon.boundedContext.settlement.entity.type.SettlementStatus;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * 정산 목록 검색 조건
+ * 모든 조건 필드가 null이면 전체 조회
+ */
+public record SettlementSearchCondition(
+        SettlementStatus status,
+        UUID sellerUuid,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static SettlementStatisticsCondition empty() {
+        return new SettlementStatisticsCondition(null, null, null, null);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementSearchRequest.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementSearchRequest.java
@@ -1,0 +1,27 @@
+package dukku.semicolon.shared.settlement.dto;
+
+import dukku.semicolon.boundedContext.settlement.entity.type.SettlementStatus;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * 정산 목록 검색 요청 DTO
+ * Controller에서 바인딩 + Validation 담당
+ */
+public record SettlementSearchRequest(
+        SettlementStatus status,
+        UUID sellerUuid,
+        @PastOrPresent(message = "시작일은 현재 또는 과거 날짜여야 합니다")
+        LocalDate startDate,
+        @PastOrPresent(message = "종료일은 현재 또는 과거 날짜여야 합니다")
+        LocalDate endDate
+) {
+    /**
+     * Repository 검색 조건으로 변환
+     */
+    public SettlementSearchCondition toCondition() {
+        return new SettlementSearchCondition(status, sellerUuid, startDate, endDate);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementStatisticsCondition.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementStatisticsCondition.java
@@ -1,0 +1,22 @@
+package dukku.semicolon.shared.settlement.dto;
+
+import dukku.semicolon.boundedContext.settlement.entity.type.SettlementStatus;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * 정산 통계 검색 조건
+ * 모든 조건 필드가 null이면 전체 조회
+ */
+public record SettlementStatisticsCondition(
+        SettlementStatus status,
+        UUID sellerUuid,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+
+    public static SettlementStatisticsCondition empty() {
+        return new SettlementStatisticsCondition(null, null, null, null);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementStatisticsRequest.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementStatisticsRequest.java
@@ -1,0 +1,29 @@
+package dukku.semicolon.shared.settlement.dto;
+
+import dukku.semicolon.boundedContext.settlement.entity.type.SettlementStatus;
+import jakarta.validation.constraints.PastOrPresent;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * 정산 통계 조회 요청 DTO
+ * Controller에서 바인딩 + Validation 담당
+ */
+public record SettlementStatisticsRequest(
+        SettlementStatus status,
+        UUID sellerUuid,
+
+        @PastOrPresent(message = "시작일은 현재 또는 과거 날짜여야 합니다")
+        LocalDate startDate,
+
+        @PastOrPresent(message = "종료일은 현재 또는 과거 날짜여야 합니다")
+        LocalDate endDate
+) {
+    /**
+     * Repository 검색 조건으로 변환
+     */
+    public SettlementStatisticsCondition toCondition() {
+        return new SettlementStatisticsCondition(status, sellerUuid, startDate, endDate);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementStatisticsResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/settlement/dto/SettlementStatisticsResponse.java
@@ -1,0 +1,33 @@
+package dukku.semicolon.shared.settlement.dto;
+
+/**
+ * 정산 통계 응답 DTO
+ * GET /admin/settlements/statistics
+ *
+ */
+public record SettlementStatisticsResponse(
+        // 전체 통계
+        long totalCount,
+        long totalAmount,
+        long totalSettlementAmount,
+        long totalFeeAmount,
+
+        // 상태별 건수
+        long createdCount,
+        long processingCount,
+        long pendingCount,
+        long successCount,
+        long failedCount,
+
+        // 상태별 정산 금액
+        long createdAmount,
+        long processingAmount,
+        long pendingAmount,
+        long successAmount,
+        long failedAmount,
+
+        // 조회 기간 내 완료된 정산
+        long completedCountInPeriod,
+        long completedAmountInPeriod
+) {
+}


### PR DESCRIPTION
## PR 제목

Closes #22 
정산 도메인 dto, usecase, facade, controller 추가

## 개요
정산 API를 처리하기 위한 요소들 추가

## 상세 내용
- settlement controller 추가
- settlement 도메인 usecase,facade추가
    - 정산 통계 조회 usecase
    - 정산 목록 조회 usecase
    - 정산 파사드
- queryDSL 추가
    - 동적 조건을 처리가히기 위한 queryDSL 추가
    - uuid, 상태, 기간 조건 통계
- settlement 도메인 DTO추가
    - request dto
    - response dto
    - condition dto(queryDSL)

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI/UX 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 빌드/패키지 수정
- [ ] 파일/폴더 제거

## PR Checklist
- [x] 커밋 메시지가 규칙에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?
