### PR TITLE
[Deposit] 시스템 지갑 초기화 코드 개선 #118

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/DepositFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/DepositFacade.java
@@ -134,4 +134,12 @@ public class DepositFacade {
             UUID userUuid, Long amount, UUID settlementUuid) {
         return chargeDepositForSettlementUseCase.execute(userUuid, amount, settlementUuid);
     }
+
+    /**
+     * 시스템 초기 자본금 주입 (ADJUST 타입 사용)
+     */
+    public void injectSystemCapital(UUID userUuid, Long amount) {
+        // orderItemUuid는 시스템 자본금 주입이므로 null 처리 (상품이 존재하지 않음)
+        increaseDepositUseCase.increase(userUuid, amount, DepositHistoryType.ADJUST, null);
+    }
 }

--- a/semicolon/src/main/java/dukku/semicolon/global/SystemDepositInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/SystemDepositInitData.java
@@ -3,11 +3,12 @@ package dukku.semicolon.global;
 import dukku.semicolon.boundedContext.deposit.app.DepositFacade;
 import dukku.semicolon.boundedContext.user.app.user.UserFacade;
 import dukku.semicolon.boundedContext.user.app.user.UserSupport;
+import dukku.semicolon.boundedContext.user.entity.User;
 import dukku.semicolon.boundedContext.user.entity.type.Role;
-import dukku.semicolon.shared.user.dto.UserRegisterRequest;
-import dukku.semicolon.shared.user.dto.UserResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.UUID;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -29,6 +30,9 @@ public class SystemDepositInitData {
 
     private static final String SYSTEM_DEPOSIT_EMAIL = "admin-deposit@dukku.shop";
     private static final String SYSTEM_DEPOSIT_NICKNAME = "시스템-예치금";
+    // 임시 하드코딩 UUID (추후 API Client 등으로 대체 예정)
+    private static final UUID SYSTEM_USER_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+    private static final Long INITIAL_CAPITAL = 1_000_000_000L; // 10억
 
     @Bean
     public CommandLineRunner initSystemDeposit(
@@ -41,33 +45,44 @@ public class SystemDepositInitData {
             @Override
             @Transactional
             public void run(String... args) throws Exception {
-                // 이미 시스템 계정이 존재하면 스킵
+                // 1. 시스템 계정 존재 여부 확인 (없으면 복구or생성)
                 if (userSupport.findByEmail(SYSTEM_DEPOSIT_EMAIL).isPresent()) {
                     log.info("[SystemDepositInitData] 시스템 예치금 계정이 이미 존재합니다.");
-                    return;
+                    // 이미 존재하더라도 UUID가 다르면 문제될 수 있으나, 일단은 스킵
+                } else {
+                    // 비밀번호 주입
+                    String password = env.getProperty("system.admin-deposit.password");
+
+                    // Redis에 미리 인증 완료 상태로 세팅
+                    redisTemplate.opsForValue().set("email:verify:ok:" + SYSTEM_DEPOSIT_EMAIL, "true",
+                            java.time.Duration.ofMinutes(5));
+
+                    // 시스템 계정 생성
+                    String encodedPassword = userSupport.encode(password);
+
+                    // User 객체 생성 시 UUID를 직접 주입
+                    // API 도입되면 이 부분은 삭제하고 API로 처리
+                    User systemUser = User.builder()
+                            .email(SYSTEM_DEPOSIT_EMAIL)
+                            .password(encodedPassword)
+                            .role(Role.SYSTEM)
+                            .nickname(SYSTEM_DEPOSIT_NICKNAME)
+                            .uuid(SYSTEM_USER_UUID) // SourceUser의 필드
+                            .build();
+
+                    User savedUser = userSupport.save(systemUser);
+                    log.info("[SystemDepositInitData] 시스템 예치금 계정 생성 완료: {} (UUID={})", SYSTEM_DEPOSIT_EMAIL,
+                            savedUser.getUuid());
                 }
 
-                // 비밀번호 주입
-                // 시스템 지갑이라 이 계정으로 직접 로그인할 일은 사실상 없긴 함
-                // DTO에 @Builder annotation 안 붙어있어서 생성자 주입으로 생성
-                String password = env.getProperty("system.admin-deposit.password");
-                UserRegisterRequest request = new UserRegisterRequest(
-                        SYSTEM_DEPOSIT_EMAIL,
-                        password,
-                        SYSTEM_DEPOSIT_NICKNAME);
-
-                // Redis에 미리 인증 완료 상태로 세팅
-                redisTemplate.opsForValue().set("email:verify:ok:" + SYSTEM_DEPOSIT_EMAIL, "true",
-                        java.time.Duration.ofMinutes(5));
-
-                // 시스템 계정 생성
-                UserResponse user = userFacade.registerUser(request, Role.SYSTEM);
-                log.info("[SystemDepositInitData] 시스템 예치금 계정 생성 완료: {}", SYSTEM_DEPOSIT_EMAIL);
-
-                // 시스템 예치금 계좌 명시적 생성
-                // findDeposit 호출 시 Deposit이 없으면 생성 (Lazy 생성 유도)
-                depositFacade.findDeposit(user.getUserUuid());
-                log.info("[SystemDepositInitData] 시스템 예치금 계좌 생성 완료: userUuid={}", user.getUserUuid());
+                // 2. 시스템 예치금 계좌 확인 및 초기 자본금 주입
+                // findDeposit 호출 시 Deposit이 없으면 생성됨 (Lazy)
+                if (depositFacade.findDeposit(SYSTEM_USER_UUID).getBalance() == 0L) {
+                    depositFacade.injectSystemCapital(SYSTEM_USER_UUID, INITIAL_CAPITAL);
+                    log.info("[SystemDepositInitData] 시스템 예치금 초기 자본금 납입 완료: {} KRW", INITIAL_CAPITAL);
+                } else {
+                    log.info("[SystemDepositInitData] 시스템 예치금 잔액이 이미 존재하여 자본금 납입을 건너뜁니다.");
+                }
             }
         };
     }


### PR DESCRIPTION
## PR 제목

[Deposit] 시스템 지갑 고정 UUID 사용하도록 변경 #118

---

## 개요

- API 도입 전까지 고정 UUID 사용하도록 하드코딩

---

## 상세 내용

- API 도입 전까지 고정 UUID 사용하도록 하드코딩
- 초기 UUID : (00000000-0000-0000-0000-000000000000)
- 시스템 유저의 UUID를 돌려주는 API 도입되면 교체
- 초기 자본금 세팅(10억)


close #118 


---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [x] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:

오타랑 코드흐름만 가볍게 체크해주세요
