### PR TITLE
[User] Settlement 상세 조회를 위한 API 추가 #130

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/in/UserInternalController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/in/UserInternalController.java
@@ -3,17 +3,22 @@ package dukku.semicolon.boundedContext.user.in;
 import dukku.common.global.exception.BadRequestException;
 import dukku.semicolon.boundedContext.user.app.user.FindUserByEmailUseCase;
 import dukku.semicolon.boundedContext.user.app.user.FindUserByRoleUseCase;
+import dukku.semicolon.boundedContext.user.app.user.FindUserUseCase;
 import dukku.semicolon.boundedContext.user.entity.User;
 import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.shared.user.dto.UserNicknameResponse;
 import dukku.semicolon.shared.user.dto.UserUuidResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -24,6 +29,7 @@ public class UserInternalController {
 
     private final FindUserByRoleUseCase findUserByRole;
     private final FindUserByEmailUseCase findUserByEmail;
+    private final FindUserUseCase findUser;
 
     @GetMapping("/uuid")
     public ResponseEntity<UserUuidResponse> getUserUuid(
@@ -47,6 +53,20 @@ public class UserInternalController {
                 .userUuid(user.getUuid())
                 .email(user.getEmail())
                 .role(user.getRole())
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{userUuid}/nickname")
+    public ResponseEntity<UserNicknameResponse> getUserNickname(@PathVariable UUID userUuid) {
+        User user = findUser.execute(userUuid);
+
+        log.info("[Internal API] User nickname lookup. userUuid={}", userUuid);
+
+        UserNicknameResponse response = UserNicknameResponse.builder()
+                .userUuid(user.getUuid())
+                .nickname(user.getNickname())
                 .build();
 
         return ResponseEntity.ok(response);

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserNicknameResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserNicknameResponse.java
@@ -1,0 +1,17 @@
+package dukku.semicolon.shared.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserNicknameResponse {
+    private UUID userUuid;
+    private String nickname;
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/out/UserApiClient.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/out/UserApiClient.java
@@ -1,10 +1,13 @@
 package dukku.semicolon.shared.user.out;
 
 import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.shared.user.dto.UserNicknameResponse;
 import dukku.semicolon.shared.user.dto.UserUuidResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+
+import java.util.UUID;
 
 @Service
 public class UserApiClient {
@@ -45,5 +48,14 @@ public class UserApiClient {
                         .build())
                 .retrieve()
                 .body(UserUuidResponse.class);
+    }
+
+    public String getNickname(UUID userUuid) {
+        UserNicknameResponse response = internalRestClient.get()
+                .uri("/{userUuid}/nickname", userUuid)
+                .retrieve()
+                .body(UserNicknameResponse.class);
+
+        return response != null ? response.getNickname() : null;
     }
 }


### PR DESCRIPTION
## PR 제목

[User] Settlement 상세 조회를 위한 API 추가 #130 

---

## 개요
- 정산 도메인에서 필요한 데이터(사용자 UUID로 닉네임 조회)를 내부 API로 제공하고, 호출하는 쪽에서 ApiClient로 조회해서 사용

---

## 상세 내용

- User BC에 내부용 엔드포인트를 작성: /api/v1/internal/users/{userUuid}/nickname
- 응답은 UserNicknameResponse(userUuid, nickname) 형태로 반환
- 다른 도메인에서는 UserApiClient.getNickname(UUID userUuid)로 호출

---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- 정산 도메인에서 제대로 호출이 되는지 확인 부탁드립니다.
