### PR TITLE
[User] 도메인 ID 기반 유저 UUID 조회 API 추가 확장 #137, #138

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/order/app/FindOrderByUuidUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/order/app/FindOrderByUuidUseCase.java
@@ -1,0 +1,20 @@
+package dukku.semicolon.boundedContext.order.app;
+
+import dukku.semicolon.boundedContext.order.entity.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class FindOrderByUuidUseCase {
+
+    private final OrderSupport orderSupport;
+
+    @Transactional(readOnly = true)
+    public Order execute(UUID orderUuid) {
+        return orderSupport.findOrderByUuid(orderUuid);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/order/in/OrderUserAdminController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/order/in/OrderUserAdminController.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.order.in;
+
+import dukku.semicolon.boundedContext.order.app.FindOrderByUuidUseCase;
+import dukku.semicolon.boundedContext.order.entity.Order;
+import dukku.semicolon.shared.user.dto.UserAdminProfileResponse;
+import dukku.semicolon.shared.user.out.UserApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/admin/orders")
+@RequiredArgsConstructor
+public class OrderUserAdminController {
+
+    private final FindOrderByUuidUseCase findOrderByUuidUseCase;
+    private final UserApiClient userApiClient;
+
+    @GetMapping("/{orderUuid}/user")
+    public ResponseEntity<UserAdminProfileResponse> getUserAdminProfile(@PathVariable UUID orderUuid) {
+        Order order = findOrderByUuidUseCase.execute(orderUuid);
+        UserAdminProfileResponse response = userApiClient.getUserAdminProfile(order.getUserUuid());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/order/in/OrderUserController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/order/in/OrderUserController.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.order.in;
+
+import dukku.semicolon.boundedContext.order.app.FindOrderByUuidUseCase;
+import dukku.semicolon.boundedContext.order.entity.Order;
+import dukku.semicolon.shared.user.dto.UserProfileResponse;
+import dukku.semicolon.shared.user.out.UserApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderUserController {
+
+    private final FindOrderByUuidUseCase findOrderByUuidUseCase;
+    private final UserApiClient userApiClient;
+
+    @GetMapping("/{orderUuid}/user")
+    public ResponseEntity<UserProfileResponse> getUserProfile(@PathVariable UUID orderUuid) {
+        Order order = findOrderByUuidUseCase.execute(orderUuid);
+        UserProfileResponse response = userApiClient.getUserProfile(order.getUserUuid());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/payment/in/PaymentUserAdminController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/payment/in/PaymentUserAdminController.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.payment.in;
+
+import dukku.semicolon.boundedContext.payment.app.FindPaymentUseCase;
+import dukku.semicolon.boundedContext.payment.entity.Payment;
+import dukku.semicolon.shared.user.dto.UserAdminProfileResponse;
+import dukku.semicolon.shared.user.out.UserApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/admin/payments")
+@RequiredArgsConstructor
+public class PaymentUserAdminController {
+
+    private final FindPaymentUseCase findPaymentUseCase;
+    private final UserApiClient userApiClient;
+
+    @GetMapping("/{paymentUuid}/user")
+    public ResponseEntity<UserAdminProfileResponse> getUserAdminProfile(@PathVariable UUID paymentUuid) {
+        Payment payment = findPaymentUseCase.execute(paymentUuid);
+        UserAdminProfileResponse response = userApiClient.getUserAdminProfile(payment.getUserUuid());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/payment/in/PaymentUserController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/payment/in/PaymentUserController.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.payment.in;
+
+import dukku.semicolon.boundedContext.payment.app.FindPaymentUseCase;
+import dukku.semicolon.boundedContext.payment.entity.Payment;
+import dukku.semicolon.shared.user.dto.UserProfileResponse;
+import dukku.semicolon.shared.user.out.UserApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentUserController {
+
+    private final FindPaymentUseCase findPaymentUseCase;
+    private final UserApiClient userApiClient;
+
+    @GetMapping("/{paymentUuid}/user")
+    public ResponseEntity<UserProfileResponse> getUserProfile(@PathVariable UUID paymentUuid) {
+        Payment payment = findPaymentUseCase.execute(paymentUuid);
+        UserProfileResponse response = userApiClient.getUserProfile(payment.getUserUuid());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/support/ProductSupport.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/support/ProductSupport.java
@@ -41,6 +41,11 @@ public class ProductSupport {
         return product;
     }
 
+    public Product findByUuid(UUID productUuid) {
+        return productRepository.findByUuid(productUuid)
+                .orElseThrow(ProductNotFoundException::new);
+    }
+
     public void validateImageCount(int addCount) {
         if (addCount > 10) {
             throw new ProductImageLimitExceededException();

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/product/FindProductByUuidUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/product/FindProductByUuidUseCase.java
@@ -1,0 +1,21 @@
+package dukku.semicolon.boundedContext.product.app.usecase.product;
+
+import dukku.semicolon.boundedContext.product.app.support.ProductSupport;
+import dukku.semicolon.boundedContext.product.entity.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class FindProductByUuidUseCase {
+
+    private final ProductSupport productSupport;
+
+    @Transactional(readOnly = true)
+    public Product execute(UUID productUuid) {
+        return productSupport.findByUuid(productUuid);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ProductUserAdminController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ProductUserAdminController.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.product.in;
+
+import dukku.semicolon.boundedContext.product.app.usecase.product.FindProductByUuidUseCase;
+import dukku.semicolon.boundedContext.product.entity.Product;
+import dukku.semicolon.shared.user.dto.UserAdminProfileResponse;
+import dukku.semicolon.shared.user.out.UserApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/admin/products")
+@RequiredArgsConstructor
+public class ProductUserAdminController {
+
+    private final FindProductByUuidUseCase findProductByUuidUseCase;
+    private final UserApiClient userApiClient;
+
+    @GetMapping("/{productUuid}/user")
+    public ResponseEntity<UserAdminProfileResponse> getUserAdminProfile(@PathVariable UUID productUuid) {
+        Product product = findProductByUuidUseCase.execute(productUuid);
+        UserAdminProfileResponse response = userApiClient.getUserAdminProfile(product.getSellerUuid());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ProductUserController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/in/ProductUserController.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.product.in;
+
+import dukku.semicolon.boundedContext.product.app.usecase.product.FindProductByUuidUseCase;
+import dukku.semicolon.boundedContext.product.entity.Product;
+import dukku.semicolon.shared.user.dto.UserProfileResponse;
+import dukku.semicolon.shared.user.out.UserApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
+public class ProductUserController {
+
+    private final FindProductByUuidUseCase findProductByUuidUseCase;
+    private final UserApiClient userApiClient;
+
+    @GetMapping("/{productUuid}/user")
+    public ResponseEntity<UserProfileResponse> getUserProfile(@PathVariable UUID productUuid) {
+        Product product = findProductByUuidUseCase.execute(productUuid);
+        UserProfileResponse response = userApiClient.getUserProfile(product.getSellerUuid());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/in/SettlementUserAdminController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/in/SettlementUserAdminController.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.settlement.in;
+
+import dukku.semicolon.boundedContext.settlement.app.GetSettlementUseCase;
+import dukku.semicolon.boundedContext.settlement.entity.Settlement;
+import dukku.semicolon.shared.user.dto.UserAdminProfileResponse;
+import dukku.semicolon.shared.user.out.UserApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/admin/settlements")
+@RequiredArgsConstructor
+public class SettlementUserAdminController {
+
+    private final GetSettlementUseCase getSettlementUseCase;
+    private final UserApiClient userApiClient;
+
+    @GetMapping("/{settlementUuid}/user")
+    public ResponseEntity<UserAdminProfileResponse> getUserAdminProfile(@PathVariable UUID settlementUuid) {
+        Settlement settlement = getSettlementUseCase.execute(settlementUuid);
+        UserAdminProfileResponse response = userApiClient.getUserAdminProfile(settlement.getSellerUuid());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/in/SettlementUserController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/settlement/in/SettlementUserController.java
@@ -1,0 +1,30 @@
+package dukku.semicolon.boundedContext.settlement.in;
+
+import dukku.semicolon.boundedContext.settlement.app.GetSettlementUseCase;
+import dukku.semicolon.boundedContext.settlement.entity.Settlement;
+import dukku.semicolon.shared.user.dto.UserProfileResponse;
+import dukku.semicolon.shared.user.out.UserApiClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/settlements")
+@RequiredArgsConstructor
+public class SettlementUserController {
+
+    private final GetSettlementUseCase getSettlementUseCase;
+    private final UserApiClient userApiClient;
+
+    @GetMapping("/{settlementUuid}/user")
+    public ResponseEntity<UserProfileResponse> getUserProfile(@PathVariable UUID settlementUuid) {
+        Settlement settlement = getSettlementUseCase.execute(settlementUuid);
+        UserProfileResponse response = userApiClient.getUserProfile(settlement.getSellerUuid());
+        return ResponseEntity.ok(response);
+    }
+}


### PR DESCRIPTION
- 상품, 주문, 결제, 정산 추가 _ 쿠폰 미구현

## PR 제목

[User] 도메인 ID 기반 유저 UUID 조회 API 추가 확장 #137, #138 

---

## 개요

- deposit 부분에 이어 상품, 결제, 주문, 정산 도메인에 컨트롤러 추가 
#138 추가 확장 


---

## 상세 내용

- 상품, 결제, 주문, 정산 도메인 컨트롤러 추가
- 쿠폰 도메인 미구현

---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
