### PR TITLE
Feat: 상품 도메인 판매자 상점 API 구현 및 찜 목록 조회 구조 개선

### DIFF
--- a/common/src/test/java/dukku/common/global/common/handler/GlobalExceptionHandlerTest.java
+++ b/common/src/test/java/dukku/common/global/common/handler/GlobalExceptionHandlerTest.java
@@ -76,7 +76,7 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
         assertThat(response.getBody()).isNotNull();
         assertThat(response.getBody().getCode()).isEqualTo(HttpStatus.NOT_FOUND.getReasonPhrase());
-        assertThat(response.getBody().getMessage()).isEqualTo("요청한 리소스를 찾을 수 없습니다.");
+        assertThat(response.getBody().getMessage()).isEqualTo("리소스를 찾을 수 없습니다.");
         assertThat(response.getBody().getStatus()).isEqualTo(404);
         assertThat(response.getBody().getDetails()).isEqualTo("리소스를 찾을 수 없습니다.");
     }
@@ -114,4 +114,3 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().getDetails()).isNull();
     }
 }
-

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/FindMyLikedProductsUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/FindMyLikedProductsUseCase.java
@@ -1,6 +1,8 @@
 package dukku.semicolon.boundedContext.product.app;
 
+import dukku.semicolon.boundedContext.product.entity.Product;
 import dukku.semicolon.boundedContext.product.out.ProductLikeRepository;
+import dukku.semicolon.boundedContext.product.out.ProductRepository;
 import dukku.semicolon.shared.product.dto.MyLikedProductListResponse;
 import dukku.semicolon.shared.product.dto.ProductListItemResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,14 +13,19 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class FindMyLikedProductsUseCase {
 
     private final ProductLikeRepository productLikeRepository;
-    private final ProductSupport productSupport;
+    private final ProductRepository productRepository;
 
     @Transactional(readOnly = true)
     public MyLikedProductListResponse execute(UUID userUuid, int page, int size) {
@@ -29,9 +36,25 @@ public class FindMyLikedProductsUseCase {
                 Sort.by(Sort.Direction.DESC, "createdAt")
         );
 
-        Page<ProductListItemResponse> mapped = productLikeRepository.findByUserUuid(userUuid, pageable)
-                .map(like -> productSupport.findListItemByProductUuid(like.getProduct().getUuid()));
+        Page<UUID> likedUuidsPage =
+                productLikeRepository.findProductUuidsByUserUuid(userUuid, pageable);
 
-        return MyLikedProductListResponse.from(mapped);
+        List<UUID> likedUuids = likedUuidsPage.getContent();
+        if (likedUuids.isEmpty()) {
+            return MyLikedProductListResponse.from(likedUuidsPage, List.of());
+        }
+
+        List<Product> products = productRepository.findByUuidInAndDeletedAtIsNull(likedUuids);
+
+        Map<UUID, Product> productMap = products.stream()
+                .collect(Collectors.toMap(Product::getUuid, Function.identity()));
+
+        List<ProductListItemResponse> items = likedUuids.stream()
+                .map(productMap::get)
+                .filter(Objects::nonNull) // 중간 삭제된 상품은 제외
+                .map(ProductMapper::toListItem)
+                .toList();
+
+        return MyLikedProductListResponse.from(likedUuidsPage, items);
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/FindMyShopProductsUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/FindMyShopProductsUseCase.java
@@ -1,0 +1,52 @@
+package dukku.semicolon.boundedContext.product.app;
+
+import dukku.common.shared.product.type.SaleStatus;
+import dukku.semicolon.boundedContext.product.entity.Product;
+import dukku.semicolon.boundedContext.product.entity.ProductSeller;
+import dukku.semicolon.boundedContext.product.out.ProductRepository;
+import dukku.semicolon.boundedContext.product.out.ProductSellerRepository;
+import dukku.semicolon.shared.product.dto.ProductListItemResponse;
+import dukku.semicolon.shared.product.dto.ShopProductListResponse;
+import dukku.semicolon.shared.product.exception.ProductSellerNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class FindMyShopProductsUseCase {
+
+    private final ProductSellerRepository productSellerRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional(readOnly = true)
+    public ShopProductListResponse execute(UUID userUuid, SaleStatus saleStatus, int page, int size) {
+
+        Pageable pageable = PageRequest.of(
+                Math.max(page, 0),
+                Math.min(size, 50),
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        // 내 상점: userUuid로 ProductSeller 찾고
+        ProductSeller seller = productSellerRepository.findByUserUuid(userUuid)
+                .orElseThrow(ProductSellerNotFoundException::new);
+
+        // seller.userUuid == Product.sellerUuid
+        UUID sellerUserUuid = seller.getUserUuid();
+
+        Page<Product> result = (saleStatus == null)
+                ? productRepository.findBySellerUuidAndDeletedAtIsNull(sellerUserUuid, pageable)
+                : productRepository.findBySellerUuidAndSaleStatusAndDeletedAtIsNull(sellerUserUuid, saleStatus, pageable);
+
+        List<ProductListItemResponse> items = result.getContent().stream()
+                .map(ProductMapper::toListItem)
+                .toList();
+
+        return ShopProductListResponse.from(result, items);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/FindMyShopUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/FindMyShopUseCase.java
@@ -1,0 +1,26 @@
+package dukku.semicolon.boundedContext.product.app;
+
+import dukku.semicolon.boundedContext.product.entity.ProductSeller;
+import dukku.semicolon.boundedContext.product.out.ProductSellerRepository;
+import dukku.semicolon.shared.product.dto.ShopResponse;
+import dukku.semicolon.shared.product.exception.ProductSellerNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class FindMyShopUseCase {
+
+    private final ProductSellerRepository productSellerRepository;
+
+    @Transactional(readOnly = true)
+    public ShopResponse execute(UUID userUuid) {
+        ProductSeller seller = productSellerRepository.findByUserUuid(userUuid)
+                .orElseThrow(ProductSellerNotFoundException::new);
+
+        return ShopResponse.from(seller);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/FindShopProductsUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/FindShopProductsUseCase.java
@@ -1,0 +1,46 @@
+package dukku.semicolon.boundedContext.product.app;
+
+import dukku.semicolon.boundedContext.product.entity.Product;
+import dukku.semicolon.boundedContext.product.entity.ProductSeller;
+import dukku.semicolon.boundedContext.product.out.ProductRepository;
+import dukku.semicolon.boundedContext.product.out.ProductSellerRepository;
+import dukku.semicolon.shared.product.dto.ProductListItemResponse;
+import dukku.semicolon.shared.product.dto.ShopProductListResponse;
+import dukku.semicolon.shared.product.exception.ProductSellerNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class FindShopProductsUseCase {
+
+    private final ProductSellerRepository productSellerRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional(readOnly = true)
+    public ShopProductListResponse execute(UUID shopUuid, int page, int size) {
+
+        Pageable pageable = PageRequest.of(
+                Math.max(page, 0),
+                Math.min(size, 50),
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        ProductSeller seller = productSellerRepository.findByUuid(shopUuid)
+                .orElseThrow(ProductSellerNotFoundException::new);
+
+        // seller.userUuid == Product.sellerUuid
+        Page<Product> result = productRepository.findBySellerUuidAndDeletedAtIsNull(seller.getUserUuid(), pageable);
+
+        List<ProductListItemResponse> items = result.getContent().stream()
+                .map(ProductMapper::toListItem)
+                .toList();
+
+        return ShopProductListResponse.from(result, items);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/FindShopUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/FindShopUseCase.java
@@ -1,0 +1,26 @@
+package dukku.semicolon.boundedContext.product.app;
+
+import dukku.semicolon.boundedContext.product.entity.ProductSeller;
+import dukku.semicolon.boundedContext.product.out.ProductSellerRepository;
+import dukku.semicolon.shared.product.dto.ShopResponse;
+import dukku.semicolon.shared.product.exception.ProductSellerNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class FindShopUseCase {
+
+    private final ProductSellerRepository productSellerRepository;
+
+    @Transactional(readOnly = true)
+    public ShopResponse execute(UUID shopUuid) {
+        ProductSeller seller = productSellerRepository.findByUuid(shopUuid)
+                .orElseThrow(ProductSellerNotFoundException::new);
+
+        return ShopResponse.from(seller);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/LikeProductUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/LikeProductUseCase.java
@@ -7,6 +7,7 @@ import dukku.semicolon.boundedContext.product.out.ProductRepository;
 import dukku.semicolon.shared.product.dto.LikeProductResponse;
 import dukku.semicolon.shared.product.exception.ProductNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +27,11 @@ public class LikeProductUseCase {
                 .orElseThrow(ProductNotFoundException::new);
 
         if (!productLikeRepository.existsByUserUuidAndProduct_Uuid(userUuid, productUuid)) {
-            productLikeRepository.save(ProductLike.create(userUuid, product));
+            try {
+                productLikeRepository.save(ProductLike.create(userUuid, product));
+            } catch (DataIntegrityViolationException ignored) {
+                // 동시성으로 이미 저장된 케이스: 무시하고 계속 진행
+            }
         }
 
         long likeCount = productLikeRepository.countByProduct_Uuid(productUuid);

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ProductLikeFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ProductLikeFacade.java
@@ -23,7 +23,7 @@ public class ProductLikeFacade {
         return unlikeProductUseCase.execute(userUuid, productUuid);
     }
 
-    public MyLikedProductListResponse myLikes(UUID userUuid, int page, int size) {
+    public MyLikedProductListResponse findMyLikes(UUID userUuid, int page, int size) {
         return findMyLikedProductsUseCase.execute(userUuid, page, size);
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ProductMapper.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ProductMapper.java
@@ -11,19 +11,7 @@ import java.util.List;
 public class ProductMapper {
 
     public static ProductListItemResponse toListItem(Product p) {
-        String thumb = p.getImages().stream()
-                .sorted(Comparator.comparingInt(ProductImage::getSortOrder))
-                .findFirst()
-                .map(ProductImage::getImageUrl)
-                .orElse(null);
-
-        return ProductListItemResponse.builder()
-                .productUuid(p.getUuid())
-                .title(p.getTitle())
-                .price(p.getPrice())
-                .thumbnailUrl(thumb)
-                .likeCount(p.getLikeCount())
-                .build();
+        return ProductListItemResponse.from(p);
     }
 
     public static ProductDetailResponse toDetail(Product p) {

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ProductSupport.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ProductSupport.java
@@ -1,32 +1,18 @@
 package dukku.semicolon.boundedContext.product.app;
 
-import dukku.semicolon.boundedContext.product.entity.Product;
 import dukku.semicolon.boundedContext.product.out.CategoryRepository;
-import dukku.semicolon.boundedContext.product.out.ProductRepository;
-import dukku.semicolon.shared.product.dto.ProductListItemResponse;
 import dukku.semicolon.shared.product.exception.ProductImageLimitExceededException;
-import dukku.semicolon.shared.product.exception.ProductNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
 public class ProductSupport {
 
-    private final ProductRepository productRepository;
     private final CategoryRepository categoryRepository;
 
     public boolean existsByCategoryId(Integer categoryId) {
         return categoryRepository.existsById(categoryId);
-    }
-
-    public ProductListItemResponse findListItemByProductUuid(UUID productUuid){
-        Product product = productRepository.findByUuidAndDeletedAtIsNull(productUuid)
-                .orElseThrow(ProductNotFoundException::new);
-
-        return ProductMapper.toListItem(product);
     }
 
     public void validateImageCount(int currentCount, int addCount) {

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ShopFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ShopFacade.java
@@ -17,9 +17,14 @@ public class ShopFacade {
     private final UpdateMyShopUseCase updateMyShopUseCase;
     private final FindShopUseCase findShopUseCase;
     private final FindShopProductsUseCase findShopProductsUseCase;
+    private final FindMyShopProductsUseCase findMyShopProductsUseCase;
 
     public ShopResponse findMyShop(UUID userUuid) {
         return findMyShopUseCase.execute(userUuid);
+    }
+
+    public ShopProductListResponse findMyShopProducts(UUID userUuid, SaleStatus saleStatus, int page, int size) {
+        return findMyShopProductsUseCase.execute(userUuid, saleStatus, page, size);
     }
 
     public ShopResponse updateMyShop(UUID userUuid, UpdateShopRequest request) {

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ShopFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ShopFacade.java
@@ -1,0 +1,35 @@
+package dukku.semicolon.boundedContext.product.app;
+
+import dukku.semicolon.shared.product.dto.ShopProductListResponse;
+import dukku.semicolon.shared.product.dto.ShopResponse;
+import dukku.semicolon.shared.product.dto.UpdateShopRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ShopFacade {
+
+    private final FindMyShopUseCase findMyShopUseCase;
+    private final UpdateMyShopUseCase updateMyShopUseCase;
+    private final FindShopUseCase findShopUseCase;
+    private final FindShopProductsUseCase findShopProductsUseCase;
+
+    public ShopResponse findMyShop(UUID userUuid) {
+        return findMyShopUseCase.execute(userUuid);
+    }
+
+    public ShopResponse updateMyShop(UUID userUuid, UpdateShopRequest request) {
+        return updateMyShopUseCase.execute(userUuid, request);
+    }
+
+    public ShopResponse findShop(UUID shopUuid) {
+        return findShopUseCase.execute(shopUuid);
+    }
+
+    public ShopProductListResponse findShopProducts(UUID shopUuid, int page, int size) {
+        return findShopProductsUseCase.execute(shopUuid, page, size);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ShopFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/ShopFacade.java
@@ -1,5 +1,6 @@
 package dukku.semicolon.boundedContext.product.app;
 
+import dukku.common.shared.product.type.SaleStatus;
 import dukku.semicolon.shared.product.dto.ShopProductListResponse;
 import dukku.semicolon.shared.product.dto.ShopResponse;
 import dukku.semicolon.shared.product.dto.UpdateShopRequest;
@@ -29,7 +30,7 @@ public class ShopFacade {
         return findShopUseCase.execute(shopUuid);
     }
 
-    public ShopProductListResponse findShopProducts(UUID shopUuid, int page, int size) {
-        return findShopProductsUseCase.execute(shopUuid, page, size);
+    public ShopProductListResponse findShopProducts(UUID shopUuid, SaleStatus saleStatus, int page, int size) {
+        return findShopProductsUseCase.execute(shopUuid, saleStatus, page, size);
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/UpdateMyShopUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/UpdateMyShopUseCase.java
@@ -1,0 +1,32 @@
+package dukku.semicolon.boundedContext.product.app;
+
+import dukku.semicolon.boundedContext.product.entity.ProductSeller;
+import dukku.semicolon.boundedContext.product.out.ProductSellerRepository;
+import dukku.semicolon.shared.product.dto.ShopResponse;
+import dukku.semicolon.shared.product.dto.UpdateShopRequest;
+import dukku.semicolon.shared.product.exception.ProductSellerNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class UpdateMyShopUseCase {
+
+    private final ProductSellerRepository productSellerRepository;
+
+    @Transactional
+    public ShopResponse execute(UUID userUuid, UpdateShopRequest request) {
+        ProductSeller seller = productSellerRepository.findByUserUuid(userUuid)
+                .orElseThrow(ProductSellerNotFoundException::new);
+
+        // intro만 수정 (null이면 그대로 유지)
+        if (request.getIntro() != null) {
+            seller.changeIntro(request.getIntro());
+        }
+
+        return ShopResponse.from(seller);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductSeller.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/entity/ProductSeller.java
@@ -46,4 +46,8 @@ public class ProductSeller extends BaseIdAndUUIDAndTime {
                 .activeListingCount(0)
                 .build();
     }
+
+    public void changeIntro(String intro) {
+        this.intro = intro;
+    }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ProductLikeController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ProductLikeController.java
@@ -1,6 +1,7 @@
 package dukku.semicolon.boundedContext.product.in;
 
 import dukku.semicolon.boundedContext.product.app.ProductLikeFacade;
+import dukku.semicolon.shared.product.docs.ProductLikeApiDocs;
 import dukku.semicolon.shared.product.dto.LikeProductResponse;
 import dukku.semicolon.shared.product.dto.MyLikedProductListResponse;
 import jakarta.validation.constraints.Max;
@@ -16,11 +17,13 @@ import java.util.UUID;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
+@ProductLikeApiDocs.ProductLikeTag
 public class ProductLikeController {
 
     private final ProductLikeFacade productLikeFacade;
 
     @PostMapping("/products/{productUuid}/likes")
+    @ProductLikeApiDocs.LikeProduct
     public LikeProductResponse like(
             @PathVariable UUID productUuid,
             @RequestHeader("X-USER-UUID") UUID userUuid // TODO : 임시 사용자 UUID 헤더
@@ -29,6 +32,7 @@ public class ProductLikeController {
     }
 
     @DeleteMapping("/products/{productUuid}/likes")
+    @ProductLikeApiDocs.UnlikeProduct
     public LikeProductResponse unlike(
             @PathVariable UUID productUuid,
             @RequestHeader("X-USER-UUID") UUID userUuid
@@ -37,6 +41,7 @@ public class ProductLikeController {
     }
 
     @GetMapping("/me/likes")
+    @ProductLikeApiDocs.FindMyLikes
     public MyLikedProductListResponse findMyLikes(
             @RequestHeader("X-USER-UUID") UUID userUuid,
             @RequestParam(defaultValue = "0") @Min(0) int page,

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ProductLikeController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ProductLikeController.java
@@ -3,6 +3,8 @@ package dukku.semicolon.boundedContext.product.in;
 import dukku.semicolon.boundedContext.product.app.ProductLikeFacade;
 import dukku.semicolon.shared.product.dto.LikeProductResponse;
 import dukku.semicolon.shared.product.dto.MyLikedProductListResponse;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -21,7 +23,7 @@ public class ProductLikeController {
     @PostMapping("/products/{productUuid}/likes")
     public LikeProductResponse like(
             @PathVariable UUID productUuid,
-            @RequestHeader("X-USER-UUID") UUID userUuid // 프로젝트 인증 방식에 맞게 바꾸기
+            @RequestHeader("X-USER-UUID") UUID userUuid // TODO : 임시 사용자 UUID 헤더
     ) {
         return productLikeFacade.like(userUuid, productUuid);
     }
@@ -35,11 +37,11 @@ public class ProductLikeController {
     }
 
     @GetMapping("/me/likes")
-    public MyLikedProductListResponse myLikes(
+    public MyLikedProductListResponse findMyLikes(
             @RequestHeader("X-USER-UUID") UUID userUuid,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
     ) {
-        return productLikeFacade.myLikes(userUuid, page, size);
+        return productLikeFacade.findMyLikes(userUuid, page, size);
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ShopController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ShopController.java
@@ -43,6 +43,18 @@ public class ShopController {
         return shopFacade.updateMyShop(userUuid, request);
     }
 
+    // 내 상점 상품 목록(내 판매 상품)
+    @GetMapping("/me/shop/products")
+    @ShopApiDocs.FindMyShopProducts
+    public ShopProductListResponse findMyShopProducts(
+            @RequestHeader("X-USER-UUID") UUID userUuid,
+            @RequestParam(required = false) SaleStatus saleStatus,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+    ) {
+        return shopFacade.findMyShopProducts(userUuid, saleStatus, page, size);
+    }
+
     // 판매자 상점 조회(공개)
     @GetMapping("/shops/{shopUuid}")
     @ShopApiDocs.FindShop

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ShopController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ShopController.java
@@ -1,0 +1,58 @@
+package dukku.semicolon.boundedContext.product.in;
+
+import dukku.semicolon.boundedContext.product.app.ShopFacade;
+import dukku.semicolon.shared.product.dto.ShopProductListResponse;
+import dukku.semicolon.shared.product.dto.ShopResponse;
+import dukku.semicolon.shared.product.dto.UpdateShopRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class ShopController {
+
+    private final ShopFacade shopFacade;
+
+    // 내 상점 조회
+    @GetMapping("/me/shop")
+    public ShopResponse findMyShop(
+            @RequestHeader("X-USER-UUID") UUID userUuid
+    ) {
+        return shopFacade.findMyShop(userUuid);
+    }
+
+    // 내 상점 소개 수정
+    @PatchMapping("/me/shop")
+    public ShopResponse updateMyShop(
+            @RequestHeader("X-USER-UUID") UUID userUuid,
+            @RequestBody @Valid UpdateShopRequest request
+    ) {
+        return shopFacade.updateMyShop(userUuid, request);
+    }
+
+    // 판매자 상점 조회(공개)
+    @GetMapping("/shops/{shopUuid}")
+    public ShopResponse findShop(
+            @PathVariable UUID shopUuid
+    ) {
+        return shopFacade.findShop(shopUuid);
+    }
+
+    // 판매자 상점 상품 목록(공개)
+    @GetMapping("/shops/{shopUuid}/products")
+    public ShopProductListResponse findShopProducts(
+            @PathVariable UUID shopUuid,
+            @RequestParam(defaultValue = "0") @Min(0) int page,
+            @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
+    ) {
+        return shopFacade.findShopProducts(shopUuid, page, size);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ShopController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ShopController.java
@@ -18,14 +18,14 @@ import java.util.UUID;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/shops")
 @ShopApiDocs.ShopTag
 public class ShopController {
 
     private final ShopFacade shopFacade;
 
     // 내 상점 조회
-    @GetMapping("/me/shop")
+    @GetMapping("/me")
     @ShopApiDocs.FindMyShop
     public ShopResponse findMyShop(
             @RequestHeader("X-USER-UUID") UUID userUuid
@@ -34,7 +34,7 @@ public class ShopController {
     }
 
     // 내 상점 소개 수정
-    @PatchMapping("/me/shop")
+    @PatchMapping("/me")
     @ShopApiDocs.UpdateMyShop
     public ShopResponse updateMyShop(
             @RequestHeader("X-USER-UUID") UUID userUuid,
@@ -44,7 +44,7 @@ public class ShopController {
     }
 
     // 내 상점 상품 목록(내 판매 상품)
-    @GetMapping("/me/shop/products")
+    @GetMapping("/me/products")
     @ShopApiDocs.FindMyShopProducts
     public ShopProductListResponse findMyShopProducts(
             @RequestHeader("X-USER-UUID") UUID userUuid,
@@ -56,7 +56,7 @@ public class ShopController {
     }
 
     // 판매자 상점 조회(공개)
-    @GetMapping("/shops/{shopUuid}")
+    @GetMapping("/{shopUuid}")
     @ShopApiDocs.FindShop
     public ShopResponse findShop(
             @PathVariable UUID shopUuid
@@ -65,7 +65,7 @@ public class ShopController {
     }
 
     // 판매자 상점 상품 목록(공개)
-    @GetMapping("/shops/{shopUuid}/products")
+    @GetMapping("/{shopUuid}/products")
     @ShopApiDocs.FindShopProducts
     public ShopProductListResponse findShopProducts(
             @PathVariable UUID shopUuid,

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ShopController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ShopController.java
@@ -1,6 +1,7 @@
 package dukku.semicolon.boundedContext.product.in;
 
 import dukku.semicolon.boundedContext.product.app.ShopFacade;
+import dukku.semicolon.shared.product.docs.ShopApiDocs;
 import dukku.semicolon.shared.product.dto.ShopProductListResponse;
 import dukku.semicolon.shared.product.dto.ShopResponse;
 import dukku.semicolon.shared.product.dto.UpdateShopRequest;
@@ -17,12 +18,14 @@ import java.util.UUID;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
+@ShopApiDocs.ShopTag
 public class ShopController {
 
     private final ShopFacade shopFacade;
 
     // 내 상점 조회
     @GetMapping("/me/shop")
+    @ShopApiDocs.FindMyShop
     public ShopResponse findMyShop(
             @RequestHeader("X-USER-UUID") UUID userUuid
     ) {
@@ -31,6 +34,7 @@ public class ShopController {
 
     // 내 상점 소개 수정
     @PatchMapping("/me/shop")
+    @ShopApiDocs.UpdateMyShop
     public ShopResponse updateMyShop(
             @RequestHeader("X-USER-UUID") UUID userUuid,
             @RequestBody @Valid UpdateShopRequest request
@@ -40,6 +44,7 @@ public class ShopController {
 
     // 판매자 상점 조회(공개)
     @GetMapping("/shops/{shopUuid}")
+    @ShopApiDocs.FindShop
     public ShopResponse findShop(
             @PathVariable UUID shopUuid
     ) {
@@ -48,6 +53,7 @@ public class ShopController {
 
     // 판매자 상점 상품 목록(공개)
     @GetMapping("/shops/{shopUuid}/products")
+    @ShopApiDocs.FindShopProducts
     public ShopProductListResponse findShopProducts(
             @PathVariable UUID shopUuid,
             @RequestParam(defaultValue = "0") @Min(0) int page,

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ShopController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ShopController.java
@@ -1,5 +1,6 @@
 package dukku.semicolon.boundedContext.product.in;
 
+import dukku.common.shared.product.type.SaleStatus;
 import dukku.semicolon.boundedContext.product.app.ShopFacade;
 import dukku.semicolon.shared.product.docs.ShopApiDocs;
 import dukku.semicolon.shared.product.dto.ShopProductListResponse;
@@ -56,9 +57,10 @@ public class ShopController {
     @ShopApiDocs.FindShopProducts
     public ShopProductListResponse findShopProducts(
             @PathVariable UUID shopUuid,
+            @RequestParam(required = false) SaleStatus saleStatus,
             @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "20") @Min(1) @Max(50) int size
     ) {
-        return shopFacade.findShopProducts(shopUuid, page, size);
+        return shopFacade.findShopProducts(shopUuid, saleStatus, page, size);
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/out/ProductLikeRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/out/ProductLikeRepository.java
@@ -4,6 +4,7 @@ import dukku.semicolon.boundedContext.product.entity.ProductLike;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -16,5 +17,11 @@ public interface ProductLikeRepository extends JpaRepository<ProductLike, Intege
 
     long countByProduct_Uuid(UUID productUuid);
 
-    Page<ProductLike> findByUserUuid(UUID userUuid, Pageable pageable);
+    @Query("""
+        select pl.product.uuid
+        from ProductLike pl
+        where pl.userUuid = :userUuid
+        order by pl.createdAt desc
+    """)
+    Page<UUID> findProductUuidsByUserUuid(UUID userUuid, Pageable pageable);
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/out/ProductRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/out/ProductRepository.java
@@ -22,6 +22,9 @@ public interface ProductRepository extends JpaRepository<Product, Integer> {
     @EntityGraph(attributePaths = "images")
     List<Product> findByUuidInAndDeletedAtIsNull(List<UUID> uuids);
 
+    @EntityGraph(attributePaths = "images")
+    Page<Product> findBySellerUuidAndDeletedAtIsNull(UUID sellerUuid, Pageable pageable);
+
     // 목록: visibility=VISIBLE, deletedAt=null 기본
     Page<Product> findByVisibilityStatusAndDeletedAtIsNull(
             VisibilityStatus visibilityStatus,

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/out/ProductRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/out/ProductRepository.java
@@ -4,8 +4,10 @@ import dukku.common.shared.product.type.VisibilityStatus;
 import dukku.semicolon.boundedContext.product.entity.Product;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,6 +18,9 @@ public interface ProductRepository extends JpaRepository<Product, Integer> {
     Optional<Product> findByUuidAndDeletedAtIsNull(UUID productUuid);
 
     boolean existsByUuidAndDeletedAtIsNull(UUID productUuid);
+
+    @EntityGraph(attributePaths = "images")
+    List<Product> findByUuidInAndDeletedAtIsNull(List<UUID> uuids);
 
     // 목록: visibility=VISIBLE, deletedAt=null 기본
     Page<Product> findByVisibilityStatusAndDeletedAtIsNull(

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/out/ProductRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/out/ProductRepository.java
@@ -1,5 +1,6 @@
 package dukku.semicolon.boundedContext.product.out;
 
+import dukku.common.shared.product.type.SaleStatus;
 import dukku.common.shared.product.type.VisibilityStatus;
 import dukku.semicolon.boundedContext.product.entity.Product;
 import org.springframework.data.domain.Page;
@@ -24,6 +25,11 @@ public interface ProductRepository extends JpaRepository<Product, Integer> {
 
     @EntityGraph(attributePaths = "images")
     Page<Product> findBySellerUuidAndDeletedAtIsNull(UUID sellerUuid, Pageable pageable);
+
+    @EntityGraph(attributePaths = "images")
+    Page<Product> findBySellerUuidAndSaleStatusAndDeletedAtIsNull(
+            UUID sellerUuid, SaleStatus saleStatus, Pageable pageable
+    );
 
     // 목록: visibility=VISIBLE, deletedAt=null 기본
     Page<Product> findByVisibilityStatusAndDeletedAtIsNull(

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/out/ProductSellerRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/out/ProductSellerRepository.java
@@ -8,4 +8,6 @@ import java.util.UUID;
 
 public interface ProductSellerRepository extends JpaRepository<ProductSeller, Integer> {
     Optional<ProductSeller> findByUserUuid(UUID userUuid);
+
+    Optional<ProductSeller> findByUuid(UUID shopUuid);
 }

--- a/semicolon/src/main/java/dukku/semicolon/shared/product/docs/ProductLikeApiDocs.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/product/docs/ProductLikeApiDocs.java
@@ -1,0 +1,172 @@
+package dukku.semicolon.shared.product.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+public final class ProductLikeApiDocs {
+
+    private ProductLikeApiDocs() {}
+
+    @Documented
+    @Target(TYPE)
+    @Retention(RUNTIME)
+    @Tag(
+            name = "상품 좋아요(찜) API",
+            description = "상품 좋아요/좋아요 취소 및 내 좋아요 목록 조회"
+    )
+    public @interface ProductLikeTag {}
+
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(
+            summary = "상품 좋아요(찜) 등록",
+            description = "상품에 좋아요(찜)를 등록합니다. 이미 좋아요 상태면 그대로 유지됩니다.",
+            parameters = {
+                    @Parameter(name = "productUuid", description = "상품 UUID", required = true,
+                            example = "3fa85f64-5717-4562-b3fc-2c963f66afa6"),
+                    @Parameter(name = "X-USER-UUID", description = "임시 사용자 UUID 헤더", required = true,
+                            example = "7fa85f64-5717-4562-b3fc-2c963f66afa6")
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "좋아요 등록 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "Like Product",
+                                            value = """
+                                                    {
+                                                      "productUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                                                      "liked": true,
+                                                      "likeCount": 151
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상품을 찾을 수 없음",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "message": "리소스를 찾을 수 없습니다.",
+                                                      "details": "존재하지 않는 상품입니다."
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    public @interface LikeProduct {}
+
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(
+            summary = "상품 좋아요(찜) 취소",
+            description = "상품 좋아요(찜)를 취소합니다. 좋아요 상태가 아니어도 정상 처리됩니다.",
+            parameters = {
+                    @Parameter(name = "productUuid", description = "상품 UUID", required = true,
+                            example = "3fa85f64-5717-4562-b3fc-2c963f66afa6"),
+                    @Parameter(name = "X-USER-UUID", description = "임시 사용자 UUID 헤더", required = true,
+                            example = "7fa85f64-5717-4562-b3fc-2c963f66afa6")
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "좋아요 취소 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "Unlike Product",
+                                            value = """
+                                                    {
+                                                      "productUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                                                      "liked": false,
+                                                      "likeCount": 150
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상품을 찾을 수 없음",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "message": "리소소스를 찾을 수 없습니다.",
+                                                      "details": "존재하지 않는 상품입니다."
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    public @interface UnlikeProduct {}
+
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(
+            summary = "내 좋아요(찜) 목록 조회",
+            description = "내가 좋아요한 상품 목록을 페이징으로 조회합니다.",
+            parameters = {
+                    @Parameter(name = "X-USER-UUID", description = "임시 사용자 UUID 헤더", required = true,
+                            example = "7fa85f64-5717-4562-b3fc-2c963f66afa6"),
+                    @Parameter(name = "page", description = "페이지(0부터 시작)", example = "0"),
+                    @Parameter(name = "size", description = "페이지 사이즈(최대 50)", example = "20")
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "내 좋아요 목록 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "My Liked Products",
+                                            value = """
+                                                    {
+                                                      "items": [
+                                                        {
+                                                          "productUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                                                          "title": "오프화이트 후드",
+                                                          "price": 120000,
+                                                          "thumbnailUrl": "https://image.../1.jpg",
+                                                          "likeCount": 15
+                                                        }
+                                                      ],
+                                                      "page": 0,
+                                                      "size": 20,
+                                                      "totalCount": 42,
+                                                      "hasNext": true
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    public @interface FindMyLikes {}
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/product/docs/ShopApiDocs.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/product/docs/ShopApiDocs.java
@@ -123,6 +123,71 @@ public final class ShopApiDocs {
     @Target(METHOD)
     @Retention(RUNTIME)
     @Operation(
+            summary = "내 상점 상품 목록 조회",
+            description = "로그인한 사용자의 상점(내 판매 상품) 목록을 페이징으로 조회합니다. (saleStatus로 필터 가능)",
+            parameters = {
+                    @Parameter(
+                            name = "X-USER-UUID",
+                            in = ParameterIn.HEADER,
+                            description = "임시 사용자 UUID 헤더",
+                            required = true,
+                            example = "7fa85f64-5717-4562-b3fc-2c963f66afa6"
+                    ),
+                    @Parameter(
+                            name = "saleStatus",
+                            in = ParameterIn.QUERY,
+                            description = "판매 상태 필터(선택): ON_SALE | RESERVED | SOLD_OUT",
+                            example = "ON_SALE"
+                    ),
+                    @Parameter(
+                            name = "page",
+                            in = ParameterIn.QUERY,
+                            description = "페이지(0부터 시작, 기본 0)",
+                            example = "0"
+                    ),
+                    @Parameter(
+                            name = "size",
+                            in = ParameterIn.QUERY,
+                            description = "페이지 사이즈(기본 20, 최대 50)",
+                            example = "20"
+                    )
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "내 상점 상품 목록 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "My Shop Products",
+                                            value = """
+                                                    {
+                                                      "items": [
+                                                        {
+                                                          "productUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                                                          "title": "빈티지 원목 독서대",
+                                                          "price": 45000,
+                                                          "thumbnailUrl": "https://cdn.image.com/p/1024_thumb.png",
+                                                          "likeCount": 150
+                                                        }
+                                                      ],
+                                                      "page": 0,
+                                                      "size": 20,
+                                                      "totalCount": 7,
+                                                      "hasNext": false
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    public @interface FindMyShopProducts {}
+
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(
             summary = "판매자 상점 조회(공개)",
             description = "판매자 상점 UUID로 상점 정보를 조회합니다.",
             parameters = {
@@ -190,19 +255,18 @@ public final class ShopApiDocs {
                             name = "saleStatus",
                             in = ParameterIn.QUERY,
                             description = "판매 상태 필터(선택): ON_SALE | RESERVED | SOLD_OUT",
-                            required = false,
                             example = "ON_SALE"
                     ),
                     @Parameter(
                             name = "page",
                             in = ParameterIn.QUERY,
-                            description = "페이지(0부터 시작)",
+                            description = "페이지(0부터 시작, 기본 0)",
                             example = "0"
                     ),
                     @Parameter(
                             name = "size",
                             in = ParameterIn.QUERY,
-                            description = "페이지 사이즈(최대 50)",
+                            description = "페이지 사이즈(기본 20, 최대 50)",
                             example = "20"
                     )
             },
@@ -214,7 +278,7 @@ public final class ShopApiDocs {
                                     mediaType = "application/json",
                                     examples = {
                                             @ExampleObject(
-                                                    name = "Shop Products (All)",
+                                                    name = "Shop Products",
                                                     value = """
                                                             {
                                                               "items": [
@@ -229,26 +293,6 @@ public final class ShopApiDocs {
                                                               "page": 0,
                                                               "size": 20,
                                                               "totalCount": 42,
-                                                              "hasNext": true
-                                                            }
-                                                            """
-                                            ),
-                                            @ExampleObject(
-                                                    name = "Shop Products (Filtered by saleStatus)",
-                                                    value = """
-                                                            {
-                                                              "items": [
-                                                                {
-                                                                  "productUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-                                                                  "title": "빈티지 원목 독서대",
-                                                                  "price": 45000,
-                                                                  "thumbnailUrl": "https://cdn.image.com/p/1024_thumb.png",
-                                                                  "likeCount": 150
-                                                                }
-                                                              ],
-                                                              "page": 0,
-                                                              "size": 20,
-                                                              "totalCount": 12,
                                                               "hasNext": true
                                                             }
                                                             """

--- a/semicolon/src/main/java/dukku/semicolon/shared/product/docs/ShopApiDocs.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/product/docs/ShopApiDocs.java
@@ -1,0 +1,220 @@
+package dukku.semicolon.shared.product.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+public final class ShopApiDocs {
+
+    private ShopApiDocs() {}
+
+    @Documented
+    @Target(TYPE)
+    @Retention(RUNTIME)
+    @Tag(
+            name = "상점(판매자) API",
+            description = "내 상점 조회/수정 및 판매자 상점/상품 목록 조회"
+    )
+    public @interface ShopTag {}
+
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(
+            summary = "내 상점 조회",
+            description = "로그인한 사용자의 상점 정보를 조회합니다.",
+            parameters = {
+                    @Parameter(name = "X-USER-UUID", description = "임시 사용자 UUID 헤더", required = true,
+                            example = "7fa85f64-5717-4562-b3fc-2c963f66afa6")
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "내 상점 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "My Shop",
+                                            value = """
+                                                    {
+                                                      "shopUuid": "11111111-2222-3333-4444-555555555555",
+                                                      "intro": "안녕하세요! 빈티지 소품 위주로 판매해요.",
+                                                      "salesCount": 10,
+                                                      "activeListingCount": 3
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    public @interface FindMyShop {}
+
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(
+            summary = "내 상점 소개 수정",
+            description = "내 상점 소개글(intro)을 수정합니다.",
+            parameters = {
+                    @Parameter(name = "X-USER-UUID", description = "임시 사용자 UUID 헤더", required = true,
+                            example = "7fa85f64-5717-4562-b3fc-2c963f66afa6")
+            },
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "Update Shop Intro",
+                                    value = """
+                                            {
+                                              "intro": "상점 소개를 이렇게 바꿨어요!"
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "내 상점 수정 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "Updated Shop",
+                                            value = """
+                                                    {
+                                                      "shopUuid": "11111111-2222-3333-4444-555555555555",
+                                                      "intro": "상점 소개를 이렇게 바꿨어요!",
+                                                      "salesCount": 10,
+                                                      "activeListingCount": 3
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    public @interface UpdateMyShop {}
+
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(
+            summary = "판매자 상점 조회(공개)",
+            description = "판매자 상점 UUID로 상점 정보를 조회합니다.",
+            parameters = {
+                    @Parameter(name = "shopUuid", description = "상점 UUID", required = true,
+                            example = "11111111-2222-3333-4444-555555555555")
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "상점 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "Shop",
+                                            value = """
+                                                    {
+                                                      "shopUuid": "11111111-2222-3333-4444-555555555555",
+                                                      "intro": "안녕하세요! 빈티지 소품 위주로 판매해요.",
+                                                      "salesCount": 10,
+                                                      "activeListingCount": 3
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상점을 찾을 수 없음",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "message": "리소스를 찾을 수 없습니다.",
+                                                      "details": "존재하지 않는 상점입니다."
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    public @interface FindShop {}
+
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(
+            summary = "판매자 상점 상품 목록 조회(공개)",
+            description = "판매자 상점의 상품 목록을 페이징으로 조회합니다.",
+            parameters = {
+                    @Parameter(name = "shopUuid", description = "상점 UUID", required = true,
+                            example = "11111111-2222-3333-4444-555555555555"),
+                    @Parameter(name = "page", description = "페이지(0부터 시작)", example = "0"),
+                    @Parameter(name = "size", description = "페이지 사이즈(최대 50)", example = "20")
+            },
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "상점 상품 목록 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            name = "Shop Products",
+                                            value = """
+                                                    {
+                                                      "totalCount": 42,
+                                                      "items": [
+                                                        {
+                                                          "productUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                                                          "thumbnailUrl": "https://cdn.image.com/p/1024_thumb.png",
+                                                          "title": "빈티지 원목 독서대",
+                                                          "price": 45000,
+                                                          "createdAt": "2026-01-14T15:00:00Z",
+                                                          "likeCount": 150,
+                                                          "commentCount": 12,
+                                                          "status": "FOR_SALE"
+                                                        }
+                                                      ],
+                                                      "page": 0,
+                                                      "size": 20,
+                                                      "hasNext": true
+                                                    }
+                                                    """
+                                    )
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상점을 찾을 수 없음",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = """
+                                                    {
+                                                      "message": "리소스를 찾을 수 없습니다.",
+                                                      "details": "존재하지 않는 상점입니다."
+                                                    }
+                                                    """
+                                    )
+                            )
+                    )
+            }
+    )
+    public @interface FindShopProducts {}
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/product/docs/ShopApiDocs.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/product/docs/ShopApiDocs.java
@@ -179,6 +179,21 @@ public final class ShopApiDocs {
                                                     """
                                     )
                             )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "상점을 찾을 수 없음",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    examples = @ExampleObject(
+                                            value = """
+                                                  {
+                                                    "message": "리소스를 찾을 수 없습니다.",
+                                                    "details": "존재하지 않는 상점입니다."
+                                                  }
+                                                  """
+                                    )
+                            )
                     )
             }
     )

--- a/semicolon/src/main/java/dukku/semicolon/shared/product/docs/ShopApiDocs.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/product/docs/ShopApiDocs.java
@@ -2,6 +2,7 @@ package dukku.semicolon.shared.product.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -35,8 +36,13 @@ public final class ShopApiDocs {
             summary = "내 상점 조회",
             description = "로그인한 사용자의 상점 정보를 조회합니다.",
             parameters = {
-                    @Parameter(name = "X-USER-UUID", description = "임시 사용자 UUID 헤더", required = true,
-                            example = "7fa85f64-5717-4562-b3fc-2c963f66afa6")
+                    @Parameter(
+                            name = "X-USER-UUID",
+                            in = ParameterIn.HEADER,
+                            description = "임시 사용자 UUID 헤더",
+                            required = true,
+                            example = "7fa85f64-5717-4562-b3fc-2c963f66afa6"
+                    )
             },
             responses = {
                     @ApiResponse(
@@ -68,8 +74,13 @@ public final class ShopApiDocs {
             summary = "내 상점 소개 수정",
             description = "내 상점 소개글(intro)을 수정합니다.",
             parameters = {
-                    @Parameter(name = "X-USER-UUID", description = "임시 사용자 UUID 헤더", required = true,
-                            example = "7fa85f64-5717-4562-b3fc-2c963f66afa6")
+                    @Parameter(
+                            name = "X-USER-UUID",
+                            in = ParameterIn.HEADER,
+                            description = "임시 사용자 UUID 헤더",
+                            required = true,
+                            example = "7fa85f64-5717-4562-b3fc-2c963f66afa6"
+                    )
             },
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,
@@ -115,8 +126,13 @@ public final class ShopApiDocs {
             summary = "판매자 상점 조회(공개)",
             description = "판매자 상점 UUID로 상점 정보를 조회합니다.",
             parameters = {
-                    @Parameter(name = "shopUuid", description = "상점 UUID", required = true,
-                            example = "11111111-2222-3333-4444-555555555555")
+                    @Parameter(
+                            name = "shopUuid",
+                            in = ParameterIn.PATH,
+                            description = "상점 UUID",
+                            required = true,
+                            example = "11111111-2222-3333-4444-555555555555"
+                    )
             },
             responses = {
                     @ApiResponse(
@@ -161,12 +177,34 @@ public final class ShopApiDocs {
     @Retention(RUNTIME)
     @Operation(
             summary = "판매자 상점 상품 목록 조회(공개)",
-            description = "판매자 상점의 상품 목록을 페이징으로 조회합니다.",
+            description = "판매자 상점의 상품 목록을 페이징으로 조회합니다. (saleStatus로 필터 가능)",
             parameters = {
-                    @Parameter(name = "shopUuid", description = "상점 UUID", required = true,
-                            example = "11111111-2222-3333-4444-555555555555"),
-                    @Parameter(name = "page", description = "페이지(0부터 시작)", example = "0"),
-                    @Parameter(name = "size", description = "페이지 사이즈(최대 50)", example = "20")
+                    @Parameter(
+                            name = "shopUuid",
+                            in = ParameterIn.PATH,
+                            description = "상점 UUID",
+                            required = true,
+                            example = "11111111-2222-3333-4444-555555555555"
+                    ),
+                    @Parameter(
+                            name = "saleStatus",
+                            in = ParameterIn.QUERY,
+                            description = "판매 상태 필터(선택): ON_SALE | RESERVED | SOLD_OUT",
+                            required = false,
+                            example = "ON_SALE"
+                    ),
+                    @Parameter(
+                            name = "page",
+                            in = ParameterIn.QUERY,
+                            description = "페이지(0부터 시작)",
+                            example = "0"
+                    ),
+                    @Parameter(
+                            name = "size",
+                            in = ParameterIn.QUERY,
+                            description = "페이지 사이즈(최대 50)",
+                            example = "20"
+                    )
             },
             responses = {
                     @ApiResponse(
@@ -174,26 +212,60 @@ public final class ShopApiDocs {
                             description = "상점 상품 목록 조회 성공",
                             content = @Content(
                                     mediaType = "application/json",
+                                    examples = {
+                                            @ExampleObject(
+                                                    name = "Shop Products (All)",
+                                                    value = """
+                                                            {
+                                                              "items": [
+                                                                {
+                                                                  "productUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                                                                  "title": "빈티지 원목 독서대",
+                                                                  "price": 45000,
+                                                                  "thumbnailUrl": "https://cdn.image.com/p/1024_thumb.png",
+                                                                  "likeCount": 150
+                                                                }
+                                                              ],
+                                                              "page": 0,
+                                                              "size": 20,
+                                                              "totalCount": 42,
+                                                              "hasNext": true
+                                                            }
+                                                            """
+                                            ),
+                                            @ExampleObject(
+                                                    name = "Shop Products (Filtered by saleStatus)",
+                                                    value = """
+                                                            {
+                                                              "items": [
+                                                                {
+                                                                  "productUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+                                                                  "title": "빈티지 원목 독서대",
+                                                                  "price": 45000,
+                                                                  "thumbnailUrl": "https://cdn.image.com/p/1024_thumb.png",
+                                                                  "likeCount": 150
+                                                                }
+                                                              ],
+                                                              "page": 0,
+                                                              "size": 20,
+                                                              "totalCount": 12,
+                                                              "hasNext": true
+                                                            }
+                                                            """
+                                            )
+                                    }
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청(saleStatus 값이 유효하지 않음 등)",
+                            content = @Content(
+                                    mediaType = "application/json",
                                     examples = @ExampleObject(
-                                            name = "Shop Products",
                                             value = """
                                                     {
-                                                      "totalCount": 42,
-                                                      "items": [
-                                                        {
-                                                          "productUuid": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-                                                          "thumbnailUrl": "https://cdn.image.com/p/1024_thumb.png",
-                                                          "title": "빈티지 원목 독서대",
-                                                          "price": 45000,
-                                                          "createdAt": "2026-01-14T15:00:00Z",
-                                                          "likeCount": 150,
-                                                          "commentCount": 12,
-                                                          "status": "FOR_SALE"
-                                                        }
-                                                      ],
-                                                      "page": 0,
-                                                      "size": 20,
-                                                      "hasNext": true
+                                                      "message": "잘못된 요청",
+                                                      "details": "saleStatus 값이 유효하지 않습니다."
                                                     }
                                                     """
                                     )

--- a/semicolon/src/main/java/dukku/semicolon/shared/product/dto/MyLikedProductListResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/product/dto/MyLikedProductListResponse.java
@@ -2,6 +2,7 @@ package dukku.semicolon.shared.product.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -22,6 +23,16 @@ public class MyLikedProductListResponse {
                 .size(pageResult.getSize())
                 .totalCount(pageResult.getTotalElements())
                 .hasNext(pageResult.hasNext())
+                .build();
+    }
+
+    public static MyLikedProductListResponse from(Page<?> metaPage, List<ProductListItemResponse> items) {
+        return MyLikedProductListResponse.builder()
+                .items(items)
+                .page(metaPage.getNumber())
+                .size(metaPage.getSize())
+                .totalCount(metaPage.getTotalElements())
+                .hasNext(metaPage.hasNext())
                 .build();
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/shared/product/dto/ShopProductListResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/product/dto/ShopProductListResponse.java
@@ -1,0 +1,28 @@
+package dukku.semicolon.shared.product.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ShopProductListResponse {
+
+    private List<ProductListItemResponse> items;
+    private int page;
+    private int size;
+    private long totalCount;
+    private boolean hasNext;
+
+    public static ShopProductListResponse from(Page<?> metaPage, List<ProductListItemResponse> items) {
+        return ShopProductListResponse.builder()
+                .items(items)
+                .page(metaPage.getNumber())
+                .size(metaPage.getSize())
+                .totalCount(metaPage.getTotalElements())
+                .hasNext(metaPage.hasNext())
+                .build();
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/product/dto/ShopResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/product/dto/ShopResponse.java
@@ -1,0 +1,25 @@
+package dukku.semicolon.shared.product.dto;
+
+import dukku.semicolon.boundedContext.product.entity.ProductSeller;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class ShopResponse {
+    private UUID shopUuid;              // ProductSeller.uuid
+    private String intro;
+    private int salesCount;
+    private int activeListingCount;
+
+    public static ShopResponse from(ProductSeller seller) {
+        return ShopResponse.builder()
+                .shopUuid(seller.getUuid())
+                .intro(seller.getIntro())
+                .salesCount(seller.getSalesCount())
+                .activeListingCount(seller.getActiveListingCount())
+                .build();
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/product/dto/UpdateShopRequest.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/product/dto/UpdateShopRequest.java
@@ -1,0 +1,11 @@
+package dukku.semicolon.shared.product.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateShopRequest {
+
+    @Size(max = 500)
+    private String intro;
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/product/exception/ProductSellerNotFoundException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/product/exception/ProductSellerNotFoundException.java
@@ -1,0 +1,9 @@
+package dukku.semicolon.shared.product.exception;
+
+import dukku.common.global.exception.NotFoundException;
+
+public class ProductSellerNotFoundException extends NotFoundException {
+    public ProductSellerNotFoundException() {
+        super("상점을 찾을 수 없습니다.");
+    }
+}


### PR DESCRIPTION
## PR 제목
Feat(product-shop): 판매자 상점 API 구현 및 찜 목록 조회 구조 개선

## 개요
기존 찜(좋아요) 목록 조회 API의 구조와 성능을 개선하고,  
판매자(상점) 도메인 조회 API를 신규로 구현했습니다.  

이후 프론트 목업과 비교하는 과정에서  
상점 상품 목록 조회 시 판매 상태별 조회가 필요함을 확인하여  
`saleStatus` 필터를 추가 반영했습니다.

## 상세 내용
- **찜(좋아요) 목록 조회 API 개선**
  - 기존 찜 목록 조회 로직 리팩토링
  - 메서드 명칭 정리 (`myLikes` → `findMyLikes`)
  - 조회 구조 개선으로 성능 이슈(N+1 가능성) 정리
- **판매자(상점) 도메인 API 신규 구현**
  - 내 상점 조회 / 소개 수정 API 구현
  - 판매자 상점 조회(공개) API 구현
  - 판매자 상점 상품 목록 조회 API 구현
- **프론트 목업 반영**
  - 상점 상품 목록 조회 시 판매 상태별 분리가 필요하여
    `saleStatus(ON_SALE / RESERVED / SOLD_OUT)` 필터 추가
- **Swagger 문서 보완**
  - `ProductLikeController`, `ShopController` API 문서 추가
  - 프론트 목업 기준으로 요청/응답 예시 명확화

## PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI/UX 수정
- [x] 코드 리팩토링
- [x] 문서 수정
- [ ] 테스트 추가/수정
- [ ] 빌드/패키지 수정
- [ ] 파일/폴더 제거

## PR Checklist
- [x] 커밋 메시지가 규칙에 맞는가?
- [x] 변경 사항이 로컬 빌드 및 기본 동작 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?