### PR TITLE
Fix(enum): MySQL 문법 columnDefinition 삭제 (PostgreSQL enum 미지원)

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/Product.java
@@ -58,7 +58,6 @@ public class Product extends BaseIdAndUUIDAndTime {
     @Enumerated(EnumType.STRING)
     @Column(
             nullable = false,
-            columnDefinition = "enum('SEALED','NO_WEAR','MINOR_WEAR','VISIBLE_WEAR','DAMAGED')",
             comment = "상품 컨디션"
     )
     private ConditionStatus conditionStatus;
@@ -66,7 +65,6 @@ public class Product extends BaseIdAndUUIDAndTime {
     @Enumerated(EnumType.STRING)
     @Column(
             nullable = false,
-            columnDefinition = "enum('ON_SALE','RESERVED','SOLD_OUT')",
             comment = "상품 판매 상태"
     )
     private SaleStatus saleStatus;
@@ -74,7 +72,6 @@ public class Product extends BaseIdAndUUIDAndTime {
     @Enumerated(EnumType.STRING)
     @Column(
             nullable = false,
-            columnDefinition = "enum('VISIBLE','HIDDEN','BLOCKED')",
             comment = "상품 노출 상태"
     )
     private VisibilityStatus visibilityStatus;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductUser.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductUser.java
@@ -32,7 +32,6 @@ public class ProductUser {
     @Enumerated(EnumType.STRING)
     @Column(
             nullable = false,
-            columnDefinition = "enum('ACTIVE','BLOCKED','DELETED')",
             comment = "계정 상태"
     )
     private AccountStatus status;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/entity/Settlement.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/entity/Settlement.java
@@ -48,7 +48,7 @@ public class Settlement extends BaseIdAndUUIDAndTime {
     private UUID depositId;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "settlement_status", nullable = false, columnDefinition = "enum('CREATED','PROCESSING','PENDING','SUCCESS','FAILED')", comment = "정산 상태")
+    @Column(name = "settlement_status", nullable = false, comment = "정산 상태")
     private SettlementStatus settlementStatus;
 
     @Column(name = "total_amount", nullable = false, columnDefinition = "bigint default 0", comment = "총액")


### PR DESCRIPTION
## PR 제목
Fix(enum): MySQL 문법 columnDefinition 삭제 (PostgreSQL enum 미지원)

## 개요
프론트 - 백엔드 연동 과정에서 발생한 오류 해결
[관련 노션 페이지](https://www.notion.so/PostgresSQL-enum-2f015a01205480ecbc5ff8063d2ebf32?source=copy_link)

## 상세 내용
- 팀원 공유 내용
: 프론트 - 백엔드 연동중 계속 internal error가 발생해서 체크하다가 확인된 사항 정리해 공유드립니다.
postgreSQL이랑 mysql이랑 enum 문법이 달라서 enum을 columDefinition으로 주입하면 오류가 나는 것 같습니다.
트러블슈팅 문서에 정리했는데 아침에 오시면 더블체크 부탁드릴게요.

## PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI/UX 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 빌드/패키지 수정
- [ ] 파일/폴더 제거

## PR Checklist
- [x] 커밋 메시지가 규칙에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?
