### PR TITLE
[Feature] 예치금 잔액검증 추가 #122 #123

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/in/AdminDepositController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/in/AdminDepositController.java
@@ -12,7 +12,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
@@ -50,9 +49,8 @@ public class AdminDepositController {
                                                 .depositUuid(deposit.getDepositUuid())
                                                 .balance(deposit.getBalance())
                                                 .updatedAt(deposit.getUpdatedAt() != null
-                                                                ? deposit.getUpdatedAt().atOffset(ZoneOffset.ofHours(9))
-                                                                : deposit.getCreatedAt()
-                                                                                .atOffset(ZoneOffset.ofHours(9)))
+                                                                ? deposit.getUpdatedAt()
+                                                                : deposit.getCreatedAt())
                                                 .build())
                                 .build();
 
@@ -164,7 +162,7 @@ public class AdminDepositController {
                                 .amount(dto.getAmount())
                                 .balanceAfter(dto.getBalanceSnapshot())
                                 .ref(mapReference(dto))
-                                .createdAt(dto.getCreatedAt().atOffset(ZoneOffset.ofHours(9)))
+                                .createdAt(dto.getCreatedAt())
                                 .build();
         }
 

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/in/DepositController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/in/DepositController.java
@@ -12,8 +12,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
@@ -53,9 +51,7 @@ public class DepositController {
                                                 .balance(depositDto.getBalance())
                                                 .updatedAt(depositDto.getUpdatedAt() != null
                                                                 ? depositDto.getUpdatedAt()
-                                                                                .atOffset(ZoneOffset.ofHours(9))
-                                                                : depositDto.getCreatedAt()
-                                                                                .atOffset(ZoneOffset.ofHours(9)))
+                                                                : depositDto.getCreatedAt())
                                                 .build())
                                 .build();
 
@@ -110,7 +106,7 @@ public class DepositController {
                                 .ref(DepositHistoryResponse.ReferenceInfo.builder()
                                                 .orderUuid(dto.getOrderItemUuid())
                                                 .build())
-                                .createdAt(dto.getCreatedAt().atOffset(ZoneOffset.ofHours(9)))
+                                .createdAt(dto.getCreatedAt())
                                 .build();
         }
 }

--- a/semicolon/src/main/java/dukku/semicolon/shared/deposit/dto/DepositBalanceResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/deposit/dto/DepositBalanceResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 /**
@@ -29,6 +29,6 @@ public class DepositBalanceResponse {
         private UUID userUuid;
         private UUID depositUuid;
         private Long balance;
-        private OffsetDateTime updatedAt;
+        private LocalDateTime updatedAt;
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/shared/deposit/dto/DepositHistoryResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/deposit/dto/DepositHistoryResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.OffsetDateTime;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,7 +42,7 @@ public class DepositHistoryResponse {
         private Long amount; // 변동 금액
         private Long balanceAfter; // 변동 후 잔액
         private ReferenceInfo ref; // 참조 정보
-        private OffsetDateTime createdAt; // 생성 일시
+        private LocalDateTime createdAt; // 생성 일시
     }
 
     @Data


### PR DESCRIPTION
## PR 제목
[Feature] 예치금 잔액검증 추가 #122 #123


---

## 개요

- 예치금 잔액검증 로직의 추가
- 잘못된 형식으로 응답하던 Response DTO의 형식 수정



---

## 상세 내용

- 결제 요청 시 예치금 잔액을 불러와서 잔액이 충분한지 체크하는 로직 추가 (실패 시 잔액부족 사유로 결제창 띄우지 않는 것이 의도)
- 컨트롤러 및 엔드포인트 추가
- 예치금 잔액 조회를 위한 ApiClient 클래스 작성
- DepositBalanceResponse/DepositHistoryResponse를 LocalDateTime으로 통일
- 사용자/관리자 예치금 응답 매핑에서 Offset 제거


---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

- 예치금 잔액조회를 internal API로 처리하는 게 적절한지
- 프론트에서 조회할 목적으로 잔액 조회를 하는 API가 있긴 한데(/api/v1/deposits/me/balance)
- 내부 처리와 외부 처리는 보안상 분리 작성되는게 적절하다고 해서 이렇게 작성
- 사실상 같은 내용의 응답을 받는 API가 두개가 되는 셈인데 이거 이렇게 해도 되는지 고민 
- (Gemini는 서로 성격이 다른 요청이라 이편이 합리적이라고 하는데 사실상 동일한 응답을 부러 따로 만드는게 좀 거슬립니다)