### PR TITLE
Feat: 사용자 팔로잉(User ↔ User) 조회 기능 추가

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/user/FindFollowerUsersUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/user/FindFollowerUsersUseCase.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.user.app.user;
+
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.boundedContext.user.entity.UserFollow;
+import dukku.semicolon.boundedContext.user.out.UserFollowRepository;
+import dukku.semicolon.boundedContext.user.out.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindFollowerUsersUseCase {
+
+    private final UserFollowRepository userFollowRepository;
+    private final UserRepository userRepository;
+
+    public List<User> execute(UUID userUuid) {
+        List<UUID> followerIds = userFollowRepository.findByFollowingId(userUuid)
+                .stream()
+                .map(UserFollow::getFollowerId)
+                .toList();
+
+        return userRepository.findAllByUuidIn(followerIds);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/user/FindFollowingUsersUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/user/FindFollowingUsersUseCase.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.user.app.user;
+
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.boundedContext.user.entity.UserFollow;
+import dukku.semicolon.boundedContext.user.out.UserFollowRepository;
+import dukku.semicolon.boundedContext.user.out.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindFollowingUsersUseCase {
+
+    private final UserFollowRepository userFollowRepository;
+    private final UserRepository userRepository;
+
+    public List<User> execute(UUID userUuid) {
+        List<UUID> followingIds = userFollowRepository.findByFollowerId(userUuid)
+                .stream()
+                .map(UserFollow::getFollowingId)
+                .toList();
+
+        return userRepository.findAllByUuidIn(followingIds);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/user/UserFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/user/UserFacade.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -22,6 +23,8 @@ public class UserFacade {
     private final UpdateUserUseCase updateUser;
     private final ChangePasswordUseCase changePassword;
     private final WithdrawUserUseCase withdrawUserUseCase;
+    private final FindFollowingUsersUseCase findFollowingUsers;
+    private final FindFollowerUsersUseCase findFollowerUsers;
 
     public UserResponse registerUser(UserRegisterRequest req, Role role) {
         return User.toUserResponse(registerUser.execute(req, role));
@@ -42,5 +45,19 @@ public class UserFacade {
 
     public void withdraw(UUID userUuid) {
         withdrawUserUseCase.withdraw(userUuid);
+    }
+
+    public List<UserResponse> findMyFollowings(UUID userUuid) {
+        return findFollowingUsers.execute(userUuid)
+                .stream()
+                .map(User::toUserResponse)
+                .toList();
+    }
+
+    public List<UserResponse> findMyFollowers(UUID userUuid) {
+        return findFollowerUsers.execute(userUuid)
+                .stream()
+                .map(User::toUserResponse)
+                .toList();
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/entity/UserFollow.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/entity/UserFollow.java
@@ -1,0 +1,57 @@
+package dukku.semicolon.boundedContext.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "user_follow",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_follower_following",
+                        columnNames = {"follower_id", "following_id"}
+                )
+        }
+)
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserFollow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "follower_id", nullable = false, comment = "팔로우 하는 사용자 UUID")
+    private UUID followerId;
+
+    @Column(name = "following_id", nullable = false, comment = "팔로우 당하는 사용자 UUID")
+    private UUID followingId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /* =========================
+       생성 메서드
+    ========================== */
+
+    public static UserFollow create(UUID followerId, UUID followingId) {
+        if (followerId.equals(followingId)) {
+            throw new IllegalArgumentException("자기 자신을 팔로우할 수 없습니다.");
+        }
+
+        return UserFollow.builder()
+                .followerId(followerId)
+                .followingId(followingId)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/in/UserController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/in/UserController.java
@@ -14,6 +14,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
@@ -59,6 +62,17 @@ public class UserController {
     public ResponseEntity<Void> deleteUser() {
         userFacade.withdraw(UserUtil.getUserId());
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me/followings")
+    public List<UserResponse> myFollowings() {
+        // 기존 메서드들과 동일하게 UserUtil을 사용합니다.
+        return userFacade.findMyFollowings(UserUtil.getUserId());
+    }
+
+    @GetMapping("/me/followers")
+    public List<UserResponse> myFollowers() {
+        return userFacade.findMyFollowers(UserUtil.getUserId());
     }
 
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/out/UserFollowRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/out/UserFollowRepository.java
@@ -1,0 +1,18 @@
+package dukku.semicolon.boundedContext.user.out;
+
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.boundedContext.user.entity.UserFollow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserFollowRepository extends JpaRepository<UserFollow, Long> {
+
+    // 내가 팔로우한 사용자들
+    List<UserFollow> findByFollowerId(UUID followerId);
+
+    // 나를 팔로우한 사용자들
+    List<UserFollow> findByFollowingId(UUID followingId);
+
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/out/UserRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/out/UserRepository.java
@@ -3,6 +3,7 @@ package dukku.semicolon.boundedContext.user.out;
 import dukku.semicolon.boundedContext.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByEmailAndDeletedAtIsNull(String email);
 
     Optional<User> findByUuidAndDeletedAtIsNull(UUID userUuid);
+
+    List<User> findAllByUuidIn(List<UUID> uuids);
 }


### PR DESCRIPTION
## PR 제목

- 변경 내용을 **단일 문장으로 요약**한다.
- 가능하면 **명령형**으로 작성한다.
- 관련 이슈 번호를 포함한다 (예: `feat: add user profile API #123`).
- PR 본문에는 작성하지 않아도 됩니다. 제목 참고용!

## 개요
사용자 간 팔로잉(User ↔ User) 관계를 조회할 수 있도록
팔로잉 도메인 구조를 설계하고, 조회 API를 구현했습니다.
본 기능은 서비스 우선순위에 따라 팔로우/언팔로우 행위는 제외하고,
조회 기능 중심으로 구현하였습니다

## 상세 내용
- 사용자 간 팔로잉 관계를 N:N 자기참조 관계로 설계
- User 엔티티의 결합도를 낮추기 위해 UserFollow 엔티티 및 테이블 분리
- UUID 기반 조회 방식으로 팔로잉/팔로워 목록 조회 구현
- 조회 전용 UseCase (FindFollowingUsersUseCase, FindFollowerUsersUseCase) 추가
- UserFacade를 통해 조회 책임을 일관되게 관리
- 인증 사용자 기준(@AuthUser) 조회 API 추가

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI/UX 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 빌드/패키지 수정
- [ ] 파일/폴더 제거

## PR Checklist
- [ ] 커밋 메시지가 규칙에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?
