### PR TITLE
[Coupon] 쿠폰 발급/사용 기능 및 부하 테스트 구현

### DIFF
--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/ActivateCouponUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/ActivateCouponUseCase.java
@@ -1,0 +1,24 @@
+package dukku.semicolon.boundedContext.coupon.app.command;
+
+import dukku.semicolon.boundedContext.coupon.entity.Coupon;
+import dukku.semicolon.boundedContext.coupon.out.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class ActivateCouponUseCase {
+    private final CouponRepository couponRepository;
+
+    public void execute(UUID couponUuid) {
+        Coupon coupon = couponRepository.findByUuid(couponUuid)
+                .orElseThrow();
+
+        coupon.activate();
+    }
+}
+

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/ActivateCouponUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/ActivateCouponUseCase.java
@@ -2,6 +2,7 @@ package dukku.semicolon.boundedContext.coupon.app.command;
 
 import dukku.semicolon.boundedContext.coupon.entity.Coupon;
 import dukku.semicolon.boundedContext.coupon.out.CouponRepository;
+import dukku.semicolon.shared.coupon.exception.CouponNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +17,7 @@ public class ActivateCouponUseCase {
 
     public void execute(UUID couponUuid) {
         Coupon coupon = couponRepository.findByUuid(couponUuid)
-                .orElseThrow();
+                .orElseThrow(CouponNotFoundException::new);
 
         coupon.activate();
     }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/CouponFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/CouponFacade.java
@@ -1,0 +1,45 @@
+package dukku.semicolon.boundedContext.coupon.app.command;
+
+import dukku.semicolon.shared.coupon.dto.CouponCreateRequest;
+import dukku.semicolon.shared.coupon.dto.CouponResponse;
+import dukku.semicolon.shared.coupon.dto.CouponUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CouponFacade {
+    private final CreateCouponUseCase createCouponUseCase;
+    private final UpdateCouponUseCase updateCouponUseCase;
+    private final ActivateCouponUseCase activateCouponUseCase;
+    private final IssueCouponUseCase issueCouponUseCase;
+    private final UseCouponUseCase useCouponUseCase;
+
+    // 쿠폰을 생성한다
+    public CouponResponse createCoupon(CouponCreateRequest request) {
+        return createCouponUseCase.execute(request);
+    }
+
+    // 초안 상태의 쿠폰 정보를 수정한다
+    public void updateDraft(UUID couponUuid, CouponUpdateRequest request) {
+        updateCouponUseCase.execute(couponUuid, request);
+    }
+
+    // 쿠폰을 활성화 상태로 변경한다
+    public void activate(UUID couponUuid) {
+        activateCouponUseCase.execute(couponUuid);
+    }
+
+    // 사용자에게 쿠폰을 발급한다
+    public void issueCoupon(UUID userUuid, UUID couponUuid) {
+        issueCouponUseCase.execute(userUuid, couponUuid);
+    }
+
+    // 사용자가 쿠폰을 사용 처리한다
+    public void useCoupon(UUID userUuid, UUID couponUuid) {
+        useCouponUseCase.execute(userUuid, couponUuid);
+    }
+
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/CouponFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/CouponFacade.java
@@ -28,7 +28,7 @@ public class CouponFacade {
     }
 
     // 쿠폰을 활성화 상태로 변경한다
-    public void activate(UUID couponUuid) {
+    public void activateCoupon(UUID couponUuid) {
         activateCouponUseCase.execute(couponUuid);
     }
 

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/CreateCouponUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/CreateCouponUseCase.java
@@ -1,0 +1,24 @@
+package dukku.semicolon.boundedContext.coupon.app.command;
+
+import dukku.semicolon.boundedContext.coupon.entity.Coupon;
+import dukku.semicolon.boundedContext.coupon.out.CouponRepository;
+import dukku.semicolon.shared.coupon.dto.CouponCreateRequest;
+import dukku.semicolon.shared.coupon.dto.CouponResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class CreateCouponUseCase {
+
+    private final CouponRepository couponRepository;
+
+    public CouponResponse execute(CouponCreateRequest request) {
+        Coupon coupon = Coupon.createCoupon(request);
+        couponRepository.save(coupon);
+
+        return CouponResponse.from(coupon);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/IssueCouponUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/IssueCouponUseCase.java
@@ -1,0 +1,71 @@
+package dukku.semicolon.boundedContext.coupon.app.command;
+
+import dukku.common.global.exception.ConflictException;
+import dukku.semicolon.boundedContext.coupon.entity.Coupon;
+import dukku.semicolon.boundedContext.coupon.entity.CouponIssueLog;
+import dukku.semicolon.boundedContext.coupon.entity.CouponUser;
+import dukku.semicolon.boundedContext.coupon.entity.type.IssueResult;
+import dukku.semicolon.boundedContext.coupon.out.CouponIssueLogRepository;
+import dukku.semicolon.boundedContext.coupon.out.CouponRepository;
+import dukku.semicolon.boundedContext.coupon.out.CouponUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class IssueCouponUseCase {
+
+    private final CouponRepository couponRepository;
+    private final CouponUserRepository couponUserRepository;
+    private final CouponIssueLogRepository couponIssueLogRepository;
+
+    public void execute(UUID userUuid, UUID couponUuid) {
+        LocalDateTime requestedAt = LocalDateTime.now();
+
+        try {
+            if (couponUserRepository.existsByUserUuidAndCoupon_Uuid(userUuid, couponUuid)) {
+                throw new ConflictException("이미 쿠폰을 발급받은 유저");
+            }
+
+            Coupon coupon = couponRepository.findByUuid(couponUuid)
+                    .orElseThrow();
+
+            CouponUser couponUser = CouponUser.issue(userUuid, coupon);
+            couponUserRepository.save(couponUser);
+
+            couponIssueLogRepository.save(
+                    CouponIssueLog.of(
+                            couponUuid,
+                            userUuid,
+                            IssueResult.SUCCESS,
+                            requestedAt
+                    )
+            );
+
+        } catch (ConflictException e) {
+
+            couponIssueLogRepository.save(
+                    CouponIssueLog.of(
+                            couponUuid,
+                            userUuid,
+                            mapResult(e),
+                            requestedAt
+                    )
+            );
+
+            throw e;
+        }
+    }
+
+    private IssueResult mapResult(ConflictException e) {
+        if (e.getMessage().contains("이미")) return IssueResult.DUPLICATE;
+        if (e.getMessage().contains("소진")) return IssueResult.SOLD_OUT;
+        if (e.getMessage().contains("활성")) return IssueResult.INACTIVE;
+        return IssueResult.ERROR;
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/IssueCouponUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/IssueCouponUseCase.java
@@ -8,6 +8,7 @@ import dukku.semicolon.boundedContext.coupon.entity.type.IssueResult;
 import dukku.semicolon.boundedContext.coupon.out.CouponIssueLogRepository;
 import dukku.semicolon.boundedContext.coupon.out.CouponRepository;
 import dukku.semicolon.boundedContext.coupon.out.CouponUserRepository;
+import dukku.semicolon.shared.coupon.exception.CouponAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +30,7 @@ public class IssueCouponUseCase {
 
         try {
             if (couponUserRepository.existsByUserUuidAndCoupon_Uuid(userUuid, couponUuid)) {
-                throw new ConflictException("이미 쿠폰을 발급받은 유저");
+                throw new CouponAlreadyExistsException();
             }
 
             Coupon coupon = couponRepository.findByUuid(couponUuid)

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/IssueCouponUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/IssueCouponUseCase.java
@@ -9,6 +9,7 @@ import dukku.semicolon.boundedContext.coupon.out.CouponIssueLogRepository;
 import dukku.semicolon.boundedContext.coupon.out.CouponRepository;
 import dukku.semicolon.boundedContext.coupon.out.CouponUserRepository;
 import dukku.semicolon.shared.coupon.exception.CouponAlreadyExistsException;
+import dukku.semicolon.shared.coupon.exception.CouponNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +35,7 @@ public class IssueCouponUseCase {
             }
 
             Coupon coupon = couponRepository.findByUuid(couponUuid)
-                    .orElseThrow();
+                    .orElseThrow(CouponNotFoundException::new);
 
             CouponUser couponUser = CouponUser.issue(userUuid, coupon);
             couponUserRepository.save(couponUser);

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/UpdateCouponUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/UpdateCouponUseCase.java
@@ -1,0 +1,25 @@
+package dukku.semicolon.boundedContext.coupon.app.command;
+
+import dukku.common.global.exception.NotFoundException;
+import dukku.semicolon.boundedContext.coupon.entity.Coupon;
+import dukku.semicolon.boundedContext.coupon.out.CouponRepository;
+import dukku.semicolon.shared.coupon.dto.CouponUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class UpdateCouponUseCase {
+    private final CouponRepository couponRepository;
+
+    public void execute(UUID couponUuid, CouponUpdateRequest request) {
+        Coupon coupon = couponRepository.findByUuid(couponUuid)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 쿠폰입니다."));
+
+        coupon.updateDraft(request);
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/UpdateCouponUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/UpdateCouponUseCase.java
@@ -1,9 +1,9 @@
 package dukku.semicolon.boundedContext.coupon.app.command;
 
-import dukku.common.global.exception.NotFoundException;
 import dukku.semicolon.boundedContext.coupon.entity.Coupon;
 import dukku.semicolon.boundedContext.coupon.out.CouponRepository;
 import dukku.semicolon.shared.coupon.dto.CouponUpdateRequest;
+import dukku.semicolon.shared.coupon.exception.CouponNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +18,7 @@ public class UpdateCouponUseCase {
 
     public void execute(UUID couponUuid, CouponUpdateRequest request) {
         Coupon coupon = couponRepository.findByUuid(couponUuid)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 쿠폰입니다."));
+                .orElseThrow(CouponNotFoundException::new);
 
         coupon.updateDraft(request);
     }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/UseCouponUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/UseCouponUseCase.java
@@ -1,8 +1,8 @@
 package dukku.semicolon.boundedContext.coupon.app.command;
 
-import dukku.common.global.exception.NotFoundException;
 import dukku.semicolon.boundedContext.coupon.entity.CouponUser;
 import dukku.semicolon.boundedContext.coupon.out.CouponUserRepository;
+import dukku.semicolon.shared.coupon.exception.CouponUserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +17,7 @@ public class UseCouponUseCase {
 
     public void execute(UUID userUuid, UUID couponUuid) {
         CouponUser couponUser = couponUserRepository.findByUserUuidAndCoupon_Uuid(userUuid, couponUuid)
-                .orElseThrow(() -> new NotFoundException("쿠폰 발급 기록이 없습니다."));
+                .orElseThrow(CouponUserNotFoundException::new);
 
         couponUser.use();
     }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/UseCouponUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/command/UseCouponUseCase.java
@@ -1,0 +1,24 @@
+package dukku.semicolon.boundedContext.coupon.app.command;
+
+import dukku.common.global.exception.NotFoundException;
+import dukku.semicolon.boundedContext.coupon.entity.CouponUser;
+import dukku.semicolon.boundedContext.coupon.out.CouponUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class UseCouponUseCase {
+    private final CouponUserRepository couponUserRepository;
+
+    public void execute(UUID userUuid, UUID couponUuid) {
+        CouponUser couponUser = couponUserRepository.findByUserUuidAndCoupon_Uuid(userUuid, couponUuid)
+                .orElseThrow(() -> new NotFoundException("쿠폰 발급 기록이 없습니다."));
+
+        couponUser.use();
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/query/CouponQueryFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/query/CouponQueryFacade.java
@@ -1,0 +1,32 @@
+package dukku.semicolon.boundedContext.coupon.app.query;
+
+import dukku.semicolon.shared.coupon.dto.CouponResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouponQueryFacade {
+    private final CouponQueryService couponQueryService;
+
+    // 사용자에게 발급 가능한 쿠폰 리스트
+    public List<CouponResponse> getIssuableCoupons(UUID userUuid) {
+        return couponQueryService.getIssuableCoupons(userUuid);
+    }
+
+    // 사용자가 보유한 쿠폰 리스트
+    public List<CouponResponse> getMyCoupons(UUID userUuid) {
+        return couponQueryService.getMyCoupons(userUuid);
+    }
+
+    // 관리자용 전체 쿠폰 리스트
+    public List<CouponResponse> getAllCoupons() {
+        return couponQueryService.getAllCoupons();
+    }
+}
+

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/query/CouponQueryService.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/app/query/CouponQueryService.java
@@ -1,0 +1,62 @@
+package dukku.semicolon.boundedContext.coupon.app.query;
+
+import dukku.semicolon.boundedContext.coupon.entity.CouponUser;
+import dukku.semicolon.boundedContext.coupon.entity.type.CouponStatus;
+import dukku.semicolon.boundedContext.coupon.entity.type.CouponUserStatus;
+import dukku.semicolon.boundedContext.coupon.out.CouponRepository;
+import dukku.semicolon.boundedContext.coupon.out.CouponUserRepository;
+import dukku.semicolon.shared.coupon.dto.CouponResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouponQueryService {
+    private final CouponRepository couponRepository;
+    private final CouponUserRepository couponUserRepository;
+
+    /**
+     * 사용자가 발급 가능한 쿠폰 목록
+     * - ACTIVE 상태
+     * - 아직 해당 쿠폰을 발급받지 않은 경우
+     */
+    public List<CouponResponse> getIssuableCoupons(UUID userUuid) {
+        return couponRepository.findByStatus(CouponStatus.ACTIVE)
+                .stream()
+                .filter(coupon ->
+                        !couponUserRepository.existsByUserUuidAndCoupon_Uuid(
+                                userUuid,
+                                coupon.getUuid()
+                        )
+                )
+                .map(CouponResponse::from)
+                .toList();
+    }
+
+    /**
+     * 사용자가 보유한 쿠폰 목록
+     */
+    public List<CouponResponse> getMyCoupons(UUID userUuid) {
+        List<CouponUser> couponUsers = couponUserRepository.findByUserUuidAndStatus(userUuid, CouponUserStatus.AVAILABLE);
+
+        return couponUsers.stream()
+                .map(CouponUser::getCoupon)
+                .map(CouponResponse::from)
+                .toList();
+    }
+
+    /**
+     * 관리자용 전체 쿠폰 목록
+     */
+    public List<CouponResponse> getAllCoupons() {
+        return couponRepository.findAll()
+                .stream()
+                .map(CouponResponse::from)
+                .toList();
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/Coupon.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/Coupon.java
@@ -1,0 +1,111 @@
+package dukku.semicolon.boundedContext.coupon.entity;
+
+import dukku.common.global.exception.ConflictException;
+import dukku.semicolon.boundedContext.coupon.entity.type.CouponStatus;
+import dukku.semicolon.shared.coupon.dto.CouponCreateRequest;
+import dukku.semicolon.shared.coupon.dto.CouponUpdateRequest;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "coupons")
+@EntityListeners(AuditingEntityListener.class)
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false, unique = true)
+    private UUID uuid;
+
+    @Column(nullable = false, length = 100)
+    private String couponName;
+
+    @Column(nullable = false)
+    private int discountAmount;
+
+    @Column(nullable = false)
+    private int minimumOrderAmount;
+
+    @Column(nullable = false)
+    private LocalDateTime validFrom;
+
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CouponStatus status;
+
+    @Column(nullable = false)
+    private int totalQuantity;
+
+    @Column(nullable = false)
+    private int issuedQuantity;
+
+    // 쿠폰 생성 시 초기 상태는 DRAFT
+    public static Coupon createCoupon(CouponCreateRequest request) {
+        return Coupon.builder()
+                .couponName(request.couponName())
+                .discountAmount(request.discountAmount())
+                .minimumOrderAmount(request.minimumOrderAmount())
+                .validFrom(request.validFrom())
+                .status(CouponStatus.DRAFT)
+                .issuedQuantity(0)
+                .totalQuantity(request.totalQuantity())
+                .build();
+    }
+
+    // 발급 전(Active로 전환 전) 수정 허용
+    public void updateDraft(CouponUpdateRequest request) {
+        if (status != CouponStatus.DRAFT) {
+            throw new ConflictException("DRAFT 상태에서만 수정 가능합니다.");
+        }
+        this.couponName = request.couponName();
+        this.discountAmount = request.discountAmount();
+        this.minimumOrderAmount = request.minimumOrderAmount();
+        this.validFrom = request.validFrom();
+    }
+
+    /* 상태 전이 */
+    public void activate() {
+        if (status != CouponStatus.DRAFT) {
+            throw new ConflictException("DRAFT만 활성화 가능");
+        }
+        this.status = CouponStatus.ACTIVE;
+    }
+
+    public void deactivate() {
+        if (status != CouponStatus.ACTIVE) {
+            throw new ConflictException("ACTIVE만 비활성화 가능");
+        }
+        this.status = CouponStatus.INACTIVE;
+    }
+
+    public void expire() {
+        this.status = CouponStatus.EXPIRED;
+    }
+
+    /* 발급 */
+    public void issue() {
+        if (status != CouponStatus.ACTIVE) {
+            throw new ConflictException("활성화된 쿠폰만 발급 가능");
+        }
+        if (issuedQuantity >= totalQuantity) {
+            throw new ConflictException("쿠폰 수량 소진");
+        }
+        this.issuedQuantity++;
+    }
+}
+

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/Coupon.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/Coupon.java
@@ -1,9 +1,9 @@
 package dukku.semicolon.boundedContext.coupon.entity;
 
-import dukku.common.global.exception.ConflictException;
 import dukku.semicolon.boundedContext.coupon.entity.type.CouponStatus;
 import dukku.semicolon.shared.coupon.dto.CouponCreateRequest;
 import dukku.semicolon.shared.coupon.dto.CouponUpdateRequest;
+import dukku.semicolon.shared.coupon.exception.*;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -70,7 +70,7 @@ public class Coupon {
     // 발급 전(Active로 전환 전) 수정 허용
     public void updateDraft(CouponUpdateRequest request) {
         if (status != CouponStatus.DRAFT) {
-            throw new ConflictException("DRAFT 상태에서만 수정 가능합니다.");
+            throw new CouponUpdateNotAllowedException();
         }
         this.couponName = request.couponName();
         this.discountAmount = request.discountAmount();
@@ -81,14 +81,14 @@ public class Coupon {
     /* 상태 전이 */
     public void activate() {
         if (status != CouponStatus.DRAFT) {
-            throw new ConflictException("DRAFT만 활성화 가능");
+            throw new CouponActivationNotAllowedException();
         }
         this.status = CouponStatus.ACTIVE;
     }
 
     public void deactivate() {
         if (status != CouponStatus.ACTIVE) {
-            throw new ConflictException("ACTIVE만 비활성화 가능");
+            throw new CouponDeactivationNotAllowedException();
         }
         this.status = CouponStatus.INACTIVE;
     }
@@ -100,10 +100,10 @@ public class Coupon {
     /* 발급 */
     public void issue() {
         if (status != CouponStatus.ACTIVE) {
-            throw new ConflictException("활성화된 쿠폰만 발급 가능");
+            throw new CouponIssueNotAllowedException();
         }
         if (issuedQuantity >= totalQuantity) {
-            throw new ConflictException("쿠폰 수량 소진");
+            throw new CouponSoldOutException();
         }
         this.issuedQuantity++;
     }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/CouponIssueLog.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/CouponIssueLog.java
@@ -1,0 +1,58 @@
+package dukku.semicolon.boundedContext.coupon.entity;
+
+import dukku.semicolon.boundedContext.coupon.entity.type.IssueResult;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "coupon_issue_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponIssueLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Column(nullable = false)
+    private UUID couponUuid;
+
+    @Column(nullable = false)
+    private UUID userUuid;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private IssueResult result;
+
+    @Column(nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime processedAt;
+
+    @Column(nullable = false)
+    private int elapsedMs;
+
+    public static CouponIssueLog of(
+            UUID couponUuid,
+            UUID userUuid,
+            IssueResult result,
+            LocalDateTime requestedAt
+    ) {
+        CouponIssueLog log = new CouponIssueLog();
+        log.couponUuid = couponUuid;
+        log.userUuid = userUuid;
+        log.result = result;
+        log.requestedAt = requestedAt;
+        log.processedAt = LocalDateTime.now();
+        log.elapsedMs =
+                (int) java.time.Duration.between(
+                        requestedAt, log.processedAt
+                ).toMillis();
+        return log;
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/CouponUser.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/CouponUser.java
@@ -1,0 +1,69 @@
+package dukku.semicolon.boundedContext.coupon.entity;
+
+import dukku.common.global.exception.ConflictException;
+import dukku.semicolon.boundedContext.coupon.entity.type.CouponUserStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "coupon_users",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_uuid", "coupon_id"})
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponUser {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_uuid", nullable = false, updatable = false)
+    private UUID userUuid;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CouponUserStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime issuedAt;
+
+    private LocalDateTime usedAt;
+
+    /* 발급 */
+    public static CouponUser issue(UUID userUuid, Coupon coupon) {
+        coupon.issue(); // 쿠폰 수량 차감
+
+        CouponUser cu = new CouponUser();
+        cu.userUuid = userUuid;
+        cu.coupon = coupon;
+        cu.status = CouponUserStatus.AVAILABLE;
+        cu.issuedAt = LocalDateTime.now();
+        return cu;
+    }
+
+    /* 사용 */
+    public void use() {
+        if (status != CouponUserStatus.AVAILABLE) {
+            throw new ConflictException("사용할 수 없는 쿠폰");
+        }
+        this.status = CouponUserStatus.USED;
+        this.usedAt = LocalDateTime.now();
+    }
+
+    /* 만료 */
+    public void expire() {
+        if (status == CouponUserStatus.USED) return;
+        this.status = CouponUserStatus.EXPIRED;
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/CouponUser.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/CouponUser.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 public class CouponUser {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Integer id;
 
     @Column(name = "user_uuid", nullable = false, updatable = false)
     private UUID userUuid;

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/type/CouponStatus.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/type/CouponStatus.java
@@ -1,0 +1,8 @@
+package dukku.semicolon.boundedContext.coupon.entity.type;
+
+public enum CouponStatus {
+    DRAFT,      // 생성 후 발급 전
+    ACTIVE,     // 발급 가능
+    INACTIVE,   // 발급 중단/비활성
+    EXPIRED     // 만료
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/type/CouponUserStatus.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/type/CouponUserStatus.java
@@ -1,0 +1,8 @@
+package dukku.semicolon.boundedContext.coupon.entity.type;
+
+public enum CouponUserStatus {
+    AVAILABLE,
+    USED,
+    EXPIRED,
+    LOCKED
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/type/IssueResult.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/entity/type/IssueResult.java
@@ -1,0 +1,9 @@
+package dukku.semicolon.boundedContext.coupon.entity.type;
+
+public enum IssueResult {
+    SUCCESS,
+    SOLD_OUT,
+    DUPLICATE,
+    INACTIVE,
+    ERROR
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/in/AdminCouponController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/in/AdminCouponController.java
@@ -1,0 +1,52 @@
+package dukku.semicolon.boundedContext.coupon.in;
+
+import dukku.semicolon.boundedContext.coupon.app.command.CouponFacade;
+import dukku.semicolon.boundedContext.coupon.app.query.CouponQueryFacade;
+import dukku.semicolon.shared.coupon.dto.CouponCreateRequest;
+import dukku.semicolon.shared.coupon.dto.CouponResponse;
+import dukku.semicolon.shared.coupon.dto.CouponUpdateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminCouponController {
+    private final CouponQueryFacade couponQueryFacade;
+    private final CouponFacade couponFacade;
+
+    // 쿠폰 생성 (관리자)
+    @PostMapping("/coupons")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CouponResponse createCoupon(@RequestBody @Valid CouponCreateRequest request) {
+        return couponFacade.createCoupon(request);
+    }
+
+    // 쿠폰 초안 수정 (관리자)
+    @PutMapping("/coupons/{couponUuid}/draft")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateDraft(
+            @PathVariable UUID couponUuid,
+            @RequestBody @Valid CouponUpdateRequest request
+    ) {
+        couponFacade.updateDraft(couponUuid, request);
+    }
+
+    // 쿠폰 활성화 (관리자)
+    @PostMapping("/coupons/{couponUuid}/activate")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void activate(@PathVariable UUID couponUuid) {
+        couponFacade.activateCoupon(couponUuid);
+    }
+
+    // 전체 쿠폰 리스트 (관리자)
+    @GetMapping("/coupons")
+    public List<CouponResponse> getAllCoupons() {
+        return couponQueryFacade.getAllCoupons();
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/in/CouponController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/in/CouponController.java
@@ -1,0 +1,79 @@
+package dukku.semicolon.boundedContext.coupon.in;
+
+import dukku.common.global.UserUtil;
+import dukku.semicolon.boundedContext.coupon.app.command.CouponFacade;
+import dukku.semicolon.boundedContext.coupon.app.query.CouponQueryFacade;
+import dukku.semicolon.shared.coupon.dto.CouponCreateRequest;
+import dukku.semicolon.shared.coupon.dto.CouponResponse;
+import dukku.semicolon.shared.coupon.dto.CouponUpdateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/coupons")
+public class CouponController {
+    private final CouponQueryFacade couponQueryFacade;
+    private final CouponFacade couponFacade;
+
+    // 쿠폰 생성 (관리자)
+    @PostMapping("/admin")
+    @ResponseStatus(HttpStatus.CREATED)
+    public CouponResponse createCoupon(@RequestBody @Valid CouponCreateRequest request) {
+        return couponFacade.createCoupon(request);
+    }
+
+    // 쿠폰 초안 수정 (관리자)
+    @PutMapping("/admin/{couponUuid}/draft")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateDraft(
+            @PathVariable UUID couponUuid,
+            @RequestBody @Valid CouponUpdateRequest request
+    ) {
+        couponFacade.updateDraft(couponUuid, request);
+    }
+
+    // 쿠폰 활성화 (관리자)
+    @PostMapping("/admin/{couponUuid}/activate")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void activate(@PathVariable UUID couponUuid) {
+        couponFacade.activate(couponUuid);
+    }
+
+    // 쿠폰 발급 (유저)
+    @PostMapping("/{couponUuid}/issue")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void issueCoupon(@PathVariable UUID couponUuid) {
+        couponFacade.issueCoupon(UserUtil.getUserId(), couponUuid);
+    }
+
+    // 쿠폰 사용 (유저)
+    @PostMapping("/{couponUuid}/use")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void useCoupon(@PathVariable UUID couponUuid) {
+        couponFacade.useCoupon(UserUtil.getUserId(), couponUuid);
+    }
+
+    // 발급 가능한 쿠폰 리스트 (유저)
+    @GetMapping("/issuable")
+    public List<CouponResponse> getIssuableCoupons() {
+        return couponQueryFacade.getIssuableCoupons(UserUtil.getUserId());
+    }
+
+    // 내가 보유한 쿠폰 리스트 (유저)
+    @GetMapping("/me")
+    public List<CouponResponse> getMyCoupons() {
+        return couponQueryFacade.getMyCoupons(UserUtil.getUserId());
+    }
+
+    // 전체 쿠폰 리스트 (관리자)
+    @GetMapping("/admin")
+    public List<CouponResponse> getAllCoupons() {
+        return couponQueryFacade.getAllCoupons();
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/in/CouponController.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/in/CouponController.java
@@ -3,10 +3,7 @@ package dukku.semicolon.boundedContext.coupon.in;
 import dukku.common.global.UserUtil;
 import dukku.semicolon.boundedContext.coupon.app.command.CouponFacade;
 import dukku.semicolon.boundedContext.coupon.app.query.CouponQueryFacade;
-import dukku.semicolon.shared.coupon.dto.CouponCreateRequest;
 import dukku.semicolon.shared.coupon.dto.CouponResponse;
-import dukku.semicolon.shared.coupon.dto.CouponUpdateRequest;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -20,30 +17,6 @@ import java.util.UUID;
 public class CouponController {
     private final CouponQueryFacade couponQueryFacade;
     private final CouponFacade couponFacade;
-
-    // 쿠폰 생성 (관리자)
-    @PostMapping("/admin")
-    @ResponseStatus(HttpStatus.CREATED)
-    public CouponResponse createCoupon(@RequestBody @Valid CouponCreateRequest request) {
-        return couponFacade.createCoupon(request);
-    }
-
-    // 쿠폰 초안 수정 (관리자)
-    @PutMapping("/admin/{couponUuid}/draft")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateDraft(
-            @PathVariable UUID couponUuid,
-            @RequestBody @Valid CouponUpdateRequest request
-    ) {
-        couponFacade.updateDraft(couponUuid, request);
-    }
-
-    // 쿠폰 활성화 (관리자)
-    @PostMapping("/admin/{couponUuid}/activate")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void activate(@PathVariable UUID couponUuid) {
-        couponFacade.activate(couponUuid);
-    }
 
     // 쿠폰 발급 (유저)
     @PostMapping("/{couponUuid}/issue")
@@ -69,11 +42,5 @@ public class CouponController {
     @GetMapping("/me")
     public List<CouponResponse> getMyCoupons() {
         return couponQueryFacade.getMyCoupons(UserUtil.getUserId());
-    }
-
-    // 전체 쿠폰 리스트 (관리자)
-    @GetMapping("/admin")
-    public List<CouponResponse> getAllCoupons() {
-        return couponQueryFacade.getAllCoupons();
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/out/CouponIssueLogRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/out/CouponIssueLogRepository.java
@@ -1,0 +1,7 @@
+package dukku.semicolon.boundedContext.coupon.out;
+
+import dukku.semicolon.boundedContext.coupon.entity.CouponIssueLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponIssueLogRepository extends JpaRepository<CouponIssueLog, Integer> {
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/out/CouponRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/out/CouponRepository.java
@@ -1,0 +1,31 @@
+package dukku.semicolon.boundedContext.coupon.out;
+
+import dukku.semicolon.boundedContext.coupon.entity.Coupon;
+import dukku.semicolon.boundedContext.coupon.entity.type.CouponStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CouponRepository extends JpaRepository<Coupon, Integer> {
+    Optional<Coupon> findByUuid(UUID couponUuid);
+
+    @Query("""
+            select c
+            from Coupon c
+            where c.status = 'ACTIVE'
+              and c.validFrom <= :now
+              and c.issuedQuantity < c.totalQuantity
+              and not exists (
+                  select 1 from CouponUser cu
+                  where cu.userUuid = :userUuid
+                    and cu.coupon = c
+              )
+            """)
+    List<Coupon> findIssuableCoupons(UUID userUuid, LocalDateTime now);
+
+    List<Coupon> findByStatus(CouponStatus status);
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/out/CouponUserRepository.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/coupon/out/CouponUserRepository.java
@@ -1,0 +1,17 @@
+package dukku.semicolon.boundedContext.coupon.out;
+
+import dukku.semicolon.boundedContext.coupon.entity.CouponUser;
+import dukku.semicolon.boundedContext.coupon.entity.type.CouponUserStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CouponUserRepository extends JpaRepository<CouponUser, Integer> {
+    boolean existsByUserUuidAndCoupon_Uuid(UUID userUuid, UUID couponUuid);
+
+    Optional<CouponUser> findByUserUuidAndCoupon_Uuid(UUID userUuid, UUID couponUuid);
+
+    List<CouponUser> findByUserUuidAndStatus(UUID userUuid, CouponUserStatus status);
+}

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/cqrs/DeleteProductSyncUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/cqrs/DeleteProductSyncUseCase.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class DeleteProductSyncUseCase {
-    private final ProductSearchRepository  productSearchRepository;
+    private final ProductSearchRepository productSearchRepository;
 
     @Transactional(readOnly = true)
     public void deletedProductToElasticsearch(int productId) {

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/cqrs/ProductSyncFacade.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/cqrs/ProductSyncFacade.java
@@ -4,8 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
-
 @Component
 @RequiredArgsConstructor
 public class ProductSyncFacade {

--- a/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/cart/CreateCartUseCase.java
+++ b/semicolon/src/main/java/dukku/semicolon/boundedContext/product/app/usecase/cart/CreateCartUseCase.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @Service

--- a/semicolon/src/main/java/dukku/semicolon/global/CategoryInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/CategoryInitData.java
@@ -6,11 +6,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.transaction.annotation.Transactional;
 
 @Configuration
 @RequiredArgsConstructor
+@Profile("release")
 @Order(1)
 public class CategoryInitData {
 

--- a/semicolon/src/main/java/dukku/semicolon/global/CategoryInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/CategoryInitData.java
@@ -6,13 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.transaction.annotation.Transactional;
 
 @Configuration
 @RequiredArgsConstructor
-@Profile("release")
 @Order(1)
 public class CategoryInitData {
 

--- a/semicolon/src/main/java/dukku/semicolon/global/CouponInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/CouponInitData.java
@@ -1,0 +1,51 @@
+package dukku.semicolon.global;
+
+import dukku.semicolon.boundedContext.coupon.entity.Coupon;
+import dukku.semicolon.boundedContext.coupon.entity.type.CouponStatus;
+import dukku.semicolon.boundedContext.coupon.out.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+@Order(1)
+public class CouponInitData {
+
+    @Bean
+    public CommandLineRunner initCoupons(CouponRepository couponRepository) {
+        return new CommandLineRunner() {
+            @Override
+            @Transactional
+            public void run(String... args) {
+                UUID couponUuid = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+                if (couponRepository.findByUuid(couponUuid).isPresent()) {
+                    log.info("테스트 쿠폰이 이미 존재하여 초기화를 건너뜁니다.");
+                    return;
+                }
+
+                Coupon coupon = Coupon.builder()
+                        .uuid(couponUuid)
+                        .couponName("선착순 배송비 할인 쿠폰")
+                        .discountAmount(3000)
+                        .minimumOrderAmount(0)
+                        .validFrom(LocalDateTime.now().minusMinutes(1))
+                        .status(CouponStatus.ACTIVE)
+                        .totalQuantity(100)
+                        .build();
+
+                couponRepository.save(coupon);
+                log.info("✅ 테스트용 선착순 쿠폰 생성 완료");
+            }
+        };
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/global/CouponInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/CouponInitData.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-@Order(1)
+@Order(4)
 public class CouponInitData {
 
     @Bean

--- a/semicolon/src/main/java/dukku/semicolon/global/ProductInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/ProductInitData.java
@@ -3,7 +3,10 @@ package dukku.semicolon.global;
 import dukku.common.shared.product.type.ConditionStatus;
 import dukku.common.shared.product.type.SaleStatus;
 import dukku.common.shared.product.type.VisibilityStatus;
-import dukku.semicolon.boundedContext.product.entity.*;
+import dukku.semicolon.boundedContext.product.entity.Category;
+import dukku.semicolon.boundedContext.product.entity.Product;
+import dukku.semicolon.boundedContext.product.entity.ProductSeller;
+import dukku.semicolon.boundedContext.product.entity.ProductUser;
 import dukku.semicolon.boundedContext.product.entity.query.ProductDocument;
 import dukku.semicolon.boundedContext.product.out.*;
 import dukku.semicolon.boundedContext.user.app.user.RegisterUserUseCase;
@@ -15,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +29,7 @@ import java.util.*;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
+@Profile("release")
 @Order(2)
 public class ProductInitData {
 
@@ -219,7 +224,7 @@ public class ProductInitData {
     }
 
     private void createSeller(String sId, String uId, String nickname, double rating, String intro, int sales,
-            int active) {
+                              int active) {
         // [수정] 직접 생성 -> UseCase 사용 (이메일 인증 Mocking 포함)
         String email = uId + "@dukku.shop";
         String password = "TestUser123!";

--- a/semicolon/src/main/java/dukku/semicolon/global/ProductInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/ProductInitData.java
@@ -18,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +28,6 @@ import java.util.*;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-@Profile("release")
 @Order(2)
 public class ProductInitData {
 

--- a/semicolon/src/main/java/dukku/semicolon/global/ProductInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/ProductInitData.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +29,7 @@ import java.util.*;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
+@Profile("release")
 @Order(2)
 public class ProductInitData {
 

--- a/semicolon/src/main/java/dukku/semicolon/global/SystemDepositInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/SystemDepositInitData.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -25,6 +26,7 @@ import java.util.UUID;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
+@Profile("release")
 @Order(3) // 다른 2개의 초기화 코드가 실행된 후 실행
 public class SystemDepositInitData {
 

--- a/semicolon/src/main/java/dukku/semicolon/global/SystemDepositInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/SystemDepositInitData.java
@@ -7,15 +7,16 @@ import dukku.semicolon.boundedContext.user.entity.User;
 import dukku.semicolon.boundedContext.user.entity.type.Role;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.UUID;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 /**
  * 시스템 예치금 관리를 위한 admin 계정 생성
@@ -25,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
+@Profile("release")
 @Order(3) // 다른 2개의 초기화 코드가 실행된 후 실행
 public class SystemDepositInitData {
 

--- a/semicolon/src/main/java/dukku/semicolon/global/SystemDepositInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/SystemDepositInitData.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -26,7 +25,6 @@ import java.util.UUID;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-@Profile("release")
 @Order(3) // 다른 2개의 초기화 코드가 실행된 후 실행
 public class SystemDepositInitData {
 

--- a/semicolon/src/main/java/dukku/semicolon/global/UserInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/UserInitData.java
@@ -10,8 +10,8 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
@@ -28,31 +28,42 @@ public class UserInitData {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final AuthTokenIssuer authTokenIssuer;
+    private final Environment env;
 
     @Bean
     public CommandLineRunner initUsers() {
-        return new CommandLineRunner() {
-            @Override
-            @Transactional
-            public void run(String... args) {
-                if (userRepository.count() >= 1000) {
-                    log.info("유저 데이터가 이미 존재하여 초기화를 건너뜁니다.");
-                    return;
+        return args -> {
+            String[] activeProfiles = env.getActiveProfiles();
+            boolean isDev = false;
+            for (String profile : activeProfiles) {
+                if (profile.equals("dev")) {
+                    isDev = true;
+                    break;
                 }
+            }
 
-                List<User> users = new ArrayList<>();
+            int userCount = isDev ? 1000 : 10; // dev=1000, release=10
+            boolean generateTokens = isDev;    // dev에서만 tokens.txt 생성
 
-                // 관리자
-                users.add(createUser("admin@semicolon.com", "Admin123!", "admin", Role.ADMIN));
+            if (userRepository.count() >= userCount) {
+                log.info("유저 데이터가 이미 존재하여 초기화를 건너뜁니다.");
+                return;
+            }
 
-                // 테스트 유저 1,000명
-                for (int i = 1; i <= 1000; i++) {
-                    users.add(createUser("user" + i + "@semicolon.com", "User123!", "user" + i, Role.USER));
-                }
+            List<User> users = new ArrayList<>();
 
-                List<User> savedUsers = userRepository.saveAll(users);
-                log.info("✅ 1001명의 유저 생성 완료");
+            // 관리자
+            users.add(createUser("admin@semicolon.com", "Admin123!", "admin", Role.ADMIN));
 
+            // 일반 유저
+            for (int i = 1; i <= userCount; i++) {
+                users.add(createUser("user" + i + "@semicolon.com", "User123!", "user" + i, Role.USER));
+            }
+
+            List<User> savedUsers = userRepository.saveAll(users);
+            log.info("✅ {}명의 유저 생성 완료", userCount + 1);
+
+            if (generateTokens) {
                 saveTokensToFile(savedUsers);
             }
         };

--- a/semicolon/src/main/java/dukku/semicolon/global/UserInitData.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/UserInitData.java
@@ -3,7 +3,9 @@ package dukku.semicolon.global;
 import dukku.semicolon.boundedContext.user.entity.User;
 import dukku.semicolon.boundedContext.user.entity.type.Role;
 import dukku.semicolon.boundedContext.user.out.UserRepository;
+import dukku.semicolon.global.auth.jwt.AuthTokenIssuer;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,8 +13,13 @@ import org.springframework.core.annotation.Order;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Configuration
 @RequiredArgsConstructor
 @Order(0)
@@ -20,26 +27,35 @@ public class UserInitData {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final AuthTokenIssuer authTokenIssuer;
 
     @Bean
     public CommandLineRunner initUsers() {
-        return args -> initUserData();
-    }
+        return new CommandLineRunner() {
+            @Override
+            @Transactional
+            public void run(String... args) {
+                if (userRepository.count() >= 1000) {
+                    log.info("유저 데이터가 이미 존재하여 초기화를 건너뜁니다.");
+                    return;
+                }
 
-    @Transactional
-    public void initUserData() {
-        if (userRepository.count() > 0) {
-            return;
-        }
+                List<User> users = new ArrayList<>();
 
-        List<User> users = List.of(
-                createUser("admin@semicolon.com", "Admin123!", "admin", Role.ADMIN),
-                createUser("user1@semicolon.com", "User123!", "user1", Role.USER),
-                createUser("user2@semicolon.com", "User123!", "user2", Role.USER),
-                createUser("user3@semicolon.com", "User123!", "user3", Role.USER)
-        );
+                // 관리자
+                users.add(createUser("admin@semicolon.com", "Admin123!", "admin", Role.ADMIN));
 
-        userRepository.saveAll(users);
+                // 테스트 유저 1,000명
+                for (int i = 1; i <= 1000; i++) {
+                    users.add(createUser("user" + i + "@semicolon.com", "User123!", "user" + i, Role.USER));
+                }
+
+                List<User> savedUsers = userRepository.saveAll(users);
+                log.info("✅ 1001명의 유저 생성 완료");
+
+                saveTokensToFile(savedUsers);
+            }
+        };
     }
 
     private User createUser(String email, String rawPassword, String nickname, Role role) {
@@ -49,5 +65,18 @@ public class UserInitData {
                 .nickname(nickname)
                 .role(role)
                 .build();
+    }
+
+    private void saveTokensToFile(List<User> savedUsers) {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter("tokens.txt"))) {
+            for (User user : savedUsers) {
+                String accessToken = authTokenIssuer.createAccessToken(user.getUuid(), user.getRole().name());
+                writer.write(user.getEmail() + "," + accessToken);
+                writer.newLine();
+            }
+            log.info("✅ tokens.txt 생성 완료");
+        } catch (IOException e) {
+            log.error("토큰 파일 저장 실패", e);
+        }
     }
 }

--- a/semicolon/src/main/java/dukku/semicolon/global/auth/controller/AuthController.java
+++ b/semicolon/src/main/java/dukku/semicolon/global/auth/controller/AuthController.java
@@ -3,7 +3,6 @@ package dukku.semicolon.global.auth.controller;
 import dukku.semicolon.global.auth.dto.LoginRequest;
 import dukku.semicolon.global.auth.dto.TokenResponse;
 import dukku.semicolon.global.auth.service.AuthService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/dto/CouponCreateRequest.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/dto/CouponCreateRequest.java
@@ -1,0 +1,24 @@
+package dukku.semicolon.shared.coupon.dto;
+
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDateTime;
+
+public record CouponCreateRequest(
+        @NotBlank(message = "쿠폰명은 필수입니다.")
+        @Size(max = 100, message = "쿠폰명은 100자 이하여야 합니다.")
+        String couponName,
+
+        @Positive(message = "할인 금액은 0보다 커야 합니다.")
+        int discountAmount,
+
+        @PositiveOrZero(message = "최소 주문 금액은 0 이상이어야 합니다.")
+        int minimumOrderAmount,
+
+        @NotNull(message = "쿠폰 시작일은 필수입니다.")
+        LocalDateTime validFrom,
+
+        @Positive(message = "총 발급 수량은 1 이상이어야 합니다.")
+        int totalQuantity
+) {
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/dto/CouponResponse.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/dto/CouponResponse.java
@@ -1,0 +1,33 @@
+package dukku.semicolon.shared.coupon.dto;
+
+import dukku.semicolon.boundedContext.coupon.entity.Coupon;
+import dukku.semicolon.boundedContext.coupon.entity.type.CouponStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CouponResponse(
+        UUID uuid,
+        String couponName,
+        int discountAmount,
+        int minimumOrderAmount,
+        LocalDateTime validFrom,
+        LocalDateTime createdAt,
+        CouponStatus status,
+        int totalQuantity,
+        int issuedQuantity
+) {
+    public static CouponResponse from(Coupon coupon) {
+        return new CouponResponse(
+                coupon.getUuid(),
+                coupon.getCouponName(),
+                coupon.getDiscountAmount(),
+                coupon.getMinimumOrderAmount(),
+                coupon.getValidFrom(),
+                coupon.getCreatedAt(),
+                coupon.getStatus(),
+                coupon.getTotalQuantity(),
+                coupon.getIssuedQuantity()
+        );
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/dto/CouponUpdateRequest.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/dto/CouponUpdateRequest.java
@@ -1,0 +1,21 @@
+package dukku.semicolon.shared.coupon.dto;
+
+import jakarta.validation.constraints.*;
+
+import java.time.LocalDateTime;
+
+public record CouponUpdateRequest(
+        @NotBlank(message = "쿠폰명은 필수입니다.")
+        @Size(max = 100, message = "쿠폰명은 100자 이하여야 합니다.")
+        String couponName,
+
+        @Positive(message = "할인 금액은 0보다 커야 합니다.")
+        int discountAmount,
+
+        @PositiveOrZero(message = "최소 주문 금액은 0 이상이어야 합니다.")
+        int minimumOrderAmount,
+
+        @NotNull(message = "쿠폰 시작일은 필수입니다.")
+        LocalDateTime validFrom
+) {
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponActivationNotAllowedException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponActivationNotAllowedException.java
@@ -1,0 +1,10 @@
+package dukku.semicolon.shared.coupon.exception;
+
+import dukku.common.global.exception.ConflictException;
+
+public class CouponActivationNotAllowedException extends ConflictException {
+
+    public CouponActivationNotAllowedException() {
+        super("쿠폰은 DRAFT 상태에서만 활성화할 수 있습니다.");
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponAlreadyExistsException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package dukku.semicolon.shared.coupon.exception;
+
+import dukku.common.global.exception.ConflictException;
+
+public class CouponAlreadyExistsException extends ConflictException {
+    public CouponAlreadyExistsException() {
+        super("이미 쿠폰을 발급받은 유저입니다.");
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponDeactivationNotAllowedException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponDeactivationNotAllowedException.java
@@ -1,0 +1,10 @@
+package dukku.semicolon.shared.coupon.exception;
+
+import dukku.common.global.exception.ConflictException;
+
+public class CouponDeactivationNotAllowedException extends ConflictException {
+
+    public CouponDeactivationNotAllowedException() {
+        super("쿠폰은 ACTIVE 상태에서만 비활성화할 수 있습니다.");
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponIssueNotAllowedException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponIssueNotAllowedException.java
@@ -1,0 +1,10 @@
+package dukku.semicolon.shared.coupon.exception;
+
+import dukku.common.global.exception.ConflictException;
+
+public class CouponIssueNotAllowedException extends ConflictException {
+
+    public CouponIssueNotAllowedException() {
+        super("활성화된 쿠폰만 발급할 수 있습니다.");
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponNotFoundException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponNotFoundException.java
@@ -1,0 +1,9 @@
+package dukku.semicolon.shared.coupon.exception;
+
+import dukku.common.global.exception.NotFoundException;
+
+public class CouponNotFoundException extends NotFoundException {
+    public CouponNotFoundException() {
+        super("존재하지 않는 쿠폰입니다.");
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponSoldOutException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponSoldOutException.java
@@ -1,0 +1,9 @@
+package dukku.semicolon.shared.coupon.exception;
+
+import dukku.common.global.exception.ConflictException;
+
+public class CouponSoldOutException extends ConflictException {
+    public CouponSoldOutException() {
+        super("쿠폰 수량이 모두 소진되었습니다.");
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponUpdateNotAllowedException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponUpdateNotAllowedException.java
@@ -1,0 +1,9 @@
+package dukku.semicolon.shared.coupon.exception;
+
+import dukku.common.global.exception.ConflictException;
+
+public class CouponUpdateNotAllowedException extends ConflictException {
+    public CouponUpdateNotAllowedException() {
+        super("DRAFT 상태에서만 수정 가능합니다.");
+    }
+}

--- a/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponUserNotFoundException.java
+++ b/semicolon/src/main/java/dukku/semicolon/shared/coupon/exception/CouponUserNotFoundException.java
@@ -1,0 +1,9 @@
+package dukku.semicolon.shared.coupon.exception;
+
+import dukku.common.global.exception.NotFoundException;
+
+public class CouponUserNotFoundException extends NotFoundException {
+    public CouponUserNotFoundException() {
+        super("쿠폰 발급 기록이 없습니다.");
+    }
+}


### PR DESCRIPTION
# PR 제목
[Coupon] 쿠폰 발급/사용 기능 및 부하 테스트 구현

## 개요
이번 PR에서 쿠폰 서비스의 **발급/사용 기능 구현과 동시성 테스트 기반 시나리오 설계**를 진행했습니다.  
동시 발급 환경에서 서비스 안정성을 검증하고, 테스트용 유저와 토큰 발급 스크립트를 추가했습니다.

## 상세 내용
- Coupon, CouponUser 도메인 상태 전이 로직 구현
- CouponFacade, CouponQueryFacade 작성
- IssueCouponUseCase 추가
- 테스트 유저 1000명과 JWT 토큰 초기화 코드 작성
- K6 부하 테스트 스크립트 작성 (tokens.txt 활용)
- 시나리오1: 100 쿠폰, 1000 유저 동시 발급 테스트 수행
## 부하 테스트 결과 보고서 (Scenario 1)

### 1. 테스트 개요
- **목적**: 초기 설계 구조에서의 쿠폰 동시 발급 정합성 검증
- **대상**: 쿠폰 100개 / 1,000명 동시 요청 (1,000 VUs)
- **도구**: k6, PostgreSQL

### 2. 테스트 결과 요약 (5회 반복)
| 회차 | 성공 응답(200) | 실패 응답(409) | DB 수량(issued_quantity) | DB 이력(coupon_users) |
| :--- | :---: | :---: | :---: | :---: |
| 1차 | 234건 | 766건 | 53 | 234 |
| 2차 | 367건 | 633건 | 75 | 367 |
| 3차 | 157건 | 843건 | 31 | 157 |
| 4차 | 159건 | 841건 | 32 | 159 |
| 5차 | 200건 | 800건 | 41 | 200 |
| **목표** | **100건** | **900건** | **100** | **100** |

### 3. 주요 문제 분석

#### ❌ 현상 1: 초과 발급 (Over-issuance)
애플리케이션 계층에서 수량을 체크하는 로직이 동시성 환경에서 무력화되었습니다. 여러 트랜잭션이 아직 커밋되지 않은 데이터를 동시에 읽어 `issuedQuantity < totalQuantity` 조건을 동시에 통과했습니다.



#### ❌ 현상 2: 수량 업데이트 누락 (Lost Update)
실제 발급된 유저(`coupon_users`) 수보다 DB의 `issued_quantity` 카운트가 낮게 기록되었습니다. 이는 두 개 이상의 트랜잭션이 동시에 값을 수정할 때, 나중에 커밋된 트랜잭션이 이전 수정분을 덮어쓰는(Overwrite) 현상 때문입니다.



### 4. 기술적 결론
- 현재의 **"조회 후 수정(Select-then-Update)"** 방식은 고부하 환경에서 정합성을 전혀 보장할 수 없음.
- 데이터 무결성을 위해 DB 수준의 원자적 연산이나 Lock 메커니즘 도입이 필수적임.

### 5. 차기 개선안 (Scenario 2)
- **Atomic Update 도입**: DB Native Query를 사용하여 수량 체크와 업데이트를 단일 연산으로 처리.
- **결과 비교**: 동일 조건(1000 VUs) 테스트 시 `issued_quantity`와 `coupon_users`가 정확히 100을 유지하는지 검증 예정.

---

## PR 유형 (라벨)
- [x] 새로운 기능 추가 (Feat)
- [x] 테스트 추가/수정 (Test)
- [x] 기타 작업 (Chore)

## PR Checklist
- [x] 커밋 메시지가 컨벤션에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?
- [x] 전체 흐름이 자연스러운가? (컨트롤러 → 서비스 → 도메인)
- [x] 메소드 역할과 책임이 적절하게 분리되었는가?
- [x] 어노테이션 사용이 목적에 맞는가? (`@Transactional`, `@Validated`, `@RequestBody` 등)
- [x] 기존 기능에 영향을 주지 않는가?
- [x] 불필요한 코드/로그가 남아있지 않은가?

## 리뷰어에게 요청 사항
