### PR TITLE
[Deposit] 결제 시 예치금 차감 구현 #68

### DIFF
--- a/common/src/main/java/dukku/common/shared/payment/event/PaymentSuccessEvent.java
+++ b/common/src/main/java/dukku/common/shared/payment/event/PaymentSuccessEvent.java
@@ -15,6 +15,7 @@ public record PaymentSuccessEvent(
                 UUID paymentId, // 2026-01-24 추가
                 UUID orderUuid,
                 Long amount,
+                Long pgAmount, // pg 결제 금액
                 Long paymentDeposit, // 사용된 예치금
                 UUID userUuid,
                 LocalDateTime occurredAt,

--- a/semicolon/build.gradle
+++ b/semicolon/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation "com.github.f4b6a3:uuid-creator:${uuidCreatorVersion}"
 
     // === Test ===
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
 
     // === Redis ===

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/ChargeDepositForSettlementUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/ChargeDepositForSettlementUseCase.java
@@ -7,6 +7,7 @@ import dukku.semicolon.boundedContext.deposit.entity.enums.DepositHistoryType;
 import dukku.semicolon.shared.deposit.dto.DepositChargeForSettlementResponse;
 import dukku.semicolon.shared.deposit.dto.DepositDto;
 import dukku.semicolon.shared.deposit.type.DepositChargeResultCode;
+import dukku.semicolon.global.SystemDepositInitData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ public class ChargeDepositForSettlementUseCase {
 
     private final FindDepositUseCase findDepositUseCase;
     private final IncreaseDepositUseCase increaseDepositUseCase;
+    private final DecreaseDepositUseCase decreaseDepositUseCase;
     private final FindDepositHistoriesUseCase findDepositHistoriesUseCase;
     private final EventPublisher eventPublisher;
 
@@ -59,6 +61,11 @@ public class ChargeDepositForSettlementUseCase {
             }
 
             increaseDepositUseCase.increase(userUuid, amount, DepositHistoryType.SETTLEMENT, settlementUuid);
+            decreaseDepositUseCase.decrease(
+                    SystemDepositInitData.SYSTEM_USER_UUID,
+                    amount,
+                    DepositHistoryType.SETTLEMENT,
+                    settlementUuid);
             eventPublisher.publish(new DepositChargeSucceededEvent(userUuid, amount, settlementUuid));
 
             DepositDto deposit = findDepositUseCase.findOrCreate(userUuid).toDto();

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/ChargeDepositUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/ChargeDepositUseCase.java
@@ -4,6 +4,7 @@ import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.deposit.event.DepositChargeFailedEvent;
 import dukku.common.shared.deposit.event.DepositChargeSucceededEvent;
 import dukku.semicolon.boundedContext.deposit.entity.enums.DepositHistoryType;
+import dukku.semicolon.global.SystemDepositInitData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,7 @@ import java.util.UUID;
 public class ChargeDepositUseCase {
 
     private final IncreaseDepositUseCase increaseDepositUseCase;
+    private final DecreaseDepositUseCase decreaseDepositUseCase;
     private final EventPublisher eventPublisher;
 
     /**
@@ -52,6 +54,11 @@ public class ChargeDepositUseCase {
         try {
             // 정산에 의한 충전은 SETTLEMENT 타입 사용
             increaseDepositUseCase.increase(userUuid, amount, DepositHistoryType.SETTLEMENT, settlementUuid);
+            decreaseDepositUseCase.decrease(
+                    SystemDepositInitData.SYSTEM_USER_UUID,
+                    amount,
+                    DepositHistoryType.SETTLEMENT,
+                    settlementUuid);
 
             // 성공 이벤트 발행
             eventPublisher.publish(new DepositChargeSucceededEvent(userUuid, amount, settlementUuid));

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/DeductDepositForPaymentUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/DeductDepositForPaymentUseCase.java
@@ -6,6 +6,7 @@ import dukku.common.shared.deposit.event.DepositUsedEvent;
 import dukku.common.shared.payment.event.PaymentSuccessEvent;
 import dukku.semicolon.boundedContext.deposit.entity.enums.DepositHistoryType;
 import dukku.semicolon.boundedContext.deposit.exception.NotEnoughDepositException;
+import dukku.semicolon.global.SystemDepositInitData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,7 @@ import java.util.UUID;
 public class DeductDepositForPaymentUseCase {
 
     private final DecreaseDepositUseCase decreaseDepositUseCase;
+    private final IncreaseDepositUseCase increaseDepositUseCase;
     private final EventPublisher eventPublisher;
 
     /**
@@ -59,6 +61,14 @@ public class DeductDepositForPaymentUseCase {
             decreaseDepositUseCase.decrease(userUuid, usage.depositAmount(), DepositHistoryType.USE,
                     usage.orderItemUuid());
         }
+
+        // 전체 차감 완료 성공 이벤트 발행
+        // 시스템 지갑 예치금 증가
+        increaseDepositUseCase.increase(
+                SystemDepositInitData.SYSTEM_USER_UUID,
+                totalAmount,
+                DepositHistoryType.DEPOSIT_CHARGE,
+                orderUuid);
 
         // 전체 차감 완료 성공 이벤트 발행
         eventPublisher.publish(new DepositUsedEvent(orderUuid, userUuid, totalAmount));

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/DepositFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/DepositFacade.java
@@ -31,6 +31,7 @@ public class DepositFacade {
     private final DecreaseDepositUseCase decreaseDepositUseCase;
     private final FindDepositHistoriesUseCase findDepositHistoriesUseCase;
     private final DeductDepositForPaymentUseCase deductDepositForPaymentUseCase;
+    private final IncreaseSystemDepositForPgUseCase increaseSystemDepositForPgUseCase;
     private final RefundDepositUseCase refundDepositUseCase;
     private final ChargeDepositUseCase chargeDepositUseCase;
     private final ChargeDepositForSettlementUseCase chargeDepositForSettlementUseCase;
@@ -104,6 +105,13 @@ public class DepositFacade {
     public void deductDepositForPayment(UUID userUuid, Long totalAmount, UUID orderUuid,
             List<PaymentSuccessEvent.ItemDepositUsage> itemDepositUsages) {
         deductDepositForPaymentUseCase.execute(userUuid, totalAmount, orderUuid, itemDepositUsages);
+    }
+
+    /**
+     * PG 결제 승인분을 시스템 지갑에 반영
+     */
+    public void increaseSystemDepositForPg(UUID orderUuid, Long pgAmount) {
+        increaseSystemDepositForPgUseCase.execute(orderUuid, pgAmount);
     }
 
     /**

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/IncreaseSystemDepositForPgUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/IncreaseSystemDepositForPgUseCase.java
@@ -1,0 +1,32 @@
+package dukku.semicolon.boundedContext.deposit.app;
+
+import dukku.semicolon.boundedContext.deposit.entity.enums.DepositHistoryType;
+import dukku.semicolon.global.SystemDepositInitData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * PG 결제 승인분을 시스템 지갑에 반영하는 UseCase
+ */
+@Service
+@RequiredArgsConstructor
+public class IncreaseSystemDepositForPgUseCase {
+
+    private final IncreaseDepositUseCase increaseDepositUseCase;
+
+    @Transactional
+    public void execute(UUID orderUuid, Long pgAmount) {
+        if (pgAmount == null || pgAmount <= 0) {
+            return;
+        }
+
+        increaseDepositUseCase.increase(
+                SystemDepositInitData.SYSTEM_USER_UUID,
+                pgAmount,
+                DepositHistoryType.PG_CHARGE,
+                orderUuid);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/entity/enums/DepositHistoryType.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/entity/enums/DepositHistoryType.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
  */
 public enum DepositHistoryType {
     CHARGE, // 충전
+    PG_CHARGE, // PG 결제 승인 입금
+    DEPOSIT_CHARGE, // 예치금 사용 입금
     SETTLEMENT, // 정산
     USE, // 사용
     ROLLBACK, // 롤백 (정산 취소 등)

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/in/DepositEventListener.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/in/DepositEventListener.java
@@ -33,6 +33,7 @@ public class DepositEventListener {
                 event.paymentDeposit(),
                 event.orderUuid(),
                 event.itemDepositUsages());
+        depositFacade.increaseSystemDepositForPg(event.orderUuid(), event.pgAmount());
     }
 
     /**

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/payment/app/ConfirmPaymentUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/payment/app/ConfirmPaymentUseCase.java
@@ -101,6 +101,7 @@ public class ConfirmPaymentUseCase {
                 payment.getUuid(), // paymentUuid (2026-01-24 추가된 필드 대응)
                 payment.getOrderUuid(),
                 payment.getAmount(),
+                payment.getAmountPg(),
                 payment.getPaymentDeposit(),
                 payment.getUserUuid(),
                 payment.getApprovedAt(),

--- a/semicolon/src/main/java/dukku/semicolon/global/SystemDepositInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/SystemDepositInitData.java
@@ -31,7 +31,7 @@ public class SystemDepositInitData {
     private static final String SYSTEM_DEPOSIT_EMAIL = "admin-deposit@dukku.shop";
     private static final String SYSTEM_DEPOSIT_NICKNAME = "시스템-예치금";
     // 임시 하드코딩 UUID (추후 API Client 등으로 대체 예정)
-    private static final UUID SYSTEM_USER_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+    public static final UUID SYSTEM_USER_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
     private static final Long INITIAL_CAPITAL = 1_000_000_000L; // 10억
 
     @Bean

--- a/semicolon/src/test/java/dukku/semicolon/boundedContext/deposit/app/DeductDepositForPaymentIntegrationTest.java
+++ b/semicolon/src/test/java/dukku/semicolon/boundedContext/deposit/app/DeductDepositForPaymentIntegrationTest.java
@@ -1,0 +1,109 @@
+package dukku.semicolon.boundedContext.deposit.app;
+
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.deposit.event.DepositUsedEvent;
+import dukku.common.shared.payment.event.PaymentSuccessEvent;
+import dukku.common.global.config.QueryDslConfig;
+import dukku.semicolon.boundedContext.deposit.entity.Deposit;
+import dukku.semicolon.boundedContext.deposit.entity.DepositHistory;
+import dukku.semicolon.boundedContext.deposit.entity.enums.DepositHistoryType;
+import dukku.semicolon.boundedContext.deposit.out.DepositHistoryRepository;
+import dukku.semicolon.boundedContext.deposit.out.DepositRepository;
+import dukku.semicolon.global.SystemDepositInitData;
+import dukku.semicolon.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+@Import({
+                QueryDslConfig.class,
+                DepositSupport.class,
+                FindDepositUseCase.class,
+                IncreaseDepositUseCase.class,
+                DecreaseDepositUseCase.class,
+                DeductDepositForPaymentUseCase.class
+})
+class DeductDepositForPaymentIntegrationTest extends IntegrationTestSupport {
+
+        @Autowired
+        private DeductDepositForPaymentUseCase deductDepositForPaymentUseCase;
+
+        @Autowired
+        private IncreaseDepositUseCase increaseDepositUseCase;
+
+        @Autowired
+        private DepositRepository depositRepository;
+
+        @Autowired
+        private DepositHistoryRepository depositHistoryRepository;
+
+        @MockitoBean
+        private EventPublisher eventPublisher;
+
+        @Test
+        @DisplayName("예치금 차감 시 사용자 잔액 감소 + 시스템 예치금 증가 + 히스토리 기록")
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        void deductDepositAndRecordHistory() {
+                try {
+                        UUID userUuid = UUID.randomUUID();
+                        UUID orderUuid = UUID.randomUUID();
+                        UUID itemUuid1 = UUID.randomUUID();
+                        UUID itemUuid2 = UUID.randomUUID();
+
+                        increaseDepositUseCase.increase(userUuid, 10000L, DepositHistoryType.CHARGE, null);
+
+                        List<PaymentSuccessEvent.ItemDepositUsage> usages = List.of(
+                                        new PaymentSuccessEvent.ItemDepositUsage(itemUuid1, 5000L),
+                                        new PaymentSuccessEvent.ItemDepositUsage(itemUuid2, 3000L));
+
+                        Long initialSystemBalance = depositRepository
+                                        .findByUserUuid(SystemDepositInitData.SYSTEM_USER_UUID)
+                                        .map(Deposit::getBalance)
+                                        .orElse(0L);
+
+                        deductDepositForPaymentUseCase.execute(userUuid, 8000L, orderUuid, usages);
+
+                        Deposit userDeposit = depositRepository.findByUserUuid(userUuid).orElseThrow();
+                        Deposit systemDeposit = depositRepository
+                                        .findByUserUuid(SystemDepositInitData.SYSTEM_USER_UUID)
+                                        .orElseThrow();
+
+                        assertThat(userDeposit.getBalance()).isEqualTo(2000L);
+                        assertThat(systemDeposit.getBalance()).isEqualTo(initialSystemBalance + 8000L);
+
+                        List<DepositHistory> userHistories = depositHistoryRepository
+                                        .findByUserUuidOrderByCreatedAtDesc(userUuid);
+                        List<DepositHistory> systemHistories = depositHistoryRepository
+                                        .findByUserUuidOrderByCreatedAtDesc(SystemDepositInitData.SYSTEM_USER_UUID);
+
+                        assertThat(userHistories).hasSize(3);
+                        assertThat(userHistories).anyMatch(history -> history.getType() == DepositHistoryType.USE
+                                        && itemUuid1.equals(history.getOrderItemUuid())
+                                        && history.getAmount() == 5000L);
+                        assertThat(userHistories).anyMatch(history -> history.getType() == DepositHistoryType.USE
+                                        && itemUuid2.equals(history.getOrderItemUuid())
+                                        && history.getAmount() == 3000L);
+
+                        assertThat(systemHistories.get(0).getType()).isEqualTo(DepositHistoryType.DEPOSIT_CHARGE);
+                        assertThat(systemHistories.get(0).getOrderItemUuid()).isEqualTo(orderUuid);
+                        assertThat(systemHistories.get(0).getAmount()).isEqualTo(8000L);
+
+                        verify(eventPublisher).publish(any(DepositUsedEvent.class));
+                } catch (Exception e) {
+                        e.printStackTrace();
+                        throw e;
+                }
+        }
+}

--- a/semicolon/src/test/java/dukku/semicolon/boundedContext/deposit/app/DepositFacadeTest.java
+++ b/semicolon/src/test/java/dukku/semicolon/boundedContext/deposit/app/DepositFacadeTest.java
@@ -1,8 +1,6 @@
 package dukku.semicolon.boundedContext.deposit.app;
 
-import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.payment.event.PaymentSuccessEvent;
-import dukku.semicolon.boundedContext.deposit.entity.enums.DepositHistoryType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +29,7 @@ class DepositFacadeTest {
                 mock(DecreaseDepositUseCase.class),
                 mock(FindDepositHistoriesUseCase.class),
                 deductDepositForPaymentUseCase,
+                mock(IncreaseSystemDepositForPgUseCase.class),
                 mock(RefundDepositUseCase.class),
                 mock(ChargeDepositUseCase.class),
                 mock(ChargeDepositForSettlementUseCase.class));

--- a/semicolon/src/test/java/dukku/semicolon/boundedContext/deposit/in/DepositEventListenerTest.java
+++ b/semicolon/src/test/java/dukku/semicolon/boundedContext/deposit/in/DepositEventListenerTest.java
@@ -1,0 +1,80 @@
+package dukku.semicolon.boundedContext.deposit.in;
+
+import dukku.common.shared.payment.event.PaymentSuccessEvent;
+import dukku.semicolon.boundedContext.deposit.app.DepositFacade;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DepositEventListenerTest {
+
+    private DepositFacade depositFacade;
+    private DepositEventListener depositEventListener;
+
+    @BeforeEach
+    void setUp() {
+        depositFacade = mock(DepositFacade.class);
+        depositEventListener = new DepositEventListener(depositFacade);
+    }
+
+    @Test
+    @DisplayName("PG 금액이 있으면 시스템 예치금을 증가시킨다")
+    void handlePaymentSuccessCreditsSystemDeposit() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+        List<PaymentSuccessEvent.ItemDepositUsage> usages = List.of(
+                new PaymentSuccessEvent.ItemDepositUsage(UUID.randomUUID(), 5000L)
+        );
+
+        PaymentSuccessEvent event = new PaymentSuccessEvent(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                orderUuid,
+                10000L,
+                3000L,
+                7000L,
+                userUuid,
+                LocalDateTime.now(),
+                usages
+        );
+
+        depositEventListener.handle(event);
+
+        verify(depositFacade).deductDepositForPayment(userUuid, 7000L, orderUuid, usages);
+        verify(depositFacade).increaseSystemDepositForPg(orderUuid, 3000L);
+    }
+
+    @Test
+    @DisplayName("PG 금액이 없으면 시스템 예치금 증가를 생략한다")
+    void handlePaymentSuccessSkipsWhenPgAmountZero() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+        List<PaymentSuccessEvent.ItemDepositUsage> usages = List.of();
+
+        PaymentSuccessEvent event = new PaymentSuccessEvent(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                orderUuid,
+                7000L,
+                0L,
+                7000L,
+                userUuid,
+                LocalDateTime.now(),
+                usages
+        );
+
+        depositEventListener.handle(event);
+
+        verify(depositFacade).deductDepositForPayment(userUuid, 7000L, orderUuid, usages);
+        verify(depositFacade).increaseSystemDepositForPg(orderUuid, 0L);
+    }
+}

--- a/semicolon/src/test/java/dukku/semicolon/boundedContext/payment/app/RequestPaymentUseCaseIntegrationTest.java
+++ b/semicolon/src/test/java/dukku/semicolon/boundedContext/payment/app/RequestPaymentUseCaseIntegrationTest.java
@@ -1,0 +1,96 @@
+package dukku.semicolon.boundedContext.payment.app;
+
+import dukku.common.global.UserUtil;
+import dukku.semicolon.boundedContext.payment.entity.Payment;
+import dukku.semicolon.boundedContext.payment.entity.PaymentOrderItem;
+import dukku.semicolon.boundedContext.payment.out.PaymentOrderItemRepository;
+import dukku.semicolon.boundedContext.payment.out.PaymentRepository;
+import dukku.semicolon.shared.deposit.out.depositApiClient.DepositApiClient;
+import dukku.semicolon.shared.payment.dto.PaymentRequest;
+import dukku.semicolon.shared.payment.dto.PaymentResponse;
+import dukku.semicolon.support.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@Import({ PaymentSupport.class, RequestPaymentUseCase.class })
+class RequestPaymentUseCaseIntegrationTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RequestPaymentUseCase requestPaymentUseCase;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private PaymentOrderItemRepository paymentOrderItemRepository;
+
+    @MockitoBean
+    private DepositApiClient depositApiClient;
+
+    @Test
+    @DisplayName("결제 요청 시 payment_order_items에 예치금 분배 정보가 저장된다")
+    void persistPaymentOrderItemsWithDepositAllocation() {
+        UUID userUuid = UUID.randomUUID();
+
+        try (MockedStatic<UserUtil> userUtil = org.mockito.Mockito.mockStatic(UserUtil.class)) {
+            userUtil.when(UserUtil::getUserId).thenReturn(userUuid);
+            when(depositApiClient.getBalance(userUuid)).thenReturn(20000L);
+
+            UUID orderUuid = UUID.randomUUID();
+            UUID itemUuid1 = UUID.randomUUID();
+            UUID itemUuid2 = UUID.randomUUID();
+
+            PaymentRequest.PaymentRequestItem item1 = PaymentRequest.PaymentRequestItem.builder()
+                    .orderItemUuid(itemUuid1)
+                    .productId(2)
+                    .productName("item-2")
+                    .price(10000L)
+                    .sellerUuid(UUID.randomUUID())
+                    .paymentCoupon(0L)
+                    .build();
+
+            PaymentRequest.PaymentRequestItem item2 = PaymentRequest.PaymentRequestItem.builder()
+                    .orderItemUuid(itemUuid2)
+                    .productId(1)
+                    .productName("item-1")
+                    .price(10000L)
+                    .sellerUuid(UUID.randomUUID())
+                    .paymentCoupon(0L)
+                    .build();
+
+            PaymentRequest request = PaymentRequest.builder()
+                    .orderUuid(orderUuid)
+                    .orderName("test-order")
+                    .amounts(PaymentRequest.Amounts.builder()
+                            .itemsTotalAmount(20000L)
+                            .couponDiscountAmount(0L)
+                            .finalPayAmount(20000L)
+                            .depositUseAmount(15000L)
+                            .pgPayAmount(5000L)
+                            .build())
+                    .items(List.of(item1, item2))
+                    .build();
+
+            PaymentResponse response = requestPaymentUseCase.execute(request, "idempotency-key");
+
+            Payment payment = paymentRepository.findByUuid(response.getData().getPaymentUuid()).orElseThrow();
+            List<PaymentOrderItem> items = paymentOrderItemRepository.findByPaymentId(payment.getId());
+
+            assertThat(items).hasSize(2);
+            assertThat(items).anyMatch(item -> item.getOrderItemUuid().equals(itemUuid2)
+                    && item.getPaymentDeposit() == 10000L);
+            assertThat(items).anyMatch(item -> item.getOrderItemUuid().equals(itemUuid1)
+                    && item.getPaymentDeposit() == 5000L);
+        }
+    }
+}

--- a/semicolon/src/test/java/dukku/semicolon/support/IntegrationTestApplication.java
+++ b/semicolon/src/test/java/dukku/semicolon/support/IntegrationTestApplication.java
@@ -1,0 +1,16 @@
+package dukku.semicolon.support;
+
+import dukku.semicolon.global.SystemDepositInitData;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@ComponentScan(
+        basePackages = "dukku.semicolon",
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SystemDepositInitData.class)
+)
+public class IntegrationTestApplication {
+}

--- a/semicolon/src/test/java/dukku/semicolon/support/IntegrationTestSupport.java
+++ b/semicolon/src/test/java/dukku/semicolon/support/IntegrationTestSupport.java
@@ -1,0 +1,17 @@
+package dukku.semicolon.support;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest(classes = IntegrationTestApplication.class, properties = {
+                "spring.datasource.url=jdbc:h2:mem:integration-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+                "spring.datasource.driver-class-name=org.h2.Driver",
+                "spring.datasource.username=sa",
+                "spring.datasource.password=",
+                "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+                "spring.jpa.hibernate.ddl-auto=create",
+                "spring.datasource.hikari.maximum-pool-size=20"
+})
+@Transactional
+public abstract class IntegrationTestSupport {
+}


### PR DESCRIPTION
## PR 제목
[Deposit] 결제 시 예치금 차감 구현 #68

---

## 개요

Deposit 도메인에 예치금 차감 구현

---

## 상세 내용
- PG결제금액을 담는 pgAmount 컬럼을 추가
- PG_CHARGE (PG결제에 의한 입금)
- DEPOSIT_CHARGE (사용자의 예치금 사용에 의한 입금)
- 기존 CHARGE 타입은 사용자의 예치금 직접 충전에 의한 입금 타입으로 남김 (MVP에서는 미구현)
- pg결제 승인분을 시스템 지갑에 반영하는 IncreaseSystemDepositForPgUseCase 추가
- 시스템 지갑에 예치금 입금 / 출금처리하 로직 추가
- 신규 추가된 사항 파사드에 연결
- 변경된 예치금 입출금 로직에 대한 테스트 추가


---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [x] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항
- 테스트는 Codex가 작성했습니다. 그냥 테스트가 있구나 정도로 봐주세요. 
- PG_CHARGE (PG결제에 의한 입금)와 DEPOSIT_CHARGE (사용자의 예치금 사용에 의한 입금) 로 타입을 분리해 좀 더 명시적으로 처리하게 했습니다. 참고 부탁드립니다.
- 하드코딩된 UUID는 호출 API 구현되면 교체예정입니다.
- 복잡한 내용은 없어서 로직 흐름 위주로 봐주시면 될 것 같습니다.