### PR TITLE
[User] 내부 사용자 UUID 조회 #126

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/user/FindUserByEmailUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/user/FindUserByEmailUseCase.java
@@ -1,0 +1,21 @@
+package dukku.semicolon.boundedContext.user.app.user;
+
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.shared.user.exception.UserNotFoundException;
+import dukku.semicolon.boundedContext.user.out.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class FindUserByEmailUseCase {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public User execute(String email) {
+        return userRepository.findByEmailAndDeletedAtIsNull(email)
+                .orElseThrow(UserNotFoundException::new);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/user/FindUserByRoleUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/app/user/FindUserByRoleUseCase.java
@@ -1,0 +1,22 @@
+package dukku.semicolon.boundedContext.user.app.user;
+
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.shared.user.exception.UserNotFoundException;
+import dukku.semicolon.boundedContext.user.out.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class FindUserByRoleUseCase {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public User execute(Role role) {
+        return userRepository.findByRoleAndDeletedAtIsNull(role)
+                .orElseThrow(UserNotFoundException::new);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/in/UserInternalController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/in/UserInternalController.java
@@ -1,0 +1,54 @@
+package dukku.semicolon.boundedContext.user.in;
+
+import dukku.common.global.exception.BadRequestException;
+import dukku.semicolon.boundedContext.user.app.user.FindUserByEmailUseCase;
+import dukku.semicolon.boundedContext.user.app.user.FindUserByRoleUseCase;
+import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.shared.user.dto.UserUuidResponse;
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/internal/users")
+@RequiredArgsConstructor
+@Hidden
+public class UserInternalController {
+
+    private final FindUserByRoleUseCase findUserByRole;
+    private final FindUserByEmailUseCase findUserByEmail;
+
+    @GetMapping("/uuid")
+    public ResponseEntity<UserUuidResponse> getUserUuid(
+            @RequestParam(required = false) Role role,
+            @RequestParam(required = false) String email
+    ) {
+        if ((role == null) == (email == null)) {
+            throw new BadRequestException("Provide exactly one of role or email.");
+        }
+        if (email != null && email.trim().isEmpty()) {
+            throw new BadRequestException("Email must not be blank.");
+        }
+
+        User user = role != null
+                ? findUserByRole.execute(role)
+                : findUserByEmail.execute(email.trim());
+
+        log.info("[Internal API] User UUID lookup. role={}, email={}", role, email);
+
+        UserUuidResponse response = UserUuidResponse.builder()
+                .userUuid(user.getUuid())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/out/UserRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/out/UserRepository.java
@@ -1,6 +1,7 @@
 package dukku.semicolon.boundedContext.user.out;
 
 import dukku.semicolon.boundedContext.user.entity.User;
+import dukku.semicolon.boundedContext.user.entity.type.Role;
 import dukku.semicolon.boundedContext.user.entity.type.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -17,6 +18,8 @@ public interface UserRepository extends JpaRepository<User, Integer> {
     Optional<User> findByUuid(UUID userUuid);
 
     Optional<User> findByUuidAndDeletedAtIsNull(UUID userUuid);
+
+    Optional<User> findByRoleAndDeletedAtIsNull(Role role);
 
     boolean existsByEmailAndDeletedAtIsNullAndIdNot(String email, Integer id);
 

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserUuidResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserUuidResponse.java
@@ -1,0 +1,19 @@
+package dukku.semicolon.shared.user.dto;
+
+import dukku.semicolon.boundedContext.user.entity.type.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUuidResponse {
+    private UUID userUuid;
+    private String email;
+    private Role role;
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/out/UserApiClient.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/out/UserApiClient.java
@@ -1,5 +1,7 @@
 package dukku.semicolon.shared.user.out;
 
+import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.shared.user.dto.UserUuidResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -7,10 +9,14 @@ import org.springframework.web.client.RestClient;
 @Service
 public class UserApiClient {
     private final RestClient restClient;
+    private final RestClient internalRestClient;
 
     public UserApiClient(@Value("${custom.global.internalBackUrl}") String internalBackUrl) {
         this.restClient = RestClient.builder()
                 .baseUrl(internalBackUrl + "/api/v1/users")
+                .build();
+        this.internalRestClient = RestClient.builder()
+                .baseUrl(internalBackUrl + "/api/v1/internal/users")
                 .build();
     }
 
@@ -19,5 +25,25 @@ public class UserApiClient {
                 .uri("/randomSecureTip")
                 .retrieve()
                 .body(String.class);
+    }
+
+    public UserUuidResponse getUserUuidByRole(Role role) {
+        return internalRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uuid")
+                        .queryParam("role", role)
+                        .build())
+                .retrieve()
+                .body(UserUuidResponse.class);
+    }
+
+    public UserUuidResponse getUserUuidByEmail(String email) {
+        return internalRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uuid")
+                        .queryParam("email", email)
+                        .build())
+                .retrieve()
+                .body(UserUuidResponse.class);
     }
 }


### PR DESCRIPTION
## PR 제목

- [User] 내부 사용자 UUID 조회 #126 
- Closes #126 
---
## 개요
- 다른 도메인은 “SYSTEM 계정이 필요할 때” 이 내부 API를 호출해서 UUID를 가져옴
- 예치금/정산 등에서 권한 판단이 필요하면, 이 UUID를 기준으로 처리 흐름을 구성

---

## 상세 내용
- role/email 기반 UUID 조회 내부 API추가
- role=SYSTEM으로 시스템 계정 UUID 조회 가능
- 응답에 userUuid, email, role 포함
---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
