### PR TITLE
[Payment] 컨벤션 반영 개선사항 리팩토링 적용 #54 #56 #174

### DIFF
--- a/common/src/main/java/dukku/common/shared/deposit/event/DepositRefundFailedEvent.java
+++ b/common/src/main/java/dukku/common/shared/deposit/event/DepositRefundFailedEvent.java
@@ -12,7 +12,7 @@ import java.util.UUID;
  * 환불 후 예치금 롤백이 실패했을 때 발행.
  */
 public record DepositRefundFailedEvent(
-        UUID refundId,
+        UUID refundUuid,
         UUID orderUuid,
         UUID paymentUuid,
         UUID userUuid,

--- a/common/src/main/java/dukku/common/shared/deposit/event/DepositRefundedEvent.java
+++ b/common/src/main/java/dukku/common/shared/deposit/event/DepositRefundedEvent.java
@@ -11,7 +11,7 @@ import java.util.UUID;
  * 알림 서비스 등에서 사용.
  */
 public record DepositRefundedEvent(
-        UUID refundId,
+        UUID refundUuid,
         UUID paymentUuid,
         UUID orderUuid,
         UUID userUuid,

--- a/common/src/main/java/dukku/common/shared/payment/dto/PaymentOrderItemDto.java
+++ b/common/src/main/java/dukku/common/shared/payment/dto/PaymentOrderItemDto.java
@@ -24,5 +24,5 @@ public class PaymentOrderItemDto {
     private String productName;
     private Long price;
     private Long paymentCoupon;
-    private Long paymentDeposit; // 2026-01-24 추가
+    private Long paymentDeposit;
 }

--- a/common/src/main/java/dukku/common/shared/payment/event/PaymentSuccessEvent.java
+++ b/common/src/main/java/dukku/common/shared/payment/event/PaymentSuccessEvent.java
@@ -13,8 +13,7 @@ import java.util.UUID;
 import dukku.common.global.event.DomainEvent;
 
 public record PaymentSuccessEvent(
-        UUID paymentUuid, // 2026-01-24 추가
-        UUID paymentId, // 2026-01-24 추가
+        UUID paymentUuid,
         UUID orderUuid,
         Long amount,
         Long pgAmount, // pg 결제 금액

--- a/common/src/main/java/dukku/common/shared/payment/event/RefundCompletedEvent.java
+++ b/common/src/main/java/dukku/common/shared/payment/event/RefundCompletedEvent.java
@@ -12,14 +12,13 @@ import java.util.UUID;
 import dukku.common.global.event.DomainEvent;
 
 public record RefundCompletedEvent(
-        UUID refundId,
-        UUID paymentId,
+        UUID refundUuid,
+        UUID paymentUuid,
         UUID orderUuid,
         Long refundAmount,
         Long refundDepositAmount, // 환불된 예치금
         UUID userUuid,
-        LocalDateTime occurredAt
-) implements DomainEvent {
+        LocalDateTime occurredAt) implements DomainEvent {
     @Override
     public String getTopic() {
         return "payment.refund-completed";

--- a/common/src/main/java/dukku/common/shared/payment/event/RefundRequestedEvent.java
+++ b/common/src/main/java/dukku/common/shared/payment/event/RefundRequestedEvent.java
@@ -12,14 +12,13 @@ import java.util.UUID;
  * 예치금 환불이 필요한 환불 건에 대해 사가를 시작할 때 발행된다.
  */
 public record RefundRequestedEvent(
-        UUID refundId,
-        UUID paymentId,
+        UUID refundUuid,
+        UUID paymentUuid,
         UUID orderUuid,
         Long refundAmount,
         Long refundDepositAmount,
         UUID userUuid,
-        LocalDateTime occurredAt
-) implements DomainEvent {
+        LocalDateTime occurredAt) implements DomainEvent {
 
     @Override
     public String getTopic() {

--- a/deposit/build.gradle
+++ b/deposit/build.gradle
@@ -15,5 +15,4 @@ dependencies {
     // === Test ===
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }

--- a/deposit/src/main/java/dukku/deposit/boundedContext/deposit/in/DepositEventListener.java
+++ b/deposit/src/main/java/dukku/deposit/boundedContext/deposit/in/DepositEventListener.java
@@ -45,13 +45,13 @@ public class DepositEventListener {
      */
     @KafkaListener(topics = "payment.refund-requested", groupId = "${spring.application.name}-group")
     public void handle(RefundRequestedEvent event) {
-        // paymentId 전달 (예치금 롤백 실패 연계)
+        // paymentUuid 전달 (예치금 롤백 실패 연계)
         depositFacade.refundDeposit(
                 event.userUuid(),
                 event.refundDepositAmount(),
                 event.orderUuid(),
-                event.paymentId(),
-                event.refundId());
+                event.paymentUuid(),
+                event.refundUuid());
     }
 
     /**

--- a/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/DeductDepositForPaymentUseCaseKafkaIntegrationTest.java
+++ b/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/DeductDepositForPaymentUseCaseKafkaIntegrationTest.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
         "spring.application.name=deposit-it",
@@ -107,7 +108,8 @@ class DeductDepositForPaymentUseCaseKafkaIntegrationTest {
             assertThat(payload.get("retryable").asBoolean()).isFalse();
 
             assertThat(depositRepository.findByUserUuid(userUuid).orElseThrow().getBalance()).isEqualTo(1000L);
-            assertThat(depositRepository.findByUserUuid(SystemDepositInitData.SYSTEM_USER_UUID).orElseThrow().getBalance())
+            assertThat(
+                    depositRepository.findByUserUuid(SystemDepositInitData.SYSTEM_USER_UUID).orElseThrow().getBalance())
                     .isEqualTo(1_000_000L);
             assertThat(historyRepository.findByUserUuidOrderByCreatedAtDesc(userUuid)).isEmpty();
             assertThat(historyRepository.findByUserUuidOrderByCreatedAtDesc(SystemDepositInitData.SYSTEM_USER_UUID))
@@ -156,6 +158,6 @@ class DeductDepositForPaymentUseCaseKafkaIntegrationTest {
             }
         }
 
-        throw new IllegalStateException("No record found for topic: " + topic);
+        return fail("No record found for topic: " + topic);
     }
 }

--- a/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/DepositMoneyFlowIntegrationTest.java
+++ b/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/DepositMoneyFlowIntegrationTest.java
@@ -145,7 +145,7 @@ class DepositMoneyFlowIntegrationTest {
         verify(eventPublisher).publish(eventCaptor.capture());
         assertThat(eventCaptor.getValue()).isInstanceOf(DepositRefundFailedEvent.class);
         DepositRefundFailedEvent event = (DepositRefundFailedEvent) eventCaptor.getValue();
-        assertThat(event.refundId()).isEqualTo(refundUuid);
+        assertThat(event.refundUuid()).isEqualTo(refundUuid);
         assertThat(event.userUuid()).isEqualTo(userUuid);
         assertThat(event.amount()).isEqualTo(3000L);
     }

--- a/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/RefundDepositUseCaseHappyPathTest.java
+++ b/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/RefundDepositUseCaseHappyPathTest.java
@@ -59,7 +59,7 @@ class RefundDepositUseCaseHappyPathTest {
 
         assertThat(eventCaptor.getValue()).isInstanceOf(DepositRefundedEvent.class);
         DepositRefundedEvent event = (DepositRefundedEvent) eventCaptor.getValue();
-        assertThat(event.refundId()).isEqualTo(refundUuid);
+        assertThat(event.refundUuid()).isEqualTo(refundUuid);
         assertThat(event.paymentUuid()).isEqualTo(paymentUuid);
         assertThat(event.orderUuid()).isEqualTo(orderUuid);
         assertThat(event.userUuid()).isEqualTo(userUuid);

--- a/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/RefundDepositUseCaseKafkaIntegrationTest.java
+++ b/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/RefundDepositUseCaseKafkaIntegrationTest.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
         "spring.application.name=deposit-it",
@@ -83,9 +84,9 @@ class RefundDepositUseCaseKafkaIntegrationTest {
     }
 
     @Test
-    @DisplayName("?섎텋 濡ㅻ갚 ??Kafka??deposit.refunded ?대깽?멸? 諛쒗뻾?섍퀬 ?ъ슜???덉튂湲덉씠 利앷??쒕떎")
+    @DisplayName("환불 롤백 시 Kafka에 deposit.refunded 이벤트가 발행되고 사용자 예치금이 증가한다")
     void refundMovesSysAndUser() throws Exception {
-        // given: ?좎? ?덉튂湲?5,000???곹깭瑜?留뚮뱺??
+        // given: 사용자 예치금이 5,000원인 상태를 만든다.
         UUID userUuid = UUID.randomUUID();
         depositRepository.save(Deposit.builder()
                 .userUuid(userUuid)
@@ -104,26 +105,27 @@ class RefundDepositUseCaseKafkaIntegrationTest {
         UUID refundUuid = UUID.randomUUID();
         Long refundDepositAmount = 3000L;
 
-        // when: refundDepositUseCase瑜??ㅽ뻾?댁꽌 refund ?좎뒪耳?댁뒪瑜?泥섎━?쒕떎.
+        // when: refundDepositUseCase를 실행해 환불 유스케이스를 처리한다.
         refundDepositUseCase.execute(userUuid, refundDepositAmount, orderUuid, paymentUuid, refundUuid);
 
         Consumer<String, String> consumer = createConsumer(DEPOSIT_REFUNDED_TOPIC);
         try {
-            // then: deposit.refunded ?대깽?멸? Kafka濡?諛쒗뻾?섍퀬 payload媛 湲곕? 媛믨낵 ?쇱튂?쒕떎.
+            // then: deposit.refunded 이벤트가 Kafka로 발행되고 payload가 기대 값과 일치한다.
             ConsumerRecord<String, String> record = waitForRecord(consumer, DEPOSIT_REFUNDED_TOPIC);
             JsonNode payload = objectMapper.readTree(record.value());
 
             assertThat(record.key()).isEqualTo(paymentUuid.toString());
-            assertThat(payload.get("refundId").asText()).isEqualTo(refundUuid.toString());
+            assertThat(payload.get("refundUuid").asText()).isEqualTo(refundUuid.toString());
             assertThat(payload.get("paymentUuid").asText()).isEqualTo(paymentUuid.toString());
             assertThat(payload.get("orderUuid").asText()).isEqualTo(orderUuid.toString());
             assertThat(payload.get("userUuid").asText()).isEqualTo(userUuid.toString());
             assertThat(payload.get("amount").asLong()).isEqualTo(refundDepositAmount);
 
-            // then: 湲곗〈 ?덉튂湲?5,000?먯뿉 3,000?먯씠 媛?곕릺??8,000?먯씠 ?쒕떎.
+            // then: 기존 예치금 5,000원에 3,000원이 더해져 8,000원이 된다.
             Deposit after = depositRepository.findByUserUuid(userUuid).orElseThrow();
             assertThat(after.getBalance()).isEqualTo(8000L);
-            Deposit systemAfter = depositRepository.findByUserUuid(SystemDepositInitData.SYSTEM_USER_UUID).orElseThrow();
+            Deposit systemAfter = depositRepository.findByUserUuid(SystemDepositInitData.SYSTEM_USER_UUID)
+                    .orElseThrow();
             assertThat(systemAfter.getBalance()).isEqualTo(997000L);
 
             List<DepositHistory> histories = depositHistoryRepository.findByUserUuidOrderByCreatedAtDesc(userUuid);
@@ -176,7 +178,7 @@ class RefundDepositUseCaseKafkaIntegrationTest {
             JsonNode payload = objectMapper.readTree(record.value());
 
             assertThat(record.key()).isEqualTo(paymentUuid.toString());
-            assertThat(payload.get("refundId").asText()).isEqualTo(refundUuid.toString());
+            assertThat(payload.get("refundUuid").asText()).isEqualTo(refundUuid.toString());
             assertThat(payload.get("paymentUuid").asText()).isEqualTo(paymentUuid.toString());
             assertThat(payload.get("orderUuid").asText()).isEqualTo(orderUuid.toString());
             assertThat(payload.get("userUuid").asText()).isEqualTo(userUuid.toString());
@@ -184,10 +186,12 @@ class RefundDepositUseCaseKafkaIntegrationTest {
             assertThat(payload.get("failureCode").asText()).isEqualTo("PERSISTENCE_ERROR");
 
             assertThat(depositRepository.findByUserUuid(userUuid).orElseThrow().getBalance()).isEqualTo(5000L);
-            assertThat(depositRepository.findByUserUuid(SystemDepositInitData.SYSTEM_USER_UUID).orElseThrow().getBalance())
+            assertThat(
+                    depositRepository.findByUserUuid(SystemDepositInitData.SYSTEM_USER_UUID).orElseThrow().getBalance())
                     .isEqualTo(1000L);
             assertThat(depositHistoryRepository.findByUserUuidOrderByCreatedAtDesc(userUuid)).isEmpty();
-            assertThat(depositHistoryRepository.findByUserUuidOrderByCreatedAtDesc(SystemDepositInitData.SYSTEM_USER_UUID))
+            assertThat(
+                    depositHistoryRepository.findByUserUuidOrderByCreatedAtDesc(SystemDepositInitData.SYSTEM_USER_UUID))
                     .isEmpty();
         } finally {
             consumer.close();
@@ -224,6 +228,6 @@ class RefundDepositUseCaseKafkaIntegrationTest {
             }
         }
 
-        throw new IllegalStateException("No record found for topic: " + topic);
+        return fail("No record found for topic: " + topic);
     }
 }

--- a/order/src/main/java/dukku/order/boundedContext/order/app/FindConfirmedItemsUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/FindConfirmedItemsUseCase.java
@@ -1,5 +1,6 @@
 package dukku.order.boundedContext.order.app;
 
+import dukku.common.global.exception.BadRequestException;
 import dukku.common.shared.order.dto.ConfirmedOrderItemResponse;
 import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.order.boundedContext.order.entity.OrderItem;
@@ -19,7 +20,7 @@ public class FindConfirmedItemsUseCase {
 
     public List<ConfirmedOrderItemResponse> execute(LocalDateTime startDateTime, LocalDateTime endDateTime){
         if (startDateTime.isAfter(endDateTime)) {
-            throw new IllegalArgumentException("startDateTime must be before endDateTime");
+            throw new BadRequestException("startDateTime must be before endDateTime");
         }
 
         return orderItemRepository

--- a/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
@@ -1,5 +1,6 @@
 package dukku.order.boundedContext.order.app;
 
+import dukku.common.global.exception.BadRequestException;
 import dukku.order.boundedContext.order.entity.Order;
 import dukku.common.shared.order.type.OrderStatus;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ public class UpdateOrderRefundStatusUseCase {
 
         // 환불금액 범위 방어
         if (refundAmount > Integer.MAX_VALUE) {
-            throw new IllegalArgumentException("Refund amount exceeds supported integer range.");
+            throw new BadRequestException("Refund amount exceeds supported integer range.");
         }
 
         // 누적 환불액 반영(총액 초과 방지)

--- a/order/src/main/java/dukku/order/boundedContext/order/in/OrderEventListener.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/in/OrderEventListener.java
@@ -37,8 +37,9 @@ public class OrderEventListener {
     // 환불 완료 이벤트 반영 실패 시 수동 개입 필요 로그
     @Recover
     public void recoverRefund(Exception e, RefundCompletedEvent event) {
-        log.error("[CRITICAL] Failed to apply refund-completed event. manual action required. orderUuid={}, refundId={}, refundAmount={}",
-                event.orderUuid(), event.refundId(), event.refundAmount(), e);
+        log.error(
+                "[CRITICAL] Failed to apply refund-completed event. manual action required. orderUuid={}, refundUuid={}, refundAmount={}",
+                event.orderUuid(), event.refundUuid(), event.refundAmount(), e);
     }
 
     // payment.success: 결제 완료 이벤트 수신 시 주문 결제 성공 반영
@@ -51,7 +52,8 @@ public class OrderEventListener {
     // payment.success 처리 실패 시 결제 롤백 요청 이벤트 발행
     @Recover
     public void recoverSuccess(Exception e, PaymentSuccessEvent event) {
-        log.error("[CRITICAL] Payment success event failed to update order. Triggering rollback. orderUuid={}, error={}",
+        log.error(
+                "[CRITICAL] Payment success event failed to update order. Triggering rollback. orderUuid={}, error={}",
                 event.orderUuid(), e.getMessage());
 
         eventPublisher.publish(
@@ -70,7 +72,8 @@ public class OrderEventListener {
     // payment.failed 처리 실패 시 수동 개입 필요 로그
     @Recover
     public void recoverFail(Exception e, PaymentFailedEvent event) {
-        log.error("[CRITICAL] Payment failed event could not be persisted to order. manual action required. orderUuid={}",
+        log.error(
+                "[CRITICAL] Payment failed event could not be persisted to order. manual action required. orderUuid={}",
                 event.orderUuid(), e);
     }
 }

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -15,5 +15,4 @@ dependencies {
     // === Test ===
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
-    testImplementation 'org.springframework.kafka:spring-kafka-test'
 }

--- a/payment/src/main/java/dukku/payment/boundedContext/payment/app/ConfirmPaymentUseCase.java
+++ b/payment/src/main/java/dukku/payment/boundedContext/payment/app/ConfirmPaymentUseCase.java
@@ -136,7 +136,6 @@ public class ConfirmPaymentUseCase {
         // 10. 결제 성공 이벤트 발행 (주문 상태 변경 및 예치금 차감 트리거)
         eventPublisher.publish(new PaymentSuccessEvent(
                 payment.getUuid(),
-                payment.getUuid(), // paymentUuid (2026-01-24 추가된 필드 대응)
                 payment.getOrderUuid(),
                 payment.getAmount(),
                 payment.getAmountPg(),
@@ -167,8 +166,8 @@ public class ConfirmPaymentUseCase {
     }
 
     private void handlePaymentFailure(Payment payment, PaymentStatus originStatus, Long originAmountPg,
-                                      Long originDeposit, PaymentFailureStage failureStage, PaymentFailureCode failureCode, boolean retryable,
-                                      String reason) {
+            Long originDeposit, PaymentFailureStage failureStage, PaymentFailureCode failureCode, boolean retryable,
+            String reason) {
         // PENDING 상태만 실패 처리 (중복 이벤트 방지)
         if (payment.getPaymentStatus() != PaymentStatus.PENDING) {
             return;

--- a/payment/src/main/java/dukku/payment/boundedContext/payment/entity/Payment.java
+++ b/payment/src/main/java/dukku/payment/boundedContext/payment/entity/Payment.java
@@ -8,6 +8,7 @@ import dukku.common.shared.payment.dto.PaymentResponse;
 import dukku.common.shared.payment.dto.PaymentConfirmResponse;
 import dukku.common.shared.payment.dto.PaymentResultResponse;
 import dukku.common.shared.payment.dto.PaymentDto;
+import dukku.common.shared.payment.exception.InvalidRefundAmountException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -100,8 +101,8 @@ public class Payment extends BaseIdAndUUIDAndTime {
     // === 정적 팩토리 메서드 ===
 
     public static Payment create(UUID orderUuid, UUID userUuid, Long amount,
-                                 Long depositAmount, Long pgAmount, Long couponAmount,
-                                 PaymentType paymentType, String tossOrderId) {
+            Long depositAmount, Long pgAmount, Long couponAmount,
+            PaymentType paymentType, String tossOrderId) {
         return Payment.builder()
                 .orderUuid(orderUuid)
                 .userUuid(userUuid)
@@ -163,7 +164,7 @@ public class Payment extends BaseIdAndUUIDAndTime {
         // 환불 가능 잔액 검증: 현재 남은 PG 금액과 예치금의 합계 확인
         long availableTotal = this.amountPg + this.paymentDeposit;
         if (refundAmountTotal > availableTotal) {
-            throw new IllegalArgumentException("환불 요청 금액이 잔여 결제 금액보다 큽니다.");
+            throw new InvalidRefundAmountException("환불 요청 금액이 잔여 결제 금액보다 큽니다.");
         }
 
         // 예치금 우선 복구 로직: 현재 남은 예치금 내에서 최대한 복구

--- a/payment/src/main/java/dukku/payment/boundedContext/payment/entity/PaymentOrderItem.java
+++ b/payment/src/main/java/dukku/payment/boundedContext/payment/entity/PaymentOrderItem.java
@@ -56,8 +56,8 @@ public class PaymentOrderItem extends BaseIdAndUUIDAndTime {
     @Column(nullable = false, comment = "결제 시점 단가")
     private Long price;
 
-    @Column(nullable = false, comment = "상품별 예치금 사용액 (2026-01-24 추가)")
-    private Long paymentDeposit; // 2026-01-24 추가
+    @Column(nullable = false, comment = "상품별 예치금 사용액")
+    private Long paymentDeposit;
 
     /**
      * 결제 주문 상품 스냅샷 생성
@@ -84,7 +84,7 @@ public class PaymentOrderItem extends BaseIdAndUUIDAndTime {
                 .price(price)
                 .paymentCoupon(paymentCoupon)
                 .sellerUuid(sellerUuid)
-                .paymentDeposit(paymentDeposit) // 2026-01-24 추가
+                .paymentDeposit(paymentDeposit)
                 .build();
     }
 
@@ -101,7 +101,7 @@ public class PaymentOrderItem extends BaseIdAndUUIDAndTime {
                 .price(this.price)
                 .paymentCoupon(this.paymentCoupon)
                 .sellerUuid(this.sellerUuid)
-                .paymentDeposit(this.paymentDeposit) // 2026-01-24 추가
+                .paymentDeposit(this.paymentDeposit)
                 .build();
     }
 }

--- a/payment/src/main/java/dukku/payment/boundedContext/payment/in/PaymentEventListener.java
+++ b/payment/src/main/java/dukku/payment/boundedContext/payment/in/PaymentEventListener.java
@@ -98,7 +98,7 @@ public class PaymentEventListener {
      */
     @KafkaListener(topics = "deposit.refunded", groupId = "${spring.application.name}-group")
     public void handle(DepositRefundedEvent event) {
-        paymentSupport.findRefundByUuid(event.refundId()).ifPresentOrElse(refund -> {
+        paymentSupport.findRefundByUuid(event.refundUuid()).ifPresentOrElse(refund -> {
             // 이미 완료된 환불이면 중복 이벤트로 보고 무시
             if (refund.getRefundStatus() == RefundStatus.COMPLETED) {
                 return;
@@ -114,9 +114,9 @@ public class PaymentEventListener {
                     refund.getRefundDepositTotal(),
                     event.userUuid(),
                     LocalDateTime.now()));
-            log.info("[환불 Saga] refundUuid={}, paymentUuid={}", event.refundId(), event.paymentUuid());
+            log.info("[환불 Saga] refundUuid={}, paymentUuid={}", event.refundUuid(), event.paymentUuid());
         }, () -> log.warn("[환불 Saga] refund 이벤트 조회 실패: refundUuid={}, paymentUuid={}",
-                event.refundId(), event.paymentUuid()));
+                event.refundUuid(), event.paymentUuid()));
     }
 
     /**
@@ -125,15 +125,15 @@ public class PaymentEventListener {
     @KafkaListener(topics = "deposit.refund.failed", groupId = "${spring.application.name}-group")
     public void handle(DepositRefundFailedEvent event) {
         // 환불 실패 시 refund 상태를 취소로 전환하고 주문 결제 상태도 장애로 반영
-        paymentSupport.findRefundByUuid(event.refundId()).ifPresentOrElse(refund -> {
+        paymentSupport.findRefundByUuid(event.refundUuid()).ifPresentOrElse(refund -> {
             if (refund.getRefundStatus() == RefundStatus.COMPLETED) {
-                log.warn("[환불 Saga 실패] 이미 완료된 환불입니다. refundUuid={}", event.refundId());
+                log.warn("[환불 Saga 실패] 이미 완료된 환불입니다. refundUuid={}", event.refundUuid());
                 return;
             }
             refund.cancel();
             paymentSupport.saveRefund(refund);
         }, () -> log.warn("[환불 Saga 실패] refund 이벤트 조회 실패: refundUuid={}, paymentUuid={}",
-                event.refundId(), event.paymentUuid()));
+                event.refundUuid(), event.paymentUuid()));
 
         paymentSupport.findPaymentByUuidOptional(event.paymentUuid()).ifPresentOrElse(payment -> {
             if (payment.getPaymentStatus() == PaymentStatus.ROLLBACK_FAILED) {

--- a/payment/src/test/java/dukku/payment/boundedContext/payment/app/PaymentIntegrationTest.java
+++ b/payment/src/test/java/dukku/payment/boundedContext/payment/app/PaymentIntegrationTest.java
@@ -152,7 +152,7 @@ class PaymentIntegrationTest {
 
         RefundCompletedEvent event = (RefundCompletedEvent) eventCaptor.getValue();
         assertThat(event.orderUuid()).isEqualTo(payment.getOrderUuid());
-        assertThat(event.paymentId()).isEqualTo(payment.getUuid());
+        assertThat(event.paymentUuid()).isEqualTo(payment.getUuid());
         assertThat(event.refundAmount()).isEqualTo(10000L);
         assertThat(event.refundDepositAmount()).isEqualTo(0L);
     }

--- a/payment/src/test/java/dukku/payment/boundedContext/payment/app/PaymentKafkaIntegrationTest.java
+++ b/payment/src/test/java/dukku/payment/boundedContext/payment/app/PaymentKafkaIntegrationTest.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -141,13 +142,13 @@ class PaymentKafkaIntegrationTest {
                 .build();
 
         // when: 결제를 승인하고 같은 결제에 대해 전체 환불을 수행한다.
-        transactionTemplate.execute(status ->
-                confirmPaymentUseCase.execute(confirmRequest, "idem-confirm-kafka-1"));
+        transactionTemplate.execute(status -> confirmPaymentUseCase.execute(confirmRequest, "idem-confirm-kafka-1"));
         refundPaymentUseCase.execute(refundRequest, "idem-refund-kafka-1");
 
         Consumer<String, String> consumer = createConsumer();
         try {
-            // then: payment.success / payment.refund-completed 토픽 이벤트가 발행되고 payload 값이 일치한다.
+            // then: payment.success / payment.refund-completed 토픽 이벤트가 발행되고 payload 값이
+            // 일치한다.
             Map<String, ConsumerRecord<String, String>> recordsByTopic = waitForRecords(
                     consumer,
                     Set.of(PAYMENT_SUCCESS_TOPIC, REFUND_COMPLETED_TOPIC));
@@ -158,7 +159,6 @@ class PaymentKafkaIntegrationTest {
             assertThat(successRecord.key()).isEqualTo(pendingPayment.getOrderUuid().toString());
             assertThat(successJson.get("orderUuid").asText()).isEqualTo(pendingPayment.getOrderUuid().toString());
             assertThat(successJson.get("paymentUuid").asText()).isEqualTo(pendingPayment.getUuid().toString());
-            assertThat(successJson.get("paymentId").asText()).isEqualTo(pendingPayment.getUuid().toString());
             assertThat(successJson.get("amount").asLong()).isEqualTo(12000L);
             assertThat(successJson.get("pgAmount").asLong()).isEqualTo(12000L);
             assertThat(successJson.get("paymentDeposit").asLong()).isEqualTo(0L);
@@ -168,7 +168,7 @@ class PaymentKafkaIntegrationTest {
 
             assertThat(refundRecord.key()).isEqualTo(pendingPayment.getOrderUuid().toString());
             assertThat(refundJson.get("orderUuid").asText()).isEqualTo(pendingPayment.getOrderUuid().toString());
-            assertThat(refundJson.get("paymentId").asText()).isEqualTo(pendingPayment.getUuid().toString());
+            assertThat(refundJson.get("paymentUuid").asText()).isEqualTo(pendingPayment.getUuid().toString());
             assertThat(refundJson.get("refundAmount").asLong()).isEqualTo(12000L);
             assertThat(refundJson.get("refundDepositAmount").asLong()).isEqualTo(0L);
 
@@ -221,7 +221,7 @@ class PaymentKafkaIntegrationTest {
             }
         }
 
-        throw new IllegalStateException("No records found for topics: " + requiredTopics);
+        return fail("No records found for topics: " + requiredTopics);
     }
 
     private Payment createPendingPayment(Long amount, String tossOrderId) {
@@ -236,4 +236,3 @@ class PaymentKafkaIntegrationTest {
                 tossOrderId));
     }
 }
-

--- a/payment/src/test/java/dukku/payment/boundedContext/payment/app/RefundPaymentUseCaseHappyPathTest.java
+++ b/payment/src/test/java/dukku/payment/boundedContext/payment/app/RefundPaymentUseCaseHappyPathTest.java
@@ -128,7 +128,7 @@ class RefundPaymentUseCaseHappyPathTest {
 
         RefundCompletedEvent event = (RefundCompletedEvent) eventCaptor.getValue();
         assertThat(event.orderUuid()).isEqualTo(orderUuid);
-        assertThat(event.paymentId()).isEqualTo(payment.getUuid());
+        assertThat(event.paymentUuid()).isEqualTo(payment.getUuid());
         assertThat(event.refundAmount()).isEqualTo(10000L);
         assertThat(event.refundDepositAmount()).isEqualTo(0L);
         assertThat(event.userUuid()).isEqualTo(userUuid);


### PR DESCRIPTION
## PR 제목

[Payment] 컨벤션 반영 개선사항 리팩토링 적용 #54 #56 #174

---

## 개요

#174 PR에서 나온 개선사항을 별도 브랜치에서 개선 후 일괄 적용
이 수정사항 반영으로 연관 이슈는 완전히 종료

close #54
close #56

---

## 상세 내용
- 깨진 한국어 텍스트 수정
- 루트 build.gradle 공통 선언과 중복된 spring-kafka-test를 모듈에서 제거
- deposit/payment 테스트 의존성 관리 기준을 루트 기준으로 정렬
- refundId/paymentId 필드를 refundUuid/paymentUuid로 변경
- deposit/payment/order의 이벤트 발행 및 소비 코드 갱신
- 테스트 갱신
- 주문 조회 기간/환불 금액 검증 실패를 BadRequestException으로 전환
- 결제 환불 가능 금액 초과 검증을 InvalidRefundAmountException으로 전환
- 도메인 검증 실패가 공통 예외 계층으로 응답되도록 처리 기준을 정렬
- Kafka 레코드 대기 타임아웃 실패를 IllegalStateException throw 대신 Assertions.fail()로 전환
- 테스트 실패가 assertion 결과로 드러나도록 실패 표현 방식을 정리
- PaymentOrderItemDto, PaymentOrderItem에 남아 있던 '// 2026-01-24 추가' 주석을 제거
- git 이력으로 추적 가능한 날짜성 주석 패턴을 정리해 컨벤션 기준에 맞춤

---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [x] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [x] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
