### PR TITLE
[Infra] MSA 기준 모듈별 whitelist 분리 및 health endpoint만 외부 점검 허용

### DIFF
--- a/auth/src/main/java/dukku/auth/global/config/SecurityReleaseConfig.java
+++ b/auth/src/main/java/dukku/auth/global/config/SecurityReleaseConfig.java
@@ -51,14 +51,6 @@ public class SecurityReleaseConfig {
                         .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
                                 .permitAll()
                         .requestMatchers(
-                                "/api/v1/categories", // GET: Public
-                                "/api/v1/products/featured", // GET: Public
-                                "/api/v1/products", // GET: Public
-                                "/api/v1/products/**", // GET: Public
-                                "/api/v1/shops/**", // GET: Public
-
-                                "/api/v1/users/email/**",
-                                "/api/v1/users/register",
                                 "/api/v1/auth/**"
                         )
                                 .permitAll() // 인증 필요없음 -> filter 미실행

--- a/auth/src/main/java/dukku/auth/global/config/SecurityReleaseConfig.java
+++ b/auth/src/main/java/dukku/auth/global/config/SecurityReleaseConfig.java
@@ -1,11 +1,12 @@
 package dukku.auth.global.config;
 
 import dukku.common.global.auth.jwt.JwtAuthenticationFilter;
+import dukku.common.global.security.SecurityWhitelist;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -47,22 +48,20 @@ public class SecurityReleaseConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
+                                .permitAll()
                         .requestMatchers(
-                                "/v3/api-docs/**",
                                 "/api/v1/categories", // GET: Public
                                 "/api/v1/products/featured", // GET: Public
                                 "/api/v1/products", // GET: Public
                                 "/api/v1/products/**", // GET: Public
                                 "/api/v1/shops/**", // GET: Public
-                                "/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/swagger-config",
+
                                 "/api/v1/users/email/**",
                                 "/api/v1/users/register",
                                 "/api/v1/auth/**"
                         )
-                        .permitAll() // 인증 필요없음 -> filter 미실행
+                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/common/src/main/java/dukku/common/global/security/SecurityWhitelist.java
+++ b/common/src/main/java/dukku/common/global/security/SecurityWhitelist.java
@@ -1,0 +1,15 @@
+package dukku.common.global.security;
+
+public final class SecurityWhitelist {
+    public static final String[] COMMON_PUBLIC = {
+            "/actuator/health", "/actuator/health/**",
+
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/api-docs/**",
+            "/swagger-config"
+    };
+
+    private SecurityWhitelist() {}
+}

--- a/coupon/src/main/java/dukku/coupon/global/config/SecurityReleaseConfig.java
+++ b/coupon/src/main/java/dukku/coupon/global/config/SecurityReleaseConfig.java
@@ -1,11 +1,12 @@
 package dukku.coupon.global.config;
 
 import dukku.common.global.auth.jwt.JwtAuthenticationFilter;
+import dukku.common.global.security.SecurityWhitelist;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -47,22 +48,20 @@ public class SecurityReleaseConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                                .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
+                                        .permitAll()
                                 .requestMatchers(
-                                        "/v3/api-docs/**",
                                         "/api/v1/categories", // GET: Public
                                         "/api/v1/products/featured", // GET: Public
                                         "/api/v1/products", // GET: Public
                                         "/api/v1/products/**", // GET: Public
                                         "/api/v1/shops/**", // GET: Public
-                                        "/api-docs/**",
-                                        "/swagger-ui/**",
-                                        "/swagger-ui.html",
-                                        "/swagger-config",
+
                                         "/api/v1/users/email/**",
                                         "/api/v1/users/register",
                                         "/api/v1/auth/**"
                                 )
-                                .permitAll() // 인증 필요없음 -> filter 미실행
+                                        .permitAll() // 인증 필요없음 -> filter 미실행
                                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/coupon/src/main/java/dukku/coupon/global/config/SecurityReleaseConfig.java
+++ b/coupon/src/main/java/dukku/coupon/global/config/SecurityReleaseConfig.java
@@ -50,18 +50,6 @@ public class SecurityReleaseConfig {
                 .authorizeHttpRequests(auth -> auth
                                 .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
                                         .permitAll()
-                                .requestMatchers(
-                                        "/api/v1/categories", // GET: Public
-                                        "/api/v1/products/featured", // GET: Public
-                                        "/api/v1/products", // GET: Public
-                                        "/api/v1/products/**", // GET: Public
-                                        "/api/v1/shops/**", // GET: Public
-
-                                        "/api/v1/users/email/**",
-                                        "/api/v1/users/register",
-                                        "/api/v1/auth/**"
-                                )
-                                        .permitAll() // 인증 필요없음 -> filter 미실행
                                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/deposit/src/main/java/dukku/deposit/global/config/SecurityReleaseConfig.java
+++ b/deposit/src/main/java/dukku/deposit/global/config/SecurityReleaseConfig.java
@@ -50,18 +50,6 @@ public class SecurityReleaseConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
                                 .permitAll()
-                        .requestMatchers(
-                                "/api/v1/categories", // GET: Public
-                                "/api/v1/products/featured", // GET: Public
-                                "/api/v1/products", // GET: Public
-                                "/api/v1/products/**", // GET: Public
-                                "/api/v1/shops/**", // GET: Public
-
-                                "/api/v1/users/email/**",
-                                "/api/v1/users/register",
-                                "/api/v1/auth/**"
-                        )
-                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/deposit/src/main/java/dukku/deposit/global/config/SecurityReleaseConfig.java
+++ b/deposit/src/main/java/dukku/deposit/global/config/SecurityReleaseConfig.java
@@ -1,11 +1,12 @@
 package dukku.deposit.global.config;
 
 import dukku.common.global.auth.jwt.JwtAuthenticationFilter;
+import dukku.common.global.security.SecurityWhitelist;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -47,22 +48,20 @@ public class SecurityReleaseConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
+                                .permitAll()
                         .requestMatchers(
-                                "/v3/api-docs/**",
                                 "/api/v1/categories", // GET: Public
                                 "/api/v1/products/featured", // GET: Public
                                 "/api/v1/products", // GET: Public
                                 "/api/v1/products/**", // GET: Public
                                 "/api/v1/shops/**", // GET: Public
-                                "/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/swagger-config",
+
                                 "/api/v1/users/email/**",
                                 "/api/v1/users/register",
                                 "/api/v1/auth/**"
                         )
-                        .permitAll() // 인증 필요없음 -> filter 미실행
+                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/order/src/main/java/dukku/order/global/config/SecurityReleaseConfig.java
+++ b/order/src/main/java/dukku/order/global/config/SecurityReleaseConfig.java
@@ -50,18 +50,6 @@ public class SecurityReleaseConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
                                 .permitAll()
-                        .requestMatchers(
-                                "/api/v1/categories", // GET: Public
-                                "/api/v1/products/featured", // GET: Public
-                                "/api/v1/products", // GET: Public
-                                "/api/v1/products/**", // GET: Public
-                                "/api/v1/shops/**", // GET: Public
-
-                                "/api/v1/users/email/**",
-                                "/api/v1/users/register",
-                                "/api/v1/auth/**"
-                        )
-                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/order/src/main/java/dukku/order/global/config/SecurityReleaseConfig.java
+++ b/order/src/main/java/dukku/order/global/config/SecurityReleaseConfig.java
@@ -1,11 +1,12 @@
 package dukku.order.global.config;
 
 import dukku.common.global.auth.jwt.JwtAuthenticationFilter;
+import dukku.common.global.security.SecurityWhitelist;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -47,22 +48,20 @@ public class SecurityReleaseConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
+                                .permitAll()
                         .requestMatchers(
-                                "/v3/api-docs/**",
                                 "/api/v1/categories", // GET: Public
                                 "/api/v1/products/featured", // GET: Public
                                 "/api/v1/products", // GET: Public
                                 "/api/v1/products/**", // GET: Public
                                 "/api/v1/shops/**", // GET: Public
-                                "/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/swagger-config",
+
                                 "/api/v1/users/email/**",
                                 "/api/v1/users/register",
                                 "/api/v1/auth/**"
                         )
-                        .permitAll() // 인증 필요없음 -> filter 미실행
+                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/payment/src/main/java/dukku/payment/global/config/SecurityReleaseConfig.java
+++ b/payment/src/main/java/dukku/payment/global/config/SecurityReleaseConfig.java
@@ -50,18 +50,6 @@ public class SecurityReleaseConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
                                 .permitAll()
-                        .requestMatchers(
-                                "/api/v1/categories", // GET: Public
-                                "/api/v1/products/featured", // GET: Public
-                                "/api/v1/products", // GET: Public
-                                "/api/v1/products/**", // GET: Public
-                                "/api/v1/shops/**", // GET: Public
-
-                                "/api/v1/users/email/**",
-                                "/api/v1/users/register",
-                                "/api/v1/auth/**"
-                        )
-                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/payment/src/main/java/dukku/payment/global/config/SecurityReleaseConfig.java
+++ b/payment/src/main/java/dukku/payment/global/config/SecurityReleaseConfig.java
@@ -1,11 +1,12 @@
 package dukku.payment.global.config;
 
 import dukku.common.global.auth.jwt.JwtAuthenticationFilter;
+import dukku.common.global.security.SecurityWhitelist;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -47,22 +48,20 @@ public class SecurityReleaseConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
+                                .permitAll()
                         .requestMatchers(
-                                "/v3/api-docs/**",
                                 "/api/v1/categories", // GET: Public
                                 "/api/v1/products/featured", // GET: Public
                                 "/api/v1/products", // GET: Public
                                 "/api/v1/products/**", // GET: Public
                                 "/api/v1/shops/**", // GET: Public
-                                "/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/swagger-config",
+
                                 "/api/v1/users/email/**",
                                 "/api/v1/users/register",
                                 "/api/v1/auth/**"
                         )
-                        .permitAll() // 인증 필요없음 -> filter 미실행
+                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/product/src/main/java/dukku/product/global/config/SecurityReleaseConfig.java
+++ b/product/src/main/java/dukku/product/global/config/SecurityReleaseConfig.java
@@ -1,11 +1,12 @@
 package dukku.product.global.config;
 
 import dukku.common.global.auth.jwt.JwtAuthenticationFilter;
+import dukku.common.global.security.SecurityWhitelist;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -47,22 +48,20 @@ public class SecurityReleaseConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
+                                .permitAll()
                         .requestMatchers(
-                                "/v3/api-docs/**",
                                 "/api/v1/categories", // GET: Public
                                 "/api/v1/products/featured", // GET: Public
                                 "/api/v1/products", // GET: Public
                                 "/api/v1/products/**", // GET: Public
                                 "/api/v1/shops/**", // GET: Public
-                                "/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/swagger-config",
+
                                 "/api/v1/users/email/**",
                                 "/api/v1/users/register",
                                 "/api/v1/auth/**"
                         )
-                        .permitAll() // 인증 필요없음 -> filter 미실행
+                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/product/src/main/java/dukku/product/global/config/SecurityReleaseConfig.java
+++ b/product/src/main/java/dukku/product/global/config/SecurityReleaseConfig.java
@@ -55,11 +55,7 @@ public class SecurityReleaseConfig {
                                 "/api/v1/products/featured", // GET: Public
                                 "/api/v1/products", // GET: Public
                                 "/api/v1/products/**", // GET: Public
-                                "/api/v1/shops/**", // GET: Public
-
-                                "/api/v1/users/email/**",
-                                "/api/v1/users/register",
-                                "/api/v1/auth/**"
+                                "/api/v1/shops/**" // GET: Public
                         )
                                 .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근

--- a/settlement/src/main/java/dukku/settlement/global/config/SecurityReleaseConfig.java
+++ b/settlement/src/main/java/dukku/settlement/global/config/SecurityReleaseConfig.java
@@ -50,18 +50,6 @@ public class SecurityReleaseConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
                                 .permitAll()
-                        .requestMatchers(
-                                "/api/v1/categories", // GET: Public
-                                "/api/v1/products/featured", // GET: Public
-                                "/api/v1/products", // GET: Public
-                                "/api/v1/products/**", // GET: Public
-                                "/api/v1/shops/**", // GET: Public
-
-                                "/api/v1/users/email/**",
-                                "/api/v1/users/register",
-                                "/api/v1/auth/**"
-                        )
-                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/settlement/src/main/java/dukku/settlement/global/config/SecurityReleaseConfig.java
+++ b/settlement/src/main/java/dukku/settlement/global/config/SecurityReleaseConfig.java
@@ -1,11 +1,12 @@
 package dukku.settlement.global.config;
 
 import dukku.common.global.auth.jwt.JwtAuthenticationFilter;
+import dukku.common.global.security.SecurityWhitelist;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -47,22 +48,20 @@ public class SecurityReleaseConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
+                                .permitAll()
                         .requestMatchers(
-                                "/v3/api-docs/**",
                                 "/api/v1/categories", // GET: Public
                                 "/api/v1/products/featured", // GET: Public
                                 "/api/v1/products", // GET: Public
                                 "/api/v1/products/**", // GET: Public
                                 "/api/v1/shops/**", // GET: Public
-                                "/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/swagger-config",
+
                                 "/api/v1/users/email/**",
                                 "/api/v1/users/register",
                                 "/api/v1/auth/**"
                         )
-                        .permitAll() // 인증 필요없음 -> filter 미실행
+                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->

--- a/user/src/main/java/dukku/user/global/config/SecurityReleaseConfig.java
+++ b/user/src/main/java/dukku/user/global/config/SecurityReleaseConfig.java
@@ -51,15 +51,8 @@ public class SecurityReleaseConfig {
                         .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
                                 .permitAll()
                         .requestMatchers(
-                                "/api/v1/categories", // GET: Public
-                                "/api/v1/products/featured", // GET: Public
-                                "/api/v1/products", // GET: Public
-                                "/api/v1/products/**", // GET: Public
-                                "/api/v1/shops/**", // GET: Public
-
                                 "/api/v1/users/email/**",
-                                "/api/v1/users/register",
-                                "/api/v1/auth/**"
+                                "/api/v1/users/register"
                         )
                                 .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근

--- a/user/src/main/java/dukku/user/global/config/SecurityReleaseConfig.java
+++ b/user/src/main/java/dukku/user/global/config/SecurityReleaseConfig.java
@@ -1,11 +1,12 @@
 package dukku.user.global.config;
 
 import dukku.common.global.auth.jwt.JwtAuthenticationFilter;
+import dukku.common.global.security.SecurityWhitelist;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -47,22 +48,20 @@ public class SecurityReleaseConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
+                                .permitAll()
                         .requestMatchers(
-                                "/v3/api-docs/**",
                                 "/api/v1/categories", // GET: Public
                                 "/api/v1/products/featured", // GET: Public
                                 "/api/v1/products", // GET: Public
                                 "/api/v1/products/**", // GET: Public
                                 "/api/v1/shops/**", // GET: Public
-                                "/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/swagger-config",
+
                                 "/api/v1/users/email/**",
                                 "/api/v1/users/register",
                                 "/api/v1/auth/**"
                         )
-                        .permitAll() // 인증 필요없음 -> filter 미실행
+                                .permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->


### PR DESCRIPTION
## PR 제목

[Infra] MSA 기준 모듈별 whitelist 분리 및 health endpoint만 외부 점검 허용

---

## 개요


k3s + Traefik Ingress 환경에서 서비스 기동 및 라우팅 테스트 중,  
대부분의 endpoint가 Security 설정에 의해 401로 차단되어  
“서비스가 실제로 안 뜬 것인지 / 보안에 의해 막힌 것인지” 구분이 어려운 상태였습니다.

그래서 MSA 구조 기준으로 모듈별 whitelist를 도메인 단위로 재정리하고,  
인프라 레벨에서 서비스 정상 기동 여부를 확인할 수 있도록  
`/actuator/health` endpoint만 예외적으로 permitAll로 허용하도록 조정했습니다.

단, actuator 전체를 공개하지 않고  
health probe 전용 endpoint만 최소 범위로 노출하는 방향으로 설정했습니다.

외부 노출 범위를 최소화하면서도, 인프라 레벨에서 정상 기동 여부를 확인할 수 있도록 보안 정책을 정리하는 목적입니다.

---

## 상세 내용

### 요약

- 각 모듈(SecurityReleaseConfig)의 whitelist를 **서비스 도메인 기준으로 분리**
  - auth → auth 관련 공개 endpoint만 permitAll
  - user → user 관련 공개 endpoint만 permitAll
  - product → 조회성 공개 endpoint만 permitAll
- 서비스 간 endpoint를 상호 whitelist에 포함하던 임시 설정 제거
- 공통 운영 점검용 endpoint만 전체 서비스에 permitAll 적용
  - `/actuator/health`
  - `/actuator/health/**`
- actuator 전체 공개가 아닌 **health 단일 endpoint만 허용**
- swagger / api-docs endpoint는 문서 확인 목적 범위 내에서만 유지
- k3s + Traefik Ingress 기준 health check 동작 확인
---
### 1️⃣ 문제 배경

- k3s 배포 후 Traefik Ingress를 통해 서비스 테스트 진행
- 모든 endpoint가 401 Unauthorized로 응답
- 이로 인해 다음 구분이 불가능했음:
  - 앱이 실제로 정상 기동했는지
  - Service → Pod 라우팅이 정상인지
  - 단순히 Security에 의해 차단된 것인지

즉, **인프라 레벨 검증이 막혀있는 상태**였음

---

### 2️⃣ 변경 사항

- 각 모듈(SecurityReleaseConfig)의 whitelist를 도메인 기준으로 재정리
- 모듈 간 endpoint를 서로 permitAll 하던 임시 설정 제거
- JWT 보호 범위는 유지

### ✅ health check endpoint만 예외 허용

```text
/actuator/health
/actuator/health/**
```

- 서비스 기동 확인
- Pod / Service / Ingress 라우팅 검증
- k8s 내부 curl 테스트 용도

### ❌ actuator 전체 공개는 하지 않음

```text
/actuator/**
```

전체 공개는 보안상 제외

---

### 3️⃣ 보안 관점 설계 의도

이번 설정은 다음 전략 기준으로 정리했습니다.

- application layer → 최소 whitelist
- health probe endpoint만 공개
- 나머지는 전부 인증 필요

그리고 외부 노출은 다음 레벨에서 제어합니다:

- Traefik Ingress 라우팅 기준 path 제어
- 외부 노출 endpoint 최소화
- edge layer 기준 접근 범위 제한

즉:

> health endpoint only exposure + ingress-level access control 전략

---

### 4️⃣ 동작 검증 방법

k8s 내부 health 체크:

```bash
kubectl -n team05 run tmp-curl --image=curlimages/curl --restart=Never --rm -i --tty -- \
  curl -i http://team05-auth/actuator/health
```

Ingress 경유 health 체크:

```bash
curl -i http://<host>/auth/actuator/health
```

검증 기준:

- health → 200 OK
- 보호 endpoint → 401 Unauthorized

---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [x] 기타 작업 (Chore)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크

- [x] 커밋 메시지가 컨벤션에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크

- [x] 서비스 경계 기준으로 whitelist 범위가 분리되었는가
- [x] 도메인 외 endpoint permitAll 제거되었는가
- [x] actuator 전체가 아닌 health만 허용되었는가

### 안정성 체크

- [x] 기존 JWT 인증 흐름에 영향 없는가
- [x] 외부 공개 범위가 과도하게 확대되지 않았는가
- [x] k3s + ingress 기준 health 체크 정상 동작 확인했는가

---

## 리뷰어에게 요청 사항

- **중점적으로 봐주면 좋은 부분**
  - 모듈별 whitelist 범위가 과하지 않은지
  - 도메인 경계 기준 permitAll 분리가 적절한지

- **고민했던 설계 포인트**
  - MSA 기준에서 서비스 간 endpoint를 서로 whitelist에 포함하지 않는 방향
  - 401 응답으로 인해 인프라 검증이 막히는 문제 해결
  - actuator 전체 공개가 아닌 health만 노출
  - ingress 레벨에서 외부 노출 제어 전략


- **피드백 받고 싶은 부분**
  - 공개 endpoint 최소화 기준의 적절성
  - 이후 gateway/ingress 중심 보안 구조로 확장 시 개선 포인트