### PR TITLE
[Product] 상품 검색 데이터 매핑 고도화 및 구매 확정 조회 구조 개편

### DIFF
--- a/common/src/main/java/dukku/common/shared/order/dto/ConfirmedOrderItemResponse.java
+++ b/common/src/main/java/dukku/common/shared/order/dto/ConfirmedOrderItemResponse.java
@@ -1,0 +1,15 @@
+package dukku.common.shared.order.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ConfirmedOrderItemResponse(
+        UUID orderItemUuid,      // 주문 상품 UUID
+        UUID orderUuid,          // 주문 UUID
+        UUID buyerUuid,          // 구매자 UUID
+        UUID sellerUuid,         // 판매자 UUID
+        UUID productUuid,        // 상품 UUID
+        String productName,      // 상품명
+        int productPrice,       // 상품 가격
+        LocalDateTime confirmedAt // 구매 확정 일시
+) {}

--- a/common/src/main/java/dukku/common/shared/order/type/OrderItemStatus.java
+++ b/common/src/main/java/dukku/common/shared/order/type/OrderItemStatus.java
@@ -21,7 +21,8 @@ public enum OrderItemStatus {
     // 환불
     REFUND_REQUESTED,       // 환불 요청
     REFUND_IN_PROGRESS,     // 환불 진행 중
-    REFUND_COMPLETED;        // 환불 완료
+    REFUND_COMPLETED,        // 환불 완료
+    SETTLEMENT_COMPLETED; // 정산 완료
 
     public boolean canChangeShippingInfo() {
         return this == PAYMENT_COMPLETED || this == PREPARING_SHIPMENT;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/order/app/FindConfirmedItemsUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/order/app/FindConfirmedItemsUseCase.java
@@ -1,0 +1,35 @@
+package dukku.semicolon.boundedContext.order.app;
+
+import dukku.common.shared.order.dto.ConfirmedOrderItemResponse;
+import dukku.common.shared.order.type.OrderItemStatus;
+import dukku.semicolon.boundedContext.order.entity.OrderItem;
+import dukku.semicolon.boundedContext.order.out.OrderItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindConfirmedItemsUseCase {
+    private final OrderItemRepository orderItemRepository;
+
+    public List<ConfirmedOrderItemResponse> execute(LocalDateTime startDateTime, LocalDateTime endDateTime){
+        if (startDateTime.isAfter(endDateTime)) {
+            throw new IllegalArgumentException("startDateTime must be before endDateTime");
+        }
+
+        return orderItemRepository
+                .findAllByStatusAndConfirmedAtBetween(
+                        OrderItemStatus.CONFIRMED,
+                        startDateTime,
+                        endDateTime
+                )
+                .stream()
+                .map(OrderItem::toConfirmedOrderItemResponse)
+                .toList();
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/order/app/OrderFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/order/app/OrderFacade.java
@@ -1,5 +1,6 @@
 package dukku.semicolon.boundedContext.order.app;
 
+import dukku.common.shared.order.dto.ConfirmedOrderItemResponse;
 import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.semicolon.boundedContext.order.entity.Order;
 import dukku.semicolon.shared.order.dto.*;
@@ -8,7 +9,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -22,6 +26,7 @@ public class OrderFacade {
     private final FindMyOrderListUseCase findMyOrderList;
     private final UpdateOrderItemDeliveryInfoUseCase updateOrderItemDeliveryInfo;
     private final UpdateOrderItemStatusUseCase  updateOrderItemStatus;
+    private final FindConfirmedItemsUseCase findConfirmedItems;
 
     public OrderResponse createOrder(OrderCreateRequest req) {
         return Order.toOrderResponse(createOrder.execute(req));
@@ -58,5 +63,10 @@ public class OrderFacade {
     // 사용자가 요청하는 경우 또는 관리자가 요청하는 경우. 구매 확정 완료, 취소 요청, 환불 요청
     public void updateDeliveryInfo(UUID orderItemUuid, OrderItemStatus status) {
         updateOrderItemStatus.execute(orderItemUuid, status);
+    }
+
+    // 주문 확정 조회
+    public List<ConfirmedOrderItemResponse> findConfirmedItems(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return  findConfirmedItems.execute(startDateTime, endDateTime);
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/order/entity/OrderItem.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/order/entity/OrderItem.java
@@ -2,6 +2,7 @@ package dukku.semicolon.boundedContext.order.entity;
 
 import dukku.common.global.exception.ConflictException;
 import dukku.common.global.jpa.entity.BaseIdAndUUIDAndTime;
+import dukku.common.shared.order.dto.ConfirmedOrderItemResponse;
 import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.semicolon.shared.order.dto.DeliveryInfoRequest;
 import dukku.semicolon.shared.order.dto.OrderCreateRequest;
@@ -11,6 +12,7 @@ import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -53,6 +55,9 @@ public class OrderItem extends BaseIdAndUUIDAndTime {
     @Enumerated(EnumType.STRING)
     private OrderItemStatus status;
 
+    @Column(comment = "구매 확정 일시")
+    private LocalDateTime confirmedAt;
+
     public static OrderItem createOrderItem(OrderCreateRequest.OrderItemCreateRequest request) {
         return OrderItem.builder()
                 .productUuid(request.getProductUuid())
@@ -94,6 +99,8 @@ public class OrderItem extends BaseIdAndUUIDAndTime {
                 if (this.status != OrderItemStatus.DELIVERED) {
                     throw new ConflictException("배송이 완료된 상품만 구매 확정할 수 있습니다.");
                 }
+
+                this.confirmedAt = LocalDateTime.now();
             }
             // TODO: 환불 정책
             /*case REFUND_REQUESTED -> {
@@ -113,5 +120,18 @@ public class OrderItem extends BaseIdAndUUIDAndTime {
     private boolean isShippingOrCompleted() {
         return this.status == OrderItemStatus.SHIPPED ||
                 this.status == OrderItemStatus.DELIVERED;
+    }
+
+    public static ConfirmedOrderItemResponse toConfirmedOrderItemResponse(OrderItem orderItem) {
+        return new ConfirmedOrderItemResponse(
+                orderItem.getUuid(),
+                orderItem.getOrder().getUuid(),
+                orderItem.getOrder().getUserUuid(),
+                orderItem.getSellerUuid(),
+                orderItem.getProductUuid(),
+                orderItem.getProductName(),
+                orderItem.getProductPrice(),
+                orderItem.getConfirmedAt()
+                );
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/order/in/OrderController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/order/in/OrderController.java
@@ -19,7 +19,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @OrderApiDocs.OrderTag
 public class OrderController {
-
     private final OrderFacade orderFacade;
 
     @PostMapping

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/order/in/OrderInternalController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/order/in/OrderInternalController.java
@@ -1,0 +1,27 @@
+package dukku.semicolon.boundedContext.order.in;
+
+import dukku.common.shared.order.dto.ConfirmedOrderItemResponse;
+import dukku.semicolon.boundedContext.order.app.OrderFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/internal/orders")
+@RequiredArgsConstructor
+public class OrderInternalController {
+    private final OrderFacade orderFacade;
+
+    @GetMapping("/items/confirmed")
+    public List<ConfirmedOrderItemResponse> findConfirmedItems(
+            @RequestParam LocalDateTime startDateTime,
+            @RequestParam LocalDateTime endDateTime
+    ) {
+        return orderFacade.findConfirmedItems(startDateTime, endDateTime);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/order/out/OrderItemRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/order/out/OrderItemRepository.java
@@ -1,11 +1,20 @@
 package dukku.semicolon.boundedContext.order.out;
 
+import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.semicolon.boundedContext.order.entity.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Integer> {
     Optional<OrderItem> findByUuid(UUID orderItemUuid);
+
+    List<OrderItem> findAllByStatusAndConfirmedAtBetween(
+            OrderItemStatus status,
+            LocalDateTime start,
+            LocalDateTime end
+    );
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/cqrs/DeleteProductSyncUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/cqrs/DeleteProductSyncUseCase.java
@@ -18,7 +18,6 @@ public class DeleteProductSyncUseCase {
     public void deletedProductToElasticsearch(int productId) {
         // 3. Document 변환
         // 이때 product의 visibilityStatus가 HIDDEN이거나 deletedAt이 있으면 그대로 ES 문서에 반영됨
-
         ProductDocument document = productSearchRepository.findById(String.valueOf(productId))
                 .orElseThrow(ProductNotFoundException::new);
 

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/cqrs/SaveToElasticSearchUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/cqrs/SaveToElasticSearchUseCase.java
@@ -20,11 +20,10 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class SaveToElasticSearchUseCase {
-
-    private final ProductSearchRepository productSearchRepository; // save용
+    private final ProductSearchRepository productSearchRepository;
     private final CategoryRepository categoryRepository;
 
-    // [핵심 추가] 부분 업데이트(update)는 Repository가 아니라 Operations가 담당합니다.
+    // 부분 업데이트(update)는 Repository가 아니라 Operations가 담당
     private final ElasticsearchOperations elasticsearchOperations;
 
     // 생성 시 편의 메서드 (Create)

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/product/ConfirmProductSaleUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/product/ConfirmProductSaleUseCase.java
@@ -1,0 +1,37 @@
+package dukku.semicolon.boundedContext.product.app.usecase.product;
+
+import dukku.semicolon.boundedContext.product.entity.Product;
+import dukku.semicolon.boundedContext.product.out.ProductRepository;
+import dukku.semicolon.shared.product.event.ProductUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConfirmProductSaleUseCase {
+    private final ProductRepository productRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void execute(UUID orderUuid, List<UUID> productUuids) {
+        List<Product> products = productRepository.findAllByUuidIn(productUuids);
+
+        for (Product product : products) {
+            // 1. DB 상태 변경 (Dirty Checking)
+            product.confirmSale(orderUuid);
+
+            // 2. ES 동기화 트리거 (이벤트 발행)
+            // TODO: N+1으로 병목 발생 가능성 있음. 추후 부하테스트 시 확인 필요
+            eventPublisher.publishEvent(new ProductUpdatedEvent(product, false));
+        }
+
+        log.info("Sale Confirmed for products: {}", productUuids);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/product/FindCategoryListUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/product/FindCategoryListUseCase.java
@@ -10,7 +10,6 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class FindCategoryListUseCase {
-
     private final CategoryRepository categoryRepository;
 
     public List<CategoryCreateResponse> execute() {

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/product/ReleaseProductReservationUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/product/ReleaseProductReservationUseCase.java
@@ -1,0 +1,37 @@
+package dukku.semicolon.boundedContext.product.app.usecase.product;
+
+import dukku.semicolon.boundedContext.product.entity.Product;
+import dukku.semicolon.boundedContext.product.out.ProductRepository;
+import dukku.semicolon.shared.product.event.ProductUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReleaseProductReservationUseCase {
+    private final ProductRepository productRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void execute(UUID orderUuid, List<UUID> productUuids) {
+        List<Product> products = productRepository.findAllByUuidIn(productUuids);
+
+        for (Product product : products) {
+            // 1. DB 상태 복구 (Dirty Checking)
+            product.releaseReservation(orderUuid);
+
+            // 2. ES 동기화 트리거
+            // TODO: N+1으로 병목 발생 가능성 있음. 추후 부하테스트 시 확인 필요
+            eventPublisher.publishEvent(new ProductUpdatedEvent(product, false));
+        }
+
+        log.info("Reservation Released for products: {}", productUuids);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/product/ReserveProductUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/product/ReserveProductUseCase.java
@@ -14,7 +14,6 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class ReserveProductUseCase {
-
     private final ProductRepository productRepository;
 
     @Transactional

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ProductEventListener.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ProductEventListener.java
@@ -1,13 +1,12 @@
 package dukku.semicolon.boundedContext.product.in;
 
-import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.order.event.OrderProductSaleConfirmedEvent;
 import dukku.common.shared.order.event.OrderProductSaleReleasedEvent;
 import dukku.semicolon.boundedContext.product.app.cqrs.ProductSyncFacade;
 import dukku.semicolon.boundedContext.product.app.cqrs.SaveToElasticSearchUseCase;
 import dukku.semicolon.boundedContext.product.app.cqrs.SyncProductSearchStatsUseCase;
-import dukku.semicolon.boundedContext.product.entity.Product;
-import dukku.semicolon.boundedContext.product.out.ProductRepository;
+import dukku.semicolon.boundedContext.product.app.usecase.product.ConfirmProductSaleUseCase;
+import dukku.semicolon.boundedContext.product.app.usecase.product.ReleaseProductReservationUseCase;
 import dukku.semicolon.shared.product.event.ProductCreatedEvent;
 import dukku.semicolon.shared.product.event.ProductDeletedEvent;
 import dukku.semicolon.shared.product.event.ProductStatsBulkUpdatedEvent;
@@ -17,12 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -31,8 +26,8 @@ public class ProductEventListener {
     private final ProductSyncFacade productSyncFacade;
     private final SaveToElasticSearchUseCase saveToElasticSearchUseCase;
     private final SyncProductSearchStatsUseCase  syncProductSearchStatsUseCase;
-    private final ProductRepository productRepository;
-    private final EventPublisher eventPublisher;
+    private final ConfirmProductSaleUseCase confirmProductSaleUseCase;
+    private final ReleaseProductReservationUseCase  releaseProductReservationUseCase;
 
     // 1. 생성 동기화
     @Async
@@ -65,44 +60,24 @@ public class ProductEventListener {
     }
 
     /**
-     * 1. 결제 완료 -> 상품 품절 처리 (SOLD_OUT)
-     * TransactionPhase.AFTER_COMMIT: 주문 트랜잭션이 완전히 끝난 후 실행
+     * 1. 결제 완료 -> 판매 확정 처리 위임
      */
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleOrderConfirmed(OrderProductSaleConfirmedEvent event) {
-        log.info("Handle Order Confirmed: orderUuid={}", event.orderUuid());
+        log.info("Trigger Confirm Sale: orderUuid={}", event.orderUuid());
 
-        List<Product> products = productRepository.findAllByUuidIn(event.productUuids());
-
-        for (Product product : products) {
-            // 1. DB 상태 변경
-            product.confirmSale(event.orderUuid());
-
-            // 2. 변경된 상태를 ES에 동기화하기 위해 ProductUpdatedEvent 발행
-            // (이전에 만든 ProductEventListener가 이걸 잡아서 ES 업데이트 수행)
-            eventPublisher.publish(new ProductUpdatedEvent(product, false));
-        }
+        confirmProductSaleUseCase.execute(event.orderUuid(), event.productUuids());
     }
 
     /**
-     * 2. 결제 실패/취소 -> 상품 판매중 복구 (ON_SALE)
+     * 2. 결제 실패/취소 -> 예약 해제 처리 위임
      */
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleOrderReleased(OrderProductSaleReleasedEvent event) {
-        log.info("Handle Order Released: orderUuid={}", event.orderUuid());
+        log.info("Trigger Release Reservation: orderUuid={}", event.orderUuid());
 
-        List<Product> products = productRepository.findAllByUuidIn(event.productUuids());
-
-        for (Product product : products) {
-            // 1. DB 상태 변경
-            product.releaseReservation(event.orderUuid());
-
-            // 2. ES 동기화 이벤트 발행
-            eventPublisher.publish(new ProductUpdatedEvent(product, false));
-        }
+        releaseProductReservationUseCase.execute(event.orderUuid(), event.productUuids());
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/shared/order/out/OrderApiClient.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/order/out/OrderApiClient.java
@@ -1,0 +1,41 @@
+package dukku.semicolon.shared.order.out;
+
+import dukku.common.shared.order.dto.ConfirmedOrderItemResponse;
+import dukku.semicolon.shared.product.dto.product.ProductReserveRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class OrderApiClient {
+
+    private final RestClient restClient;
+
+    public OrderApiClient(@Value("${custom.global.internalBackUrl}") String internalBackUrl) {
+        this.restClient = RestClient.builder()
+                .baseUrl(internalBackUrl + "/api/v1/internal/orders")
+                .build();
+    }
+
+    // 구매 확정 주문 상품 기간 조회
+    public List<ConfirmedOrderItemResponse> findConfirmedItems(
+            LocalDateTime startDateTime,
+            LocalDateTime endDateTime
+    ) {
+        return restClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/items/confirmed")
+                        .queryParam("startDateTime", startDateTime)
+                        .queryParam("endDateTime", endDateTime)
+                        .build()
+                )
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {});
+    }
+}


### PR DESCRIPTION
## PR 제목

[Product] 상품 검색 데이터 매핑 고도화 및 구매 확정 조회 구조 개편

---

## 개요

Elasticsearch 검색 품질 향상을 위해 초기 데이터(`ProductInitData`) 매핑 로직을 고도화하고, 외부(Order) 서비스와의 결합도를 낮추기 위해 구매 확정 처리 로직을 리팩토링했습니다. 또한, 이벤트 리스너의 비즈니스 로직을 전용 UseCase로 분리하여 역할과 책임을 명확히 했습니다.

---

## 상세 내용

- **ES 계층형 검색 및 필터링 지원 (`ProductDocument` 매핑 개선)**
  - 기존 단일 `categoryId` 대신 `categoryIds` 리스트를 주입하여 상위 카테고리 검색 시 하위 상품이 함께 조회되도록 개선했습니다.
  - 중고 거래 필수 필터인 `conditionStatus`(상태)와 `deletedAt`(삭제일) 필드를 매핑했습니다.
  - `ProductInitData`에서 트랜잭션 제약 없이 족보를 생성하기 위해 `getCategoryPath` 헬퍼 메서드를 구현했습니다.

- **이벤트 리스너 리팩토링 (`ProductEventListener`)**
  - 리스너가 비즈니스 로직(DB 조회/수정)을 직접 수행하던 구조에서, `ConfirmProductSaleUseCase`와 `ReleaseProductReservationUseCase`로 위임하도록 변경했습니다.
  - 이를 통해 리스너는 "이벤트 수신 및 위임"에만 집중하고, 트랜잭션 관리는 UseCase가 담당합니다.

- **구매 확정 조회 로직 개편 (`OrderApiClient`)**
  - 기존의 주문/상품 UUID 기반 개별 조회 방식에서 **기간(`startDateTime`, `endDateTime`) 기준 조회**로 변경했습니다.
  - `ProductReserveRequest`에 대한 의존을 제거하고, `/items/confirmed` 전용 API를 통해 확정된 항목만 명확히 가져오도록 개선했습니다.
  - 정확한 확정 시점 추적을 위해 `confirmedAt` 기준을 도입했습니다.

---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)
      - 설정, 패키지, 잡일
      - 주석 추가
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [x] 커밋 메시지가 컨벤션에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [x] 전체 흐름이 자연스러운가?
      (컨트롤러 → 서비스 → 도메인)
- [x] 메소드 역할과 책임이 적절하게 분리되었는가? (Listener → UseCase 위임)
- [x] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Async` 등

### 안정성 체크
- [x] 기존 기능에 영향을 주지 않는가?
- [x] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
  - `ProductEventListener`에서 `UseCase`로 로직을 이관하면서 트랜잭션 전파(`@Transactional`)가 의도대로 동작할지 확인 부탁드립니다.
  - `ProductInitData`에서 재귀 쿼리 대신 Java단에서 반복문으로 `categoryIds`를 생성하는 방식이 초기 데이터 생성 성능에 큰 영향이 없을지 봐주시면 좋겠습니다.
- **고민했던 설계 포인트**:
  - 주문 확정 처리 시 N건의 상품에 대해 루프를 돌며 이벤트를 발행하고 있습니다. 현재는 대량 주문이 빈번하지 않다고 판단하여 단순 루프 방식을 택했으나, 추후 성능 이슈 발생 시 Bulk Update로 전환할 계획입니다.