### PR TITLE
[User] 도메인 ID 기반 유저 UUID 조회 API 추가 #137

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/DepositFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/DepositFacade.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 public class DepositFacade {
 
     private final FindDepositUseCase findDepositUseCase;
+    private final FindDepositByDepositUuidUseCase findDepositByDepositUuidUseCase;
     private final IncreaseDepositUseCase increaseDepositUseCase;
     private final DecreaseDepositUseCase decreaseDepositUseCase;
     private final FindDepositHistoriesUseCase findDepositHistoriesUseCase;
@@ -41,6 +42,10 @@ public class DepositFacade {
      */
     public DepositDto findDeposit(UUID userUuid) {
         return findDepositUseCase.findOrCreate(userUuid).toDto();
+    }
+
+    public DepositDto findDepositByDepositUuid(UUID depositUuid) {
+        return findDepositByDepositUuidUseCase.execute(depositUuid).toDto();
     }
 
     /**

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/DepositSupport.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/DepositSupport.java
@@ -23,6 +23,10 @@ public class DepositSupport {
         return depositRepository.findByUserUuid(userUuid);
     }
 
+    public Optional<Deposit> findByDepositUuid(UUID depositUuid) {
+        return depositRepository.findByDepositUuid(depositUuid);
+    }
+
     public Deposit save(Deposit deposit) {
         return depositRepository.save(deposit);
     }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/FindDepositByDepositUuidUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/app/FindDepositByDepositUuidUseCase.java
@@ -1,0 +1,22 @@
+package dukku.semicolon.boundedContext.deposit.app;
+
+import dukku.semicolon.boundedContext.deposit.entity.Deposit;
+import dukku.semicolon.shared.deposit.exception.DepositNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindDepositByDepositUuidUseCase {
+
+    private final DepositSupport depositSupport;
+
+    public Deposit execute(UUID depositUuid) {
+        return depositSupport.findByDepositUuid(depositUuid)
+                .orElseThrow(DepositNotFoundException::new);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/in/DepositUserAdminController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/in/DepositUserAdminController.java
@@ -1,0 +1,32 @@
+package dukku.semicolon.boundedContext.deposit.in;
+
+import dukku.semicolon.boundedContext.deposit.app.DepositFacade;
+import dukku.semicolon.shared.deposit.docs.DepositApiDocs;
+import dukku.semicolon.shared.deposit.dto.DepositDto;
+import dukku.semicolon.shared.user.dto.UserAdminProfileResponse;
+import dukku.semicolon.shared.user.out.UserApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/admin/deposits")
+@RequiredArgsConstructor
+@DepositApiDocs.DepositTag
+public class DepositUserAdminController {
+
+    private final DepositFacade depositFacade;
+    private final UserApiClient userApiClient;
+
+    @GetMapping("/{depositUuid}/user")
+    public ResponseEntity<UserAdminProfileResponse> getUserAdminProfile(@PathVariable UUID depositUuid) {
+        DepositDto deposit = depositFacade.findDepositByDepositUuid(depositUuid);
+        UserAdminProfileResponse response = userApiClient.getUserAdminProfile(deposit.getUserUuid());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/in/DepositUserController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/deposit/in/DepositUserController.java
@@ -1,0 +1,32 @@
+package dukku.semicolon.boundedContext.deposit.in;
+
+import dukku.semicolon.boundedContext.deposit.app.DepositFacade;
+import dukku.semicolon.shared.deposit.docs.DepositApiDocs;
+import dukku.semicolon.shared.deposit.dto.DepositDto;
+import dukku.semicolon.shared.user.dto.UserProfileResponse;
+import dukku.semicolon.shared.user.out.UserApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/deposits")
+@RequiredArgsConstructor
+@DepositApiDocs.DepositTag
+public class DepositUserController {
+
+    private final DepositFacade depositFacade;
+    private final UserApiClient userApiClient;
+
+    @GetMapping("/{depositUuid}/user")
+    public ResponseEntity<UserProfileResponse> getUserProfile(@PathVariable UUID depositUuid) {
+        DepositDto deposit = depositFacade.findDepositByDepositUuid(depositUuid);
+        UserProfileResponse response = userApiClient.getUserProfile(deposit.getUserUuid());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/user/in/UserInternalController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/user/in/UserInternalController.java
@@ -3,17 +3,23 @@ package dukku.semicolon.boundedContext.user.in;
 import dukku.common.global.exception.BadRequestException;
 import dukku.semicolon.boundedContext.user.app.user.FindUserByEmailUseCase;
 import dukku.semicolon.boundedContext.user.app.user.FindUserByRoleUseCase;
+import dukku.semicolon.boundedContext.user.app.user.FindUserUseCase;
 import dukku.semicolon.boundedContext.user.entity.User;
 import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.shared.user.dto.UserAdminProfileResponse;
+import dukku.semicolon.shared.user.dto.UserProfileResponse;
 import dukku.semicolon.shared.user.dto.UserUuidResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -24,6 +30,7 @@ public class UserInternalController {
 
     private final FindUserByRoleUseCase findUserByRole;
     private final FindUserByEmailUseCase findUserByEmail;
+    private final FindUserUseCase findUser;
 
     @GetMapping("/uuid")
     public ResponseEntity<UserUuidResponse> getUserUuid(
@@ -47,6 +54,41 @@ public class UserInternalController {
                 .userUuid(user.getUuid())
                 .email(user.getEmail())
                 .role(user.getRole())
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{userUuid}/profile")
+    public ResponseEntity<UserProfileResponse> getUserProfile(@PathVariable UUID userUuid) {
+        User user = findUser.execute(userUuid);
+
+        log.info("[Internal API] User profile lookup. userUuid={}", userUuid);
+
+        UserProfileResponse response = UserProfileResponse.builder()
+                .userUuid(user.getUuid())
+                .nickname(user.getNickname())
+                .createdAt(user.getCreatedAt())
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{userUuid}/admin")
+    public ResponseEntity<UserAdminProfileResponse> getUserAdminProfile(@PathVariable UUID userUuid) {
+        User user = findUser.execute(userUuid);
+
+        log.info("[Internal API] User admin profile lookup. userUuid={}", userUuid);
+
+        UserAdminProfileResponse response = UserAdminProfileResponse.builder()
+                .userUuid(user.getUuid())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .role(user.getRole())
+                .status(user.getStatus())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .deletedAt(user.getDeletedAt())
                 .build();
 
         return ResponseEntity.ok(response);

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserAdminProfileResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserAdminProfileResponse.java
@@ -1,0 +1,26 @@
+package dukku.semicolon.shared.user.dto;
+
+import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.boundedContext.user.entity.type.UserStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAdminProfileResponse {
+    private UUID userUuid;
+    private String email;
+    private String nickname;
+    private Role role;
+    private UserStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserProfileResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/dto/UserProfileResponse.java
@@ -1,0 +1,19 @@
+package dukku.semicolon.shared.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileResponse {
+    private UUID userUuid;
+    private String nickname;
+    private LocalDateTime createdAt;
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/user/out/UserApiClient.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/user/out/UserApiClient.java
@@ -1,10 +1,14 @@
 package dukku.semicolon.shared.user.out;
 
 import dukku.semicolon.boundedContext.user.entity.type.Role;
+import dukku.semicolon.shared.user.dto.UserAdminProfileResponse;
+import dukku.semicolon.shared.user.dto.UserProfileResponse;
 import dukku.semicolon.shared.user.dto.UserUuidResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
+
+import java.util.UUID;
 
 @Service
 public class UserApiClient {
@@ -45,5 +49,19 @@ public class UserApiClient {
                         .build())
                 .retrieve()
                 .body(UserUuidResponse.class);
+    }
+
+    public UserProfileResponse getUserProfile(UUID userUuid) {
+        return internalRestClient.get()
+                .uri("/{userUuid}/profile", userUuid)
+                .retrieve()
+                .body(UserProfileResponse.class);
+    }
+
+    public UserAdminProfileResponse getUserAdminProfile(UUID userUuid) {
+        return internalRestClient.get()
+                .uri("/{userUuid}/admin", userUuid)
+                .retrieve()
+                .body(UserAdminProfileResponse.class);
     }
 }

--- a/semicolon/src/test/java/dukku/semicolon/boundedContext/deposit/app/DepositFacadeTest.java
+++ b/semicolon/src/test/java/dukku/semicolon/boundedContext/deposit/app/DepositFacadeTest.java
@@ -18,13 +18,17 @@ class DepositFacadeTest {
 
     private DeductDepositForPaymentUseCase deductDepositForPaymentUseCase;
     private DepositFacade depositFacade;
+    private FindDepositByDepositUuidUseCase findDepositByDepositUuidUseCase;
+
 
     @BeforeEach
     void setUp() {
+        findDepositByDepositUuidUseCase = mock(FindDepositByDepositUuidUseCase.class);
         deductDepositForPaymentUseCase = mock(DeductDepositForPaymentUseCase.class);
 
         depositFacade = new DepositFacade(
                 mock(FindDepositUseCase.class),
+                findDepositByDepositUuidUseCase,
                 mock(IncreaseDepositUseCase.class),
                 mock(DecreaseDepositUseCase.class),
                 mock(FindDepositHistoriesUseCase.class),


### PR DESCRIPTION
## PR 제목

- [User] 도메인 ID 기반 유저 UUID 조회 API 추가 #137 
- Closes #137 
---

## 개요

- deposit부분만 적용, 이후 다른 도메인 확장 예정
- 도메인별 ID(예치금 UUID)를 파라미터로 받아 연관된 유저 정보를 조회하는 API를 추가
- 예치금 도메인에 일반/관리자용 컨트롤러 2개를 분리

---

## 상세 내용

• 일반용: depositUuid로 유저 조회 → 닉네임, 생성일 반환
• 관리자용: depositUuid로 유저 조회 → 이메일, 닉네임, 역할, 생성일, 수정일, 삭제일, 상태 반환
• 내부 유저 조회 API를 확장하여 프로필/관리자 프로필 응답을 제공

---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
