### PR TITLE
[Infra] dev로 머지되는 PR에 build 제약 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: build-and-push
+
+on:
+  pull_request:
+    branches: [ "dev" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@v4
+
+      - name: Build Docker Image (no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: semicolon-backend:ci


### PR DESCRIPTION
## 개요
dev 브랜치로 머지되는 PR에 대해
CI 빌드가 통과되지 않으면 머지할 수 없도록 제약을 추가했습니다.

feature 브랜치에서 작업한 코드가
빌드 실패 상태로 dev에 반영되는 것을 방지하기 위한 목적입니다.

## 상세 내용
- 변경된 주요 사항 리스트
- 왜 이 변경이 필요한지 설명

## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI/UX 수정
- [ ] 코드 리팩토링
- [ ] 문서 수정
- [ ] 테스트 추가/수정
- [x] 빌드/패키지 수정
- [ ] 파일/폴더 제거

## PR Checklist
- [x] 커밋 메시지가 규칙에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?
