### PR TITLE
Feat: 상품 도메인 엔티티 및 공통 상태 Enum 정의 추가 #25 #34

### DIFF
--- a/common/src/main/java/dukku/common/global/exception/NotFoundException.java
+++ b/common/src/main/java/dukku/common/global/exception/NotFoundException.java
@@ -4,6 +4,6 @@ import org.springframework.http.HttpStatus;
 
 public class NotFoundException extends BaseException {
     public NotFoundException(String details) {
-        super(HttpStatus.NOT_FOUND.getReasonPhrase(), "요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, details);
+        super(HttpStatus.NOT_FOUND.getReasonPhrase(), "리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND, details);
     }
 }

--- a/common/src/main/java/dukku/common/global/jpa/entity/BaseIdAndTime.java
+++ b/common/src/main/java/dukku/common/global/jpa/entity/BaseIdAndTime.java
@@ -1,9 +1,6 @@
 package dukku.common.global.jpa.entity;
 
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -22,8 +19,10 @@ public abstract class BaseIdAndTime extends BaseEntity<Integer> {
     private Integer id;
 
     @CreatedDate
+    @Column(nullable = false, updatable = false, comment = "생성일")
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Column(comment = "수정일")
     private LocalDateTime updatedAt;
 }

--- a/common/src/main/java/dukku/common/global/jpa/entity/BaseIdAndUUIDAndTime.java
+++ b/common/src/main/java/dukku/common/global/jpa/entity/BaseIdAndUUIDAndTime.java
@@ -28,9 +28,11 @@ public abstract class BaseIdAndUUIDAndTime extends BaseEntity<Integer> {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Integer id;
+
     @JdbcTypeCode(SqlTypes.UUID)
-    @Column(columnDefinition = "uuid", updatable = false, nullable = false, unique = true, comment = "유저 UUID")
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false, unique = true, comment = "엔티티 UUID")
     private UUID uuid;
+
     @CreatedDate
     @Column(nullable = false, updatable = false, comment = "생성일")
     private LocalDateTime createdAt;

--- a/common/src/main/java/dukku/common/shared/product/type/AccountStatus.java
+++ b/common/src/main/java/dukku/common/shared/product/type/AccountStatus.java
@@ -1,0 +1,5 @@
+package dukku.common.shared.product.type;
+
+public enum AccountStatus {
+    ACTIVE, BLOCKED, DELETED
+}

--- a/common/src/main/java/dukku/common/shared/product/type/ConditionStatus.java
+++ b/common/src/main/java/dukku/common/shared/product/type/ConditionStatus.java
@@ -1,0 +1,5 @@
+package dukku.common.shared.product.type;
+
+public enum ConditionStatus {
+    SEALED, NO_WEAR, MINOR_WEAR, VISIBLE_WEAR, DAMAGED
+}

--- a/common/src/main/java/dukku/common/shared/product/type/SaleStatus.java
+++ b/common/src/main/java/dukku/common/shared/product/type/SaleStatus.java
@@ -1,0 +1,5 @@
+package dukku.common.shared.product.type;
+
+public enum SaleStatus {
+    ON_SALE, RESERVED, SOLD_OUT
+}

--- a/common/src/main/java/dukku/common/shared/product/type/VisibilityStatus.java
+++ b/common/src/main/java/dukku/common/shared/product/type/VisibilityStatus.java
@@ -1,0 +1,5 @@
+package dukku.common.shared.product.type;
+
+public enum VisibilityStatus {
+    VISIBLE, HIDDEN, BLOCKED
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Category.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Category.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.product.entity;
+
+import dukku.common.global.jpa.entity.BaseIdAndUUIDAndTime;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(
+        name = "categories",
+        indexes = {
+                @Index(name = "idx_categories_parent_id", columnList = "parent_id")
+        }
+)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseIdAndUUIDAndTime {
+
+    @Column(nullable = false, length = 100, comment = "카테고리 이름")
+    private String categoryName;
+
+    @Column(nullable = false, comment = "깊이(1: 최상위, max: 3)")
+    private int depth;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id", comment = "상위 카테고리")
+    private Category parent;
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Category.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Category.java
@@ -3,7 +3,6 @@ package dukku.semicolon.boundedContext.product.entity;
 import dukku.common.global.jpa.entity.BaseIdAndTime;
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(
@@ -13,7 +12,7 @@ import lombok.experimental.SuperBuilder;
         }
 )
 @Getter
-@SuperBuilder
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class Category extends BaseIdAndTime {

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Category.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Category.java
@@ -27,4 +27,19 @@ public class Category extends BaseIdAndTime {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id", comment = "상위 카테고리")
     private Category parent;
+
+    public static Category createRoot(String name) {
+        return Category.builder()
+                .categoryName(name)
+                .depth(1)
+                .build();
+    }
+
+    public static Category createChild(String name, Category parent) {
+        return Category.builder()
+                .categoryName(name)
+                .parent(parent)
+                .depth(parent.getDepth() + 1)
+                .build();
+    }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Category.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Category.java
@@ -1,6 +1,6 @@
 package dukku.semicolon.boundedContext.product.entity;
 
-import dukku.common.global.jpa.entity.BaseIdAndUUIDAndTime;
+import dukku.common.global.jpa.entity.BaseIdAndTime;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -16,7 +16,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class Category extends BaseIdAndUUIDAndTime {
+public class Category extends BaseIdAndTime {
 
     @Column(nullable = false, length = 100, comment = "카테고리 이름")
     private String categoryName;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
@@ -1,0 +1,106 @@
+package dukku.semicolon.boundedContext.product.entity;
+
+import dukku.common.global.jpa.entity.BaseIdAndUUIDAndTime;
+import dukku.common.shared.product.type.ConditionStatus;
+import dukku.common.shared.product.type.SaleStatus;
+import dukku.common.shared.product.type.VisibilityStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "products",
+        indexes = {
+                @Index(name = "idx_products_category_created", columnList = "category_id, created_at"),
+                @Index(name = "idx_products_sale_status", columnList = "sale_status"),
+                @Index(name = "idx_products_visibility_status", columnList = "visibility_status")
+        }
+)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseIdAndUUIDAndTime {
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column( nullable = false, columnDefinition = "uuid", comment = "판매자 UUID")
+    private UUID sellerUuid;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, comment = "카테고리")
+    private Category category;
+
+    @Column(nullable = false, length = 200, comment = "상품 제목")
+    private String title;
+
+    @Column(columnDefinition = "TEXT", comment = "상품 설명")
+    private String description;
+
+    @Column(nullable = false, comment = "상품 가격")
+    private Integer price;
+
+    @Column(nullable = false, comment = "배송비")
+    private Integer shippingFee;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+            nullable = false,
+            columnDefinition = "enum('SEALED','NO_WEAR','MINOR_WEAR','VISIBLE_WEAR','DAMAGED')",
+            comment = "상품 컨디션"
+    )
+    private ConditionStatus conditionStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+            nullable = false,
+            columnDefinition = "enum('ON_SALE','RESERVED','SOLD_OUT')",
+            comment = "상품 판매 상태"
+    )
+    private SaleStatus saleStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+            nullable = false,
+            columnDefinition = "enum('VISIBLE','HIDDEN','BLOCKED')",
+            comment = "상품 노출 상태"
+    )
+    private VisibilityStatus visibilityStatus;
+
+    @Column(nullable = false, comment = "조회수")
+    private Integer viewCount;
+
+    @Column(nullable = false, comment = "좋아요 수")
+    private Integer likeCount;
+
+    @Column(nullable = false, comment = "댓글 수")
+    private Integer commentCount;
+
+    @Column(comment = "삭제일(소프트 삭제)")
+    private LocalDateTime deletedAt;
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(columnDefinition = "uuid", comment = "현재 예약 중인 주문 UUID")
+    private UUID reservedOrderUuid;
+
+    @PrePersist
+    public void prePersist() {
+        super.prePersist();
+        if (this.shippingFee == null) this.shippingFee = 0;
+        if (this.viewCount == null) this.viewCount = 0;
+        if (this.likeCount == null) this.likeCount = 0;
+        if (this.commentCount == null) this.commentCount = 0;
+
+        if (this.conditionStatus == null) this.conditionStatus = ConditionStatus.SEALED;
+        if (this.saleStatus == null) this.saleStatus = SaleStatus.ON_SALE;
+        if (this.visibilityStatus == null) this.visibilityStatus = VisibilityStatus.VISIBLE;
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
@@ -20,10 +20,6 @@ import java.util.UUID;
 @Table(
         name = "products",
         indexes = {
-                @Index(name = "idx_products_category_created", columnList = "category_id, created_at"),
-                @Index(name = "idx_products_sale_status", columnList = "sale_status"),
-                @Index(name = "idx_products_visibility_status", columnList = "visibility_status"),
-
                 @Index(
                         name = "idx_products_cat_vis_sale_created",
                         columnList = "category_id, visibility_status, sale_status, created_at"

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
@@ -26,10 +26,6 @@ import java.util.UUID;
                 @Index(
                         name = "idx_products_cat_vis_sale_like",
                         columnList = "category_id, visibility_status, sale_status, like_count"
-                ),
-                @Index(
-                        name = "idx_products_cat_vis_sale_price",
-                        columnList = "category_id, visibility_status, sale_status, price"
                 )
         }
 )

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
@@ -5,15 +5,14 @@ import dukku.common.shared.product.type.ConditionStatus;
 import dukku.common.shared.product.type.SaleStatus;
 import dukku.common.shared.product.type.VisibilityStatus;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -130,5 +129,18 @@ public class Product extends BaseIdAndUUIDAndTime {
     public void reserve(UUID orderUuid) {
         this.saleStatus = SaleStatus.RESERVED;
         this.reservedOrderUuid = orderUuid;
+    }
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ProductImage> images = new ArrayList<>();
+
+    public void addImage(String imageUrl) {
+        int nextSortOrder = images.stream()
+                .mapToInt(ProductImage::getSortOrder)
+                .max()
+                .orElse(0) + 1;
+
+        images.add(ProductImage.create(this, imageUrl, nextSortOrder));
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
@@ -100,16 +100,35 @@ public class Product extends BaseIdAndUUIDAndTime {
     @Column(columnDefinition = "uuid", comment = "현재 예약 중인 주문 UUID")
     private UUID reservedOrderUuid;
 
-    @PrePersist
-    public void prePersist() {
-        super.prePersist();
-        if (this.shippingFee == null) this.shippingFee = 0;
-        if (this.viewCount == null) this.viewCount = 0;
-        if (this.likeCount == null) this.likeCount = 0;
-        if (this.commentCount == null) this.commentCount = 0;
+    public static Product create(
+            UUID sellerUuid,
+            Category category,
+            String title,
+            String description,
+            Integer price,
+            Integer shippingFee,
+            ConditionStatus conditionStatus
+    ) {
+        return Product.builder()
+                .sellerUuid(sellerUuid)
+                .category(category)
+                .title(title)
+                .description(description)
+                .price(price)
+                .shippingFee(shippingFee == null ? 0 : shippingFee)
 
-        if (this.conditionStatus == null) this.conditionStatus = ConditionStatus.SEALED;
-        if (this.saleStatus == null) this.saleStatus = SaleStatus.ON_SALE;
-        if (this.visibilityStatus == null) this.visibilityStatus = VisibilityStatus.VISIBLE;
+                .conditionStatus(conditionStatus == null ? ConditionStatus.SEALED : conditionStatus)
+                .saleStatus(SaleStatus.ON_SALE)
+                .visibilityStatus(VisibilityStatus.VISIBLE)
+
+                .viewCount(0)
+                .likeCount(0)
+                .commentCount(0)
+                .build();
+    }
+
+    public void reserve(UUID orderUuid) {
+        this.saleStatus = SaleStatus.RESERVED;
+        this.reservedOrderUuid = orderUuid;
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
@@ -55,10 +55,10 @@ public class Product extends BaseIdAndUUIDAndTime {
     private String description;
 
     @Column(nullable = false, comment = "상품 가격")
-    private Integer price;
+    private Long price;
 
     @Column(nullable = false, comment = "배송비")
-    private Integer shippingFee;
+    private Long shippingFee;
 
     @Enumerated(EnumType.STRING)
     @Column(
@@ -105,8 +105,8 @@ public class Product extends BaseIdAndUUIDAndTime {
             Category category,
             String title,
             String description,
-            Integer price,
-            Integer shippingFee,
+            Long price,
+            Long shippingFee,
             ConditionStatus conditionStatus
     ) {
         return Product.builder()
@@ -115,7 +115,7 @@ public class Product extends BaseIdAndUUIDAndTime {
                 .title(title)
                 .description(description)
                 .price(price)
-                .shippingFee(shippingFee == null ? 0 : shippingFee)
+                .shippingFee(shippingFee == null ? 0L : shippingFee)
 
                 .conditionStatus(conditionStatus == null ? ConditionStatus.SEALED : conditionStatus)
                 .saleStatus(SaleStatus.ON_SALE)

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
@@ -22,7 +22,20 @@ import java.util.UUID;
         indexes = {
                 @Index(name = "idx_products_category_created", columnList = "category_id, created_at"),
                 @Index(name = "idx_products_sale_status", columnList = "sale_status"),
-                @Index(name = "idx_products_visibility_status", columnList = "visibility_status")
+                @Index(name = "idx_products_visibility_status", columnList = "visibility_status"),
+
+                @Index(
+                        name = "idx_products_cat_vis_sale_created",
+                        columnList = "category_id, visibility_status, sale_status, created_at"
+                ),
+                @Index(
+                        name = "idx_products_cat_vis_sale_like",
+                        columnList = "category_id, visibility_status, sale_status, like_count"
+                ),
+                @Index(
+                        name = "idx_products_cat_vis_sale_price",
+                        columnList = "category_id, visibility_status, sale_status, price"
+                )
         }
 )
 @Getter

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
@@ -85,13 +85,13 @@ public class Product extends BaseIdAndUUIDAndTime {
     private VisibilityStatus visibilityStatus;
 
     @Column(nullable = false, comment = "조회수")
-    private Integer viewCount;
+    private int viewCount;
 
     @Column(nullable = false, comment = "좋아요 수")
-    private Integer likeCount;
+    private int likeCount;
 
     @Column(nullable = false, comment = "댓글 수")
-    private Integer commentCount;
+    private int commentCount;
 
     @Column(comment = "삭제일(소프트 삭제)")
     private LocalDateTime deletedAt;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductComment.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductComment.java
@@ -1,0 +1,50 @@
+package dukku.semicolon.boundedContext.product.entity;
+
+import dukku.common.global.jpa.entity.BaseIdAndUUIDAndTime;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * 후순위 작업 : 테이블 미리 생성
+ */
+@Entity
+@Table(
+        name = "product_comments",
+        indexes = {
+                @Index(name = "idx_product_comments_product_created", columnList = "product_id, created_at"),
+                @Index(name = "idx_product_comments_parent", columnList = "parent_id")
+        }
+)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductComment extends BaseIdAndUUIDAndTime {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false, comment = "상품 ID")
+    private Product product;
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(nullable = false, columnDefinition = "uuid", comment = "작성자 UUID")
+    private UUID userUuid;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id", comment = "부모 댓글 ID(대댓글)")
+    private ProductComment parent;
+
+    @Column(nullable = false, columnDefinition = "TEXT", comment = "내용")
+    private String content;
+
+    @Column(comment = "삭제일(소프트 삭제)")
+    private LocalDateTime deletedAt;
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductImage.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductImage.java
@@ -1,0 +1,44 @@
+package dukku.semicolon.boundedContext.product.entity;
+
+
+import dukku.common.global.jpa.entity.BaseIdAndUUIDAndTime;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(
+        name = "product_images",
+        indexes = {
+                @Index(name = "idx_product_images_product_sort", columnList = "product_id, sort_order")
+        }
+)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductImage extends BaseIdAndUUIDAndTime {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false, comment = "상품 ID")
+    private Product product;
+
+    @Column(nullable = false, comment = "이미지 URL")
+    private String imageUrl;
+
+    @Column(nullable = false, comment = "정렬 순서")
+    private Integer sortOrder;
+
+    @Column(nullable = false, comment = "썸네일 여부")
+    private Boolean isThumbnail;
+
+    @PrePersist
+    public void prePersist() {
+        super.prePersist();
+        if (this.sortOrder == null) this.sortOrder = 1;
+        if (this.isThumbnail == null) this.isThumbnail = false;
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductImage.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductImage.java
@@ -30,17 +30,17 @@ public class ProductImage extends BaseIdAndUUIDAndTime {
     private String imageUrl;
 
     @Column(nullable = false, comment = "정렬 순서")
-    private Integer sortOrder;
+    private int sortOrder;
 
     @Column(nullable = false, comment = "썸네일 여부")
-    private Boolean isThumbnail;
+    private boolean isThumbnail;
 
-    public static ProductImage create(Product product, String imageUrl, Integer sortOrder, Boolean isThumbnail) {
+    public static ProductImage create(Product product, String imageUrl, int sortOrder, boolean isThumbnail) {
         return ProductImage.builder()
                 .product(product)
                 .imageUrl(imageUrl)
-                .sortOrder(sortOrder == null ? 1 : sortOrder)
-                .isThumbnail(isThumbnail != null && isThumbnail)
+                .sortOrder(sortOrder)
+                .isThumbnail(isThumbnail)
                 .build();
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductImage.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductImage.java
@@ -35,12 +35,13 @@ public class ProductImage extends BaseIdAndUUIDAndTime {
     @Column(nullable = false, comment = "썸네일 여부")
     private boolean isThumbnail;
 
-    public static ProductImage create(Product product, String imageUrl, int sortOrder, boolean isThumbnail) {
+    public static ProductImage create(Product product, String imageUrl, int sortOrder) {
+        if (sortOrder < 1) throw new IllegalArgumentException("sortOrder는 1 이상이어야 합니다.");
         return ProductImage.builder()
                 .product(product)
                 .imageUrl(imageUrl)
                 .sortOrder(sortOrder)
-                .isThumbnail(isThumbnail)
+                .isThumbnail(sortOrder == 1)
                 .build();
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductImage.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductImage.java
@@ -35,10 +35,12 @@ public class ProductImage extends BaseIdAndUUIDAndTime {
     @Column(nullable = false, comment = "썸네일 여부")
     private Boolean isThumbnail;
 
-    @PrePersist
-    public void prePersist() {
-        super.prePersist();
-        if (this.sortOrder == null) this.sortOrder = 1;
-        if (this.isThumbnail == null) this.isThumbnail = false;
+    public static ProductImage create(Product product, String imageUrl, Integer sortOrder, Boolean isThumbnail) {
+        return ProductImage.builder()
+                .product(product)
+                .imageUrl(imageUrl)
+                .sortOrder(sortOrder == null ? 1 : sortOrder)
+                .isThumbnail(isThumbnail != null && isThumbnail)
+                .build();
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductLike.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductLike.java
@@ -1,0 +1,39 @@
+package dukku.semicolon.boundedContext.product.entity;
+
+import dukku.common.global.jpa.entity.BaseIdAndUUIDAndTime;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "product_likes",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_product_likes_user_product", columnNames = {"user_uuid", "product_id"})
+        },
+        indexes = {
+                @Index(name = "idx_product_likes_product", columnList = "product_id"),
+                @Index(name = "idx_product_likes_user", columnList = "user_uuid")
+        }
+)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductLike extends BaseIdAndUUIDAndTime {
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(nullable = false, columnDefinition = "uuid",  comment = "유저 UUID")
+    private UUID userUuid;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false, name = "product_id", comment = "상품 ID")
+    private Product product;
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductSeller.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductSeller.java
@@ -1,0 +1,47 @@
+package dukku.semicolon.boundedContext.product.entity;
+
+import dukku.common.global.jpa.entity.BaseIdAndUUIDAndTime;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "product_sellers",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_product_sellers_user_uuid", columnNames = {"user_uuid"})
+        }
+)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductSeller extends BaseIdAndUUIDAndTime {
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(nullable = false, columnDefinition = "uuid", comment = "유저 UUID")
+    private UUID userUuid;
+
+    @Column(columnDefinition = "TEXT", comment = "상점 소개")
+    private String intro;
+
+    @Column(nullable = false, comment = "누적 판매 횟수")
+    private Integer salesCount;
+
+    @Column(nullable = false, comment = "현재 판매중 상품 수")
+    private Integer activeListingCount;
+
+    @PrePersist
+    public void prePersist() {
+        super.prePersist();
+        if (this.salesCount == null) this.salesCount = 0;
+        if (this.activeListingCount == null) this.activeListingCount = 0;
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductSeller.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductSeller.java
@@ -38,10 +38,12 @@ public class ProductSeller extends BaseIdAndUUIDAndTime {
     @Column(nullable = false, comment = "현재 판매중 상품 수")
     private Integer activeListingCount;
 
-    @PrePersist
-    public void prePersist() {
-        super.prePersist();
-        if (this.salesCount == null) this.salesCount = 0;
-        if (this.activeListingCount == null) this.activeListingCount = 0;
+    public static ProductSeller create(UUID userUuid, String intro) {
+        return ProductSeller.builder()
+                .userUuid(userUuid)
+                .intro(intro)
+                .salesCount(0)
+                .activeListingCount(0)
+                .build();
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductSeller.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductSeller.java
@@ -33,10 +33,10 @@ public class ProductSeller extends BaseIdAndUUIDAndTime {
     private String intro;
 
     @Column(nullable = false, comment = "누적 판매 횟수")
-    private Integer salesCount;
+    private int salesCount;
 
     @Column(nullable = false, comment = "현재 판매중 상품 수")
-    private Integer activeListingCount;
+    private int activeListingCount;
 
     public static ProductSeller create(UUID userUuid, String intro) {
         return ProductSeller.builder()

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductUser.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductUser.java
@@ -1,0 +1,44 @@
+package dukku.semicolon.boundedContext.product.entity;
+
+import dukku.common.shared.product.type.AccountStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "product_users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_product_users_nickname", columnNames = {"nickname"})
+        }
+)
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductUser {
+
+    @Id
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(nullable = false, columnDefinition = "uuid", comment = "유저 UUID")
+    private UUID userUuid;
+
+    @Column(nullable = false, length = 50, comment = "닉네임")
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+            nullable = false,
+            columnDefinition = "enum('ACTIVE','BLOCKED','DELETED')",
+            comment = "계정 상태"
+    )
+    private AccountStatus status;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.status == null) this.status = AccountStatus.ACTIVE;
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductUser.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductUser.java
@@ -37,8 +37,11 @@ public class ProductUser {
     )
     private AccountStatus status;
 
-    @PrePersist
-    public void prePersist() {
-        if (this.status == null) this.status = AccountStatus.ACTIVE;
+    public static ProductUser create(UUID userUuid, String nickname) {
+        return ProductUser.builder()
+                .userUuid(userUuid)
+                .nickname(nickname)
+                .status(AccountStatus.ACTIVE)
+                .build();
     }
 }


### PR DESCRIPTION
## PR 제목
- 상품 도메인 엔티티 및 공통 상태 Enum 정의 추가 #25 #34

## 연관된 이슈 
- closes #25 
- #34 

## 개요
상품 도메인의 초기 개발을 위한 엔티티 및 공통 Enum 정의를 추가하고,
목록 조회 및 상태 기반 필터링을 고려한 기본 인덱스/제약 조건을 반영했습니다.

또한 dev 브랜치 반영 과정에서 발생한 테스트 메시지 불일치 및 공통 BaseEntity 코멘트 표현 문제를 함께 정리하여,
현재 기준에서 빌드 및 컴파일이 정상적으로 통과되도록 정합성을 맞췄습니다.
- 로컬 환경에서 `./gradlew clean build` 기준 빌드 정상 통과 확인

## 상세 내용

### 1. 상품 도메인 엔티티 생성 (/boundedContext/product/entity)
- 상품 도메인의 초기 개발을 위한 핵심 엔티티 추가
  - Product
  - Category
  - ProductImage
  - ProductLike
  - ProductComment
- 상품 판매자 정보를 관리하기 위한 ProductSeller 엔티티 추가
- MSA 구조를 고려한 사용자 Replica 테이블 ProductUser 추가
  (user_uuid 기반 식별)

### 2. 공통 Enum 정의 (/common/shared/product/type)
- 도메인 간 공유 가능성이 있는 상태 값을 공통 Enum으로 정의
  - ConditionStatus
  - SaleStatus
  - VisibilityStatus
  - AccountStatus
- 주문/결제/정산/검색 도메인과의 연계를 고려하여 common.shared 경로에 배치

### 3. 제약 조건 및 관계 매핑 반영
- 상품 좋아요 중복 방지를 위한 Unique 제약
  - product_likes (user_uuid, product_id)
- 카테고리/댓글 Self Reference 구조 반영
  - 카테고리 상위/하위 구조
  - 댓글 대댓글 구조 (parent_id)

### 4. 상품 목록 조회를 고려한 인덱스 설계
- 상품 목록 조회 패턴을 기준으로 복합 인덱스 구성
  - 카테고리 + 노출 상태 + 판매 상태 + 생성일 (최신순)
  - 카테고리 + 노출 상태 + 판매 상태 + 좋아요 수 (인기순)
  - 카테고리 + 노출 상태 + 판매 상태 + 가격 (저가/고가순)
- 기존 단일 인덱스는 복합 인덱스로 대체하여 중복 제거

### 5. 기본값 처리 방식 정리
- 공통 BaseEntity에 이미 @PrePersist가 정의되어 있어
  엔티티 레벨에서 추가 @PrePersist 사용 시 오류가 발생하는 이슈 확인
- 해당 이슈를 회피하기 위해
  상품 도메인 엔티티 생성 시 정적 팩토리 메서드(create)를 통해
  기본값을 명시적으로 설정하는 방식으로 처리

### 6. 공통 영역 
- dev 브랜치 반영 과정에서 변경된 예외 메시지로 인한 테스트 실패 수정
- BaseEntity UUID 컬럼의 의미가 특정 도메인(User)에 종속되지 않도록
  코멘트 표현을 중립적인 의미로 정리
- 로컬 환경 기준 `./gradlew clean build` 통과 확인

### 7. 기타 
- 금액 관련 필드 Integer -> Long 타입 변경 관련하여
   Product 도메인은 해당 PR 에서 해결했습니다. 
  - 관련 이슈 : #34 

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI/UX 수정
- [x] 코드 리팩토링
- [ ] 문서 수정
- [x] 테스트 추가/수정
- [ ] 빌드/패키지 수정
- [ ] 파일/폴더 제거

## PR Checklist
- [x] 커밋 메시지가 규칙에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?

## 리뷰어에게 요청드리는 확인 사항
- common.shared vs 도메인 내부 Enum 분리 기준이 팀 컨벤션에 맞는지
- 상품 목록 조회를 고려한 인덱스 설계가 현재 요구사항에 과하지 않은지
- ProductUser, ProductSeller를 Replica/프로필 개념으로 분리한 구조가
  MSA 기준에서 적절한지