### PR TITLE
[Payment] 환불에 대한 멱등성 구현(order) #192

### DIFF
--- a/common/src/main/java/dukku/common/shared/order/exception/OrderRefundAmountOutOfRangeException.java
+++ b/common/src/main/java/dukku/common/shared/order/exception/OrderRefundAmountOutOfRangeException.java
@@ -1,0 +1,12 @@
+package dukku.common.shared.order.exception;
+
+import dukku.common.global.exception.BadRequestException;
+
+/**
+ * 주문 환불 금액이 유효 범위를 벗어난 경우 발생하는 예외입니다
+ */
+public class OrderRefundAmountOutOfRangeException extends BadRequestException {
+    public OrderRefundAmountOutOfRangeException() {
+        super("주문 환불 금액이 유효하지 않습니다");
+    }
+}

--- a/common/src/main/java/dukku/common/shared/payment/docs/PaymentApiDocs.java
+++ b/common/src/main/java/dukku/common/shared/payment/docs/PaymentApiDocs.java
@@ -17,32 +17,26 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * 결제(Payment) 관련 Swagger 전용 Meta-Annotation 모음
+ * 결제(Payment) Swagger 메타 애노테이션 모음
  */
 public final class PaymentApiDocs {
 
     private PaymentApiDocs() {
     }
 
-    // =============== 공통 태그 ===============
+    // 공통 태그
     @Documented
     @Target(TYPE)
     @Retention(RUNTIME)
-    @Tag(name = "결제 API", description = "결제 요청, 승인, 조회, 환불 관련 기능")
+    @Tag(name = "결제 API", description = "결제 요청, 승인, 조회, 환불 기능")
     public @interface PaymentTag {
     }
 
-    // =============== 1) 결제 요청 (준비) ===============
+    // 결제 요청
     @Documented
     @Target(METHOD)
     @Retention(RUNTIME)
-    @Operation(summary = "결제 요청 (준비)", description = """
-            프론트에서 결제 준비 요청 시 토스 결제창 호출에 필요한 정보를 반환합니다.
-            
-            - 주문 정보와 금액을 검증합니다.
-            - 예치금 잔액을 확인합니다.
-            - 토스 결제창 호출에 필요한 orderId, successUrl, failUrl 등을 생성합니다.
-            """, requestBody = @RequestBody(required = true, content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Payment Request", value = """
+    @Operation(summary = "결제 요청", description = "토스 결제창 노출에 필요한 결제 준비 정보를 생성", requestBody = @RequestBody(required = true, content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Payment Request", value = """
             {
               "orderUuid": "b2f0f6d3-9c4f-44d1-9f1f-8c2b3c7b1a11",
               "couponUuid": null,
@@ -75,23 +69,17 @@ public final class PaymentApiDocs {
                       "createdAt": "2026-01-14T16:20:00+09:00"
                     }
                     """))),
-            @ApiResponse(responseCode = "400", description = "금액 불일치 또는 예치금 부족", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"AMOUNT_MISMATCH\", \"message\": \"결제 금액이 일치하지 않습니다.\"}"))),
-            @ApiResponse(responseCode = "409", description = "중복 요청 (멱등성 충돌)", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"IDEMPOTENCY_CONFLICT\", \"message\": \"이미 처리된 결제 요청입니다.\"}")))
+            @ApiResponse(responseCode = "400", description = "금액 불일치 또는 예치금 부족", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"AMOUNT_MISMATCH\", \"message\": \"결제 금액이 일치하지 않습니다\"}"))),
+            @ApiResponse(responseCode = "409", description = "중복 요청", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"IDEMPOTENCY_CONFLICT\", \"message\": \"이미 처리된 결제 요청입니다\"}")))
     })
     public @interface RequestPayment {
     }
 
-    // =============== 2) 결제 승인 확정 ===============
+    // 결제 승인
     @Documented
     @Target(METHOD)
     @Retention(RUNTIME)
-    @Operation(summary = "결제 승인 확정", description = """
-            토스 인증 완료 후 백엔드에서 최종 승인 처리를 합니다.
-            
-            - paymentKey, orderId, amount를 검증합니다.
-            - 토스 Confirm API를 호출합니다.
-            - 성공 시 결제 상태를 DONE으로 변경하고 예치금을 차감합니다.
-            """, requestBody = @RequestBody(required = true, content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Confirm Request", value = """
+    @Operation(summary = "결제 승인", description = "토스 승인 API를 호출해 결제를 확정", requestBody = @RequestBody(required = true, content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Confirm Request", value = """
             {
               "paymentUuid": "9a5be1c6-735e-4f69-a35f-7a9f6b0a9a9a",
               "toss": {
@@ -105,78 +93,44 @@ public final class PaymentApiDocs {
                     {
                       "success": true,
                       "code": "PAYMENT_CONFIRMED",
-                      "message": "결제가 승인되었습니다.",
+                      "message": "결제가 승인되었습니다",
                       "data": {
                         "paymentUuid": "9a5be1c6-735e-4f69-a35f-7a9f6b0a9a9a",
                         "status": "DONE",
-                        "approvedAt": "2026-01-14T16:22:10+09:00",
-                        "toss": {
-                          "orderId": "TOSS_9a5be1c6_20260114_001",
-                          "paymentKey": "tviva20260114pgkey_abcdef123456"
-                        },
-                        "amounts": {
-                          "finalPayAmount": 13500,
-                          "depositUseAmount": 4500,
-                          "pgPayAmount": 9000
-                        }
-                      }
-                    }
-                    """))),
-            @ApiResponse(responseCode = "400", description = "금액 또는 orderId 불일치", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"TOSS_AMOUNT_MISMATCH\", \"message\": \"토스 결제 금액이 일치하지 않습니다.\"}"))),
-            @ApiResponse(responseCode = "409", description = "결제 상태가 PENDING이 아님", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"PAYMENT_NOT_PENDING\", \"message\": \"결제 상태가 승인 대기(PENDING)가 아닙니다.\"}"))),
-            @ApiResponse(responseCode = "502", description = "토스 승인 API 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"TOSS_CONFIRM_FAILED\", \"message\": \"결제 승인에 실패했습니다.\"}")))
-    })
-    public @interface ConfirmPayment {
-    }
-
-    // =============== 3) 결제 내역 조회 ===============
-    @Documented
-    @Target(METHOD)
-    @Retention(RUNTIME)
-    @Operation(summary = "결제 내역 조회", description = "특정 결제의 상세 정보를 조회합니다.", parameters = {
-            @Parameter(name = "paymentId", description = "결제 UUID", required = true, example = "9a5be1c6-735e-4f69-a35f-7a9f6b0a9a9a")
-    }, responses = {
-            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Result Response", value = """
-                    {
-                      "success": true,
-                      "code": "PAYMENT_RESULT_RETRIEVED",
-                      "message": "결제 내역을 조회했습니다.",
-                      "data": {
-                        "paymentId": "9a5be1c6-735e-4f69-a35f-7a9f6b0a9a9a",
-                        "orderUuid": "b2f0f6d3-9c4f-44d1-9f1f-8c2b3c7b1a11",
-                        "status": "DONE",
-                        "amounts": {
-                          "totalAmount": 15000,
-                          "couponDiscountAmount": 1500,
-                          "depositUseAmount": 4500,
-                          "pgPayAmount": 9000,
-                          "finalPayAmount": 13500
-                        },
-                        "createdAt": "2026-01-14T16:20:00+09:00",
                         "approvedAt": "2026-01-14T16:22:10+09:00"
                       }
                     }
                     """))),
-            @ApiResponse(responseCode = "404", description = "결제 내역 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"PAYMENT_NOT_FOUND\", \"message\": \"결제 내역을 찾을 수 없습니다.\"}")))
+            @ApiResponse(responseCode = "400", description = "금액 또는 orderId 불일치", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"TOSS_AMOUNT_MISMATCH\", \"message\": \"토스 결제 금액이 일치하지 않습니다\"}"))),
+            @ApiResponse(responseCode = "409", description = "결제 상태가 PENDING이 아님", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"PAYMENT_NOT_PENDING\", \"message\": \"결제 상태가 승인 대기가 아닙니다\"}"))),
+            @ApiResponse(responseCode = "502", description = "토스 승인 API 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"TOSS_CONFIRM_FAILED\", \"message\": \"결제 승인에 실패했습니다\"}")))
+    })
+    public @interface ConfirmPayment {
+    }
+
+    // 결제 조회
+    @Documented
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @Operation(summary = "결제 결과 조회", description = "결제 UUID로 결제 상세 정보를 조회", parameters = {
+            @Parameter(name = "paymentId", description = "결제 UUID", required = true, example = "9a5be1c6-735e-4f69-a35f-7a9f6b0a9a9a")
+    }, responses = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "결제 이력 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"PAYMENT_NOT_FOUND\", \"message\": \"결제 이력을 찾을 수 없습니다\"}")))
     })
     public @interface GetPaymentResult {
     }
 
-    // =============== 4) 환불 요청 ===============
+    // 환불 요청
     @Documented
     @Target(METHOD)
     @Retention(RUNTIME)
-    @Operation(summary = "환불 요청", description = """
-            결제 취소/환불을 요청합니다.
-            
-            - items가 있으면 부분 환불, 없으면 전체 환불로 처리됩니다.
-            - 예치금 사용분은 예치금으로, PG 결제분은 PG로 환불됩니다.
-            """, requestBody = @RequestBody(required = true, content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Refund Request", value = """
+    @Operation(summary = "환불 요청", description = "전체 또는 부분 환불을 요청", requestBody = @RequestBody(required = true, content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Refund Request", value = """
             {
               "paymentId": "9a5be1c6-735e-4f69-a35f-7a9f6b0a9a9a",
               "orderUuid": "b2f0f6d3-9c4f-44d1-9f1f-8c2b3c7b1a11",
               "refundAmount": 3750,
-              "reason": "단순변심",
+              "reason": "단순 변심",
               "items": [
                 {
                   "orderItemUuid": "f1b2c3d4-1111-2222-3333-444455556666",
@@ -185,34 +139,10 @@ public final class PaymentApiDocs {
               ]
             }
             """))), responses = {
-            @ApiResponse(responseCode = "200", description = "환불 요청 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(name = "Refund Response", value = """
-                    {
-                      "success": true,
-                      "code": "REFUND_REQUESTED",
-                      "message": "환불 요청이 접수되었습니다.",
-                      "data": {
-                        "refundId": "3c5a8f20-2c4f-4b7a-9e5e-0a3e91e8a111",
-                        "paymentId": "9a5be1c6-735e-4f69-a35f-7a9f6b0a9a9a",
-                        "orderUuid": "b2f0f6d3-9c4f-44d1-9f1f-8c2b3c7b1a11",
-                        "status": "CANCELED",
-                        "amounts": {
-                          "requestedRefundAmount": 3750,
-                          "depositRefundAmount": 1000,
-                          "pgRefundAmount": 2750
-                        },
-                        "pg": {
-                          "provider": "TOSS_PAYMENTS",
-                          "tossOrderId": "TOSS_9a5be1c6_20260114_001",
-                          "cancelTransactionKey": "8B3D...TXN..."
-                        },
-                        "createdAt": "2026-01-14T16:40:00+09:00",
-                        "completedAt": "2026-01-14T16:40:02+09:00"
-                      }
-                    }
-                    """))),
-            @ApiResponse(responseCode = "409", description = "환불 불가 상태", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"PAYMENT_NOT_REFUNDABLE\", \"message\": \"해당 결제는 환불할 수 없는 상태입니다.\"}"))),
-            @ApiResponse(responseCode = "422", description = "환불 금액 오류", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"INVALID_REFUND_AMOUNT\", \"message\": \"유효하지 않은 환불 금액입니다.\"}"))),
-            @ApiResponse(responseCode = "502", description = "PG 취소 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"PG_CANCEL_FAILED\", \"message\": \"PG 결제 취소에 실패했습니다.\"}")))
+            @ApiResponse(responseCode = "200", description = "환불 요청 성공"),
+            @ApiResponse(responseCode = "409", description = "환불 불가 상태", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"PAYMENT_NOT_REFUNDABLE\", \"message\": \"해당 결제는 환불할 수 없는 상태입니다\"}"))),
+            @ApiResponse(responseCode = "422", description = "환불 금액 오류", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"INVALID_REFUND_AMOUNT\", \"message\": \"유효하지 않은 환불 금액입니다\"}"))),
+            @ApiResponse(responseCode = "502", description = "PG 취소 실패", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"code\": \"PG_CANCEL_FAILED\", \"message\": \"PG 결제 취소에 실패했습니다\"}")))
     })
     public @interface RefundPayment {
     }

--- a/common/src/main/java/dukku/common/shared/payment/dto/PaymentRefundResponse.java
+++ b/common/src/main/java/dukku/common/shared/payment/dto/PaymentRefundResponse.java
@@ -29,7 +29,7 @@ public class PaymentRefundResponse {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class RefundData {
-        private UUID refundId;
+        private UUID refundUuid;
         private UUID paymentId;
         private UUID orderUuid;
         private PaymentStatus status;

--- a/order/src/main/java/dukku/order/boundedContext/order/app/OrderSupport.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/OrderSupport.java
@@ -1,10 +1,13 @@
 package dukku.order.boundedContext.order.app;
 
-import dukku.order.boundedContext.order.entity.Order;
-import dukku.order.boundedContext.order.out.OrderRepository;
 import dukku.common.shared.order.exception.OrderNotFoundException;
+import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.entity.ProcessedRefundEvent;
+import dukku.order.boundedContext.order.out.OrderRepository;
+import dukku.order.boundedContext.order.out.ProcessedRefundEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -12,6 +15,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class OrderSupport {
     private final OrderRepository orderRepository;
+    private final ProcessedRefundEventRepository processedRefundEventRepository;
 
     public Order findOrderByUuid(UUID orderUuid) {
         return orderRepository.findByUuid(orderUuid)
@@ -25,5 +29,25 @@ public class OrderSupport {
 
     public Order save(Order order) {
         return orderRepository.save(order);
+    }
+
+    /**
+     * 주문 환불 완료 이벤트를 중복 처리하지 않도록 마킹하는 메서드
+     *
+     * <p>동일한 refundUuid가 이미 처리된 경우 false를 반환</p>
+     * <p>처리 이력이 없으면 저장 후 true를 반환</p>
+     *
+     * @param refundUuid 환불 이벤트 UUID
+     * @param orderUuid 주문 UUID
+     * @param refundAmount 환불 금액
+     * @return 처리 여부
+     */
+    @Transactional
+    public boolean tryMarkRefundCompleted(UUID refundUuid, UUID orderUuid, Long refundAmount) {
+        if (processedRefundEventRepository.existsByRefundUuid(refundUuid)) {
+            return false;
+        }
+        processedRefundEventRepository.save(ProcessedRefundEvent.create(refundUuid, orderUuid, refundAmount));
+        return true;
     }
 }

--- a/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
@@ -1,8 +1,8 @@
 package dukku.order.boundedContext.order.app;
 
-import dukku.common.global.exception.BadRequestException;
-import dukku.order.boundedContext.order.entity.Order;
+import dukku.common.shared.order.exception.OrderRefundAmountOutOfRangeException;
 import dukku.common.shared.order.type.OrderStatus;
+import dukku.order.boundedContext.order.entity.Order;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,39 +15,43 @@ public class UpdateOrderRefundStatusUseCase {
     private final OrderSupport orderSupport;
 
     /**
-     * 결제/환불 이벤트의 환불금액 반영과 주문 상태 정리
-     * 총 결제금액 대비 누적 환불금액 기준으로 상태 분기
+     * 결제 환불 이벤트의 환불 금액을 주문에 반영하고 상태를 갱신
+     * 누적 환불 금액과 총 결제 금액을 비교해 상태를 분기
+     *
+     * @param refundUuid 환불 UUID
+     * @param orderUuid 주문 UUID
+     * @param refundAmount 누적 환불 금액
      */
     @Transactional
-    public void updateRefund(UUID orderUuid, Long refundAmount) {
-        // 입력값이 null 또는 0 이하면 즉시 종료
-        if (refundAmount == null || refundAmount <= 0) {
+    public void updateRefund(UUID refundUuid, UUID orderUuid, Long refundAmount) {
+        // 입력값이 없거나 0 이하이면 즉시 종료
+        if (refundUuid == null || orderUuid == null || refundAmount == null || refundAmount <= 0) {
             return;
         }
 
-        // 주문 조회 실패는 상위 트랜잭션에서 롤백/재시도 대상으로 이동
+        // 주문 조회 실패는 상위 트랜잭션에서 롤백 또는 재시도로 처리
         Order order = orderSupport.findOrderByUuid(orderUuid);
 
-        // 환불금액 범위 방어
+        // 환불 금액 범위 방어
         if (refundAmount > Integer.MAX_VALUE) {
-            throw new BadRequestException("Refund amount exceeds supported integer range.");
+            throw new OrderRefundAmountOutOfRangeException();
         }
 
-        // 누적 환불액 반영(총액 초과 방지)
+        // 누적 환불 금액 반영
         order.updateRefundedAmount(refundAmount.intValue());
 
-        // 주문 상태가 이미 취소면 추가 상태 변경 생략
+        // 이미 취소된 주문이면 추가 상태 변경 생략
         if (order.getStatus() == OrderStatus.CANCELED) {
             return;
         }
 
-        // 누적 환불액 >= 총액이면 주문 취소
+        // 누적 환불 금액이 총액 이상이면 주문 취소
         if (order.getRefundedAmount() >= order.getTotalAmount()) {
             order.updateOrderStatus(OrderStatus.CANCELED);
             return;
         }
 
-        // 누적 환불액 미만이면 부분환불
+        // 일부만 환불된 경우 부분 환불 상태 반영
         order.updateOrderStatus(OrderStatus.PARTIAL_REFUNDED);
     }
 }

--- a/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
@@ -29,6 +29,11 @@ public class UpdateOrderRefundStatusUseCase {
             return;
         }
 
+        // 이미 처리된 환불 이벤트면 중복 적용 방지
+        if (!orderSupport.tryMarkRefundCompleted(refundUuid, orderUuid, refundAmount)) {
+            return;
+        }
+
         // 주문 조회 실패는 상위 트랜잭션에서 롤백 또는 재시도로 처리
         Order order = orderSupport.findOrderByUuid(orderUuid);
 

--- a/order/src/main/java/dukku/order/boundedContext/order/entity/ProcessedRefundEvent.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/entity/ProcessedRefundEvent.java
@@ -1,0 +1,67 @@
+package dukku.order.boundedContext.order.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(name = "processed_refund_events", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_processed_refund_events_refund_uuid", columnNames = "refund_uuid")
+})
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+/**
+ * 이미 처리된 환불 이벤트를 추적해 중복 반영을 방지하기 위한 엔티티
+ */
+public class ProcessedRefundEvent {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Integer id;
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(name = "refund_uuid", nullable = false, updatable = false, columnDefinition = "uuid")
+    private UUID refundUuid;
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(name = "order_uuid", nullable = false, updatable = false, columnDefinition = "uuid")
+    private UUID orderUuid;
+
+    @Column(name = "refund_amount", nullable = false, updatable = false)
+    private Long refundAmount;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static ProcessedRefundEvent create(UUID refundUuid, UUID orderUuid, Long refundAmount) {
+        return ProcessedRefundEvent.builder()
+                .refundUuid(refundUuid)
+                .orderUuid(orderUuid)
+                .refundAmount(refundAmount)
+                .build();
+    }
+}
+

--- a/order/src/main/java/dukku/order/boundedContext/order/in/OrderEventListener.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/in/OrderEventListener.java
@@ -19,22 +19,22 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 /**
- * 결제 모듈 이벤트 수신으로 주문 상태를 동기화
- * 재시도/보상 라우팅은 동일 리스너에서 처리
+ * 결제 모듈 이벤트를 수신해 주문 상태를 갱신
+ * 재시도와 보상 흐름을 동일 리스너에서 처리
  */
 public class OrderEventListener {
     private final UpdateOrderStatusUseCase updateOrderStatusUseCase;
     private final UpdateOrderRefundStatusUseCase updateOrderRefundStatusUseCase;
     private final EventPublisher eventPublisher;
 
-    // payment.refund-completed: 환불 완료 이벤트 수신 시 주문 환불액/상태 반영
+    // payment.refund-completed 이벤트 수신 후 주문 환불 상태 반영
     @Retryable(backoff = @Backoff(delay = 1000))
     @org.springframework.kafka.annotation.KafkaListener(topics = "payment.refund-completed", groupId = "${spring.application.name}-group")
     public void handle(RefundCompletedEvent event) {
-        updateOrderRefundStatusUseCase.updateRefund(event.orderUuid(), event.refundAmount());
+        updateOrderRefundStatusUseCase.updateRefund(event.refundUuid(), event.orderUuid(), event.refundAmount());
     }
 
-    // 환불 완료 이벤트 반영 실패 시 수동 개입 필요 로그
+    // 환불 완료 이벤트 반영 실패 시 수동 확인이 필요하다는 로그 기록
     @Recover
     public void recoverRefund(Exception e, RefundCompletedEvent event) {
         log.error(
@@ -42,7 +42,7 @@ public class OrderEventListener {
                 event.orderUuid(), event.refundUuid(), event.refundAmount(), e);
     }
 
-    // payment.success: 결제 완료 이벤트 수신 시 주문 결제 성공 반영
+    // payment.success 이벤트 수신 후 주문 결제 성공 반영
     @Retryable(backoff = @Backoff(delay = 1000))
     @KafkaListener(topics = "payment.success", groupId = "${spring.application.name}-group")
     public void handle(PaymentSuccessEvent event) {
@@ -62,18 +62,18 @@ public class OrderEventListener {
                         "Order processing failed after payment success; trigger rollback refund"));
     }
 
-    // payment.failed: 결제 실패 이벤트 수신 시 주문 실패 상태 반영
+    // payment.failed 이벤트 수신 후 주문 실패 상태 반영
     @Retryable(backoff = @Backoff(delay = 1000))
     @KafkaListener(topics = "payment.failed", groupId = "${spring.application.name}-group")
     public void handle(PaymentFailedEvent event) {
         updateOrderStatusUseCase.failPayment(event.orderUuid());
     }
 
-    // payment.failed 처리 실패 시 수동 개입 필요 로그
+    // payment.failed 처리 실패 시 수동 확인이 필요하다는 로그 기록
     @Recover
     public void recoverFail(Exception e, PaymentFailedEvent event) {
         log.error(
-                "[CRITICAL] Payment failed event could not be persisted to order. manual action required. orderUuid={}",
+                "[CRITICAL] Payment failed event could not be persisted to order. manual action required. orderUuid= {}",
                 event.orderUuid(), e);
     }
 }

--- a/order/src/main/java/dukku/order/boundedContext/order/out/ProcessedRefundEventRepository.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/out/ProcessedRefundEventRepository.java
@@ -1,0 +1,13 @@
+package dukku.order.boundedContext.order.out;
+
+import dukku.order.boundedContext.order.entity.ProcessedRefundEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+/**
+ * 환불 이벤트 처리 여부를 조회해 중복 반영을 차단하는 레포지토리
+ */
+public interface ProcessedRefundEventRepository extends JpaRepository<ProcessedRefundEvent, Integer> {
+    boolean existsByRefundUuid(UUID refundUuid);
+}

--- a/order/src/test/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCaseHappyPathTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCaseHappyPathTest.java
@@ -1,5 +1,6 @@
 package dukku.order.boundedContext.order.app;
 
+import dukku.common.shared.order.exception.OrderRefundAmountOutOfRangeException;
 import dukku.common.shared.order.type.OrderStatus;
 import dukku.order.boundedContext.order.entity.Order;
 import org.junit.jupiter.api.DisplayName;
@@ -12,9 +13,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * 주문 환불 상태 갱신 UseCase의 정상 동작 테스트
+ */
 @ExtendWith(MockitoExtension.class)
 class UpdateOrderRefundStatusUseCaseHappyPathTest {
 
@@ -25,9 +30,10 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
     private UpdateOrderRefundStatusUseCase useCase;
 
     @Test
-    @DisplayName("주문 금액만큼 환불되면 환불 누적금이 갱신되고 상태가 CANCELED로 바뀐다")
+    @DisplayName("주문 금액만큼 환불되면 환불 누적액이 갱신되고 상태가 CANCELED로 변경된다")
     void appliesFullRefundToOrderStatus() {
-        // given: PAID 상태 주문과 전체 환불 금액이 주어진다.
+        // given: PAID 상태 주문과 전체 환불 금액 준비
+        UUID refundUuid = UUID.randomUUID();
         UUID orderUuid = UUID.randomUUID();
 
         Order order = Order.builder()
@@ -43,12 +49,66 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
 
         when(orderSupport.findOrderByUuid(orderUuid)).thenReturn(order);
 
-        // when: 환불 상태 업데이트를 실행한다.
-        useCase.updateRefund(orderUuid, 12000L);
+        // when: 환불 상태 업데이트 실행
+        useCase.updateRefund(refundUuid, orderUuid, 12000L);
 
-        // then: 누적 환불액이 갱신되고 주문 상태가 CANCELED로 전이된다.
+        // then: 누적 환불액과 주문 상태가 기대값으로 변경
         verify(orderSupport).findOrderByUuid(orderUuid);
         assertThat(order.getRefundedAmount()).isEqualTo(12000);
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("부분 환불 요청이면 환불 누적액이 갱신되고 상태가 PARTIAL_REFUNDED로 변경된다")
+    void appliesPartialRefundToOrderStatus() {
+        // given: PAID 상태 주문과 부분 환불 금액 준비
+        UUID refundUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+
+        Order order = Order.builder()
+                .uuid(orderUuid)
+                .userUuid(UUID.randomUUID())
+                .totalAmount(12000)
+                .address("seoul")
+                .recipient("tester")
+                .contactNumber("010-0000-0000")
+                .refundedAmount(0)
+                .status(OrderStatus.PAID)
+                .build();
+
+        when(orderSupport.findOrderByUuid(orderUuid)).thenReturn(order);
+
+        // when: 환불 상태 업데이트 실행
+        useCase.updateRefund(refundUuid, orderUuid, 5000L);
+
+        // then: 상태가 PARTIAL_REFUNDED로 반영되고 누적 환불액이 갱신
+        verify(orderSupport).findOrderByUuid(orderUuid);
+        assertThat(order.getRefundedAmount()).isEqualTo(5000);
+        assertThat(order.getStatus()).isEqualTo(OrderStatus.PARTIAL_REFUNDED);
+    }
+
+    @Test
+    @DisplayName("환불 금액이 int 범위를 넘으면 OrderRefundAmountOutOfRangeException이 발생한다")
+    void throwsWhenRefundAmountOutOfIntegerRange() {
+        // given: int 범위를 초과하는 환불 금액 준비
+        UUID refundUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+
+        Order order = Order.builder()
+                .uuid(orderUuid)
+                .userUuid(UUID.randomUUID())
+                .totalAmount(12000)
+                .address("seoul")
+                .recipient("tester")
+                .contactNumber("010-0000-0000")
+                .refundedAmount(0)
+                .status(OrderStatus.PAID)
+                .build();
+
+        when(orderSupport.findOrderByUuid(orderUuid)).thenReturn(order);
+
+        // when/then: 예외 발생 확인
+        assertThatThrownBy(() -> useCase.updateRefund(refundUuid, orderUuid, (long) Integer.MAX_VALUE + 1))
+                .isInstanceOf(OrderRefundAmountOutOfRangeException.class);
     }
 }

--- a/order/src/test/java/dukku/order/boundedContext/order/out/OrderEventListenerHappyPathTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/out/OrderEventListenerHappyPathTest.java
@@ -3,9 +3,9 @@ package dukku.order.boundedContext.order.out;
 import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.order.type.OrderStatus;
 import dukku.common.shared.payment.event.RefundCompletedEvent;
-import dukku.order.boundedContext.order.in.OrderEventListener;
 import dukku.order.boundedContext.order.app.UpdateOrderStatusUseCase;
 import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.in.OrderEventListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +18,9 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * payment.refund-completed 이벤트 수신 시 주문 상태 반영 동작 테스트
+ */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
         "spring.datasource.url=jdbc:h2:mem:order_listener_it;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
         "spring.datasource.driver-class-name=org.h2.Driver",
@@ -42,11 +45,9 @@ class OrderEventListenerHappyPathTest {
     @Autowired
     private OrderRepository orderRepository;
 
-    // payment.success/payment.failed 경로는 본 테스트 범위가 아니므로 mock 처리
     @MockitoBean
     private UpdateOrderStatusUseCase updateOrderStatusUseCase;
 
-    // Kafka publish 의존성을 제거하기 위해 mock 처리
     @MockitoBean
     private EventPublisher eventPublisher;
 
@@ -56,19 +57,10 @@ class OrderEventListenerHappyPathTest {
     }
 
     @Test
-    @DisplayName("전체 환불 이벤트를 수신하면 주문의 환불금액이 누적되고 상태가 CANCELED가 된다")
+    @DisplayName("전체 환불 이벤트를 수신하면 환불액이 누적되고 상태가 CANCELED로 바뀐다")
     void appliesFullRefundValuesFromEventToOrder() {
-        // given: PAID 주문이 저장되어 있고, 해당 주문으로 full refund 이벤트가 들어온다.
-        Order order = Order.builder()
-                .userUuid(UUID.randomUUID())
-                .totalAmount(15000)
-                .address("seoul")
-                .recipient("tester")
-                .contactNumber("010-1111-2222")
-                .refundedAmount(0)
-                .status(OrderStatus.PAID)
-                .build();
-        order = orderRepository.save(order);
+        // given: PAID 주문과 전체 환불 이벤트 준비
+        Order order = orderRepository.save(newOrder(15000));
 
         RefundCompletedEvent event = new RefundCompletedEvent(
                 UUID.randomUUID(),
@@ -79,29 +71,20 @@ class OrderEventListenerHappyPathTest {
                 UUID.randomUUID(),
                 LocalDateTime.now());
 
-        // when: order BC 리스너가 payment.refund-completed 이벤트를 처리한다.
+        // when: payment.refund-completed 이벤트 처리
         listener.handle(event);
 
-        // then: 실제 DB에 환불 금액이 누적되고 주문 상태가 CANCELED로 반영된다.
+        // then: 환불 금액 누적과 상태 변경 확인
         Order updated = orderRepository.findByUuid(order.getUuid()).orElseThrow();
         assertThat(updated.getRefundedAmount()).isEqualTo(15000);
         assertThat(updated.getStatus()).isEqualTo(OrderStatus.CANCELED);
     }
 
     @Test
-    @DisplayName("부분 환불 이벤트를 수신하면 주문의 환불금액이 누적되고 상태가 PARTIAL_REFUNDED가 된다")
+    @DisplayName("부분 환불 이벤트를 수신하면 환불액이 누적되고 상태가 PARTIAL_REFUNDED가 된다")
     void appliesPartialRefundValuesFromEventToOrder() {
-        // given: PAID 주문이 저장되어 있고, 부분 환불 이벤트가 들어온다.
-        Order order = Order.builder()
-                .userUuid(UUID.randomUUID())
-                .totalAmount(20000)
-                .address("seoul")
-                .recipient("tester")
-                .contactNumber("010-1111-2222")
-                .refundedAmount(0)
-                .status(OrderStatus.PAID)
-                .build();
-        order = orderRepository.save(order);
+        // given: PAID 주문과 부분 환불 이벤트 준비
+        Order order = orderRepository.save(newOrder(20000));
 
         RefundCompletedEvent event = new RefundCompletedEvent(
                 UUID.randomUUID(),
@@ -112,12 +95,83 @@ class OrderEventListenerHappyPathTest {
                 UUID.randomUUID(),
                 LocalDateTime.now());
 
-        // when: order BC 리스너가 payment.refund-completed 이벤트를 처리한다.
+        // when: payment.refund-completed 이벤트 처리
         listener.handle(event);
 
-        // then: 실제 DB에 부분 환불 금액이 반영되고 주문 상태가 PARTIAL_REFUNDED로 전이된다.
+        // then: 부분 환불 금액과 상태 반영 확인
         Order updated = orderRepository.findByUuid(order.getUuid()).orElseThrow();
         assertThat(updated.getRefundedAmount()).isEqualTo(5000);
         assertThat(updated.getStatus()).isEqualTo(OrderStatus.PARTIAL_REFUNDED);
+    }
+
+    @Test
+    @DisplayName("동일 refundUuid를 여러 번 받으면 최초 한 번만 반영된다")
+    void duplicateRefundCompletedEventIsAppliedTwiceInCurrentStage() {
+        // given: 동일 refundUuid를 가진 중복 이벤트 준비
+        Order order = orderRepository.save(newOrder(10000));
+        UUID refundUuid = UUID.randomUUID();
+
+        RefundCompletedEvent duplicated = new RefundCompletedEvent(
+                refundUuid,
+                UUID.randomUUID(),
+                order.getUuid(),
+                5000L,
+                0L,
+                UUID.randomUUID(),
+                LocalDateTime.now());
+
+        // when: 동일 이벤트를 두 번 처리
+        listener.handle(duplicated);
+        listener.handle(duplicated);
+
+        // then: 누적 환불액이 한 번만 반영되었는지 확인
+        Order updated = orderRepository.findByUuid(order.getUuid()).orElseThrow();
+        assertThat(updated.getRefundedAmount()).isEqualTo(10000);
+        assertThat(updated.getStatus()).isEqualTo(OrderStatus.CANCELED);
+    }
+
+    @Test
+    @DisplayName("서로 다른 refundUuid는 각각 별도로 반영된다")
+    void appliesDifferentRefundUuidsSeparately() {
+        // given: 서로 다른 refundUuid를 가진 이벤트 두 개 준비
+        Order order = orderRepository.save(newOrder(10000));
+
+        RefundCompletedEvent first = new RefundCompletedEvent(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                order.getUuid(),
+                5000L,
+                0L,
+                UUID.randomUUID(),
+                LocalDateTime.now());
+        RefundCompletedEvent second = new RefundCompletedEvent(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                order.getUuid(),
+                5000L,
+                0L,
+                UUID.randomUUID(),
+                LocalDateTime.now());
+
+        // when: 각 이벤트를 순차 처리
+        listener.handle(first);
+        listener.handle(second);
+
+        // then: 두 이벤트 금액이 모두 누적되는지 확인
+        Order updated = orderRepository.findByUuid(order.getUuid()).orElseThrow();
+        assertThat(updated.getRefundedAmount()).isEqualTo(10000);
+        assertThat(updated.getStatus()).isEqualTo(OrderStatus.CANCELED);
+    }
+
+    private Order newOrder(int totalAmount) {
+        return Order.builder()
+                .userUuid(UUID.randomUUID())
+                .totalAmount(totalAmount)
+                .address("seoul")
+                .recipient("tester")
+                .contactNumber("010-1111-2222")
+                .refundedAmount(0)
+                .status(OrderStatus.PAID)
+                .build();
     }
 }

--- a/order/src/test/java/dukku/order/boundedContext/order/out/OrderEventListenerHappyPathTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/out/OrderEventListenerHappyPathTest.java
@@ -6,6 +6,7 @@ import dukku.common.shared.payment.event.RefundCompletedEvent;
 import dukku.order.boundedContext.order.app.UpdateOrderStatusUseCase;
 import dukku.order.boundedContext.order.entity.Order;
 import dukku.order.boundedContext.order.in.OrderEventListener;
+import dukku.order.boundedContext.order.out.ProcessedRefundEventRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,6 +46,9 @@ class OrderEventListenerHappyPathTest {
     @Autowired
     private OrderRepository orderRepository;
 
+    @Autowired
+    private ProcessedRefundEventRepository processedRefundEventRepository;
+
     @MockitoBean
     private UpdateOrderStatusUseCase updateOrderStatusUseCase;
 
@@ -53,6 +57,7 @@ class OrderEventListenerHappyPathTest {
 
     @BeforeEach
     void cleanUp() {
+        processedRefundEventRepository.deleteAll();
         orderRepository.deleteAll();
     }
 
@@ -106,7 +111,7 @@ class OrderEventListenerHappyPathTest {
 
     @Test
     @DisplayName("동일 refundUuid를 여러 번 받으면 최초 한 번만 반영된다")
-    void duplicateRefundCompletedEventIsAppliedTwiceInCurrentStage() {
+    void duplicateRefundCompletedEventIsIgnored() {
         // given: 동일 refundUuid를 가진 중복 이벤트 준비
         Order order = orderRepository.save(newOrder(10000));
         UUID refundUuid = UUID.randomUUID();
@@ -124,10 +129,10 @@ class OrderEventListenerHappyPathTest {
         listener.handle(duplicated);
         listener.handle(duplicated);
 
-        // then: 누적 환불액이 한 번만 반영되었는지 확인
+        // then: 두 번째는 무시되어 5000만 반영
         Order updated = orderRepository.findByUuid(order.getUuid()).orElseThrow();
-        assertThat(updated.getRefundedAmount()).isEqualTo(10000);
-        assertThat(updated.getStatus()).isEqualTo(OrderStatus.CANCELED);
+        assertThat(updated.getRefundedAmount()).isEqualTo(5000);
+        assertThat(updated.getStatus()).isEqualTo(OrderStatus.PARTIAL_REFUNDED);
     }
 
     @Test

--- a/payment/src/main/java/dukku/payment/boundedContext/payment/entity/Refund.java
+++ b/payment/src/main/java/dukku/payment/boundedContext/payment/entity/Refund.java
@@ -19,14 +19,12 @@ import java.util.List;
 /**
  * 환불 정보 엔티티
  *
- * <p>
- * 특정 {@code Payment}에 대한 환불 처리를 기록한다.
- * 총 환불 금액과 예치금으로 환불된 금액을 나누어 관리한다.
- *
+ * <p>특정 {@code Payment}에 대한 환불 처리 내역을 관리</p>
+ * <p>총 환불 금액과 예치금 환불 금액을 분리해 저장</p>
  * <h3>금액 필드 설명</h3>
  * <ul>
- * <li>{@code refundAmountTotal} - 총 환불 금액 (PG 취소액 + 예치금 환불액)</li>
- * <li>{@code refundDepositTotal} - 이 중 예치금으로 복구된 금액</li>
+ * <li>{@code refundAmountTotal} - 총 환불 금액</li>
+ * <li>{@code refundDepositTotal} - 예치금으로 환불한 금액</li>
  * </ul>
  */
 @Entity
@@ -44,24 +42,24 @@ public class Refund extends BaseIdAndUUIDAndTime {
     @Column(nullable = false, comment = "총 환불 금액")
     private Long refundAmountTotal;
 
-    @Column(nullable = false, comment = "예치금으로 복구된 금액")
+    @Column(nullable = false, comment = "예치금으로 환불한 금액")
     private Long refundDepositTotal;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, comment = "환불 상태")
     private RefundStatus refundStatus;
 
-    @Column(comment = "환불 승인일")
+    @Column(comment = "환불 확정 시각")
     private LocalDateTime approvedAt;
 
-    @Column(unique = true, length = 100, comment = "멱등성 키 (중복 환불 방지)")
+    @Column(unique = true, length = 100, comment = "멱등성 키")
     private String idempotencyKey;
 
     @Builder.Default
     @OneToMany(mappedBy = "refund", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RefundItem> items = new ArrayList<>();
 
-    // === 정적 팩토리 메서드 ===
+    // 정적 팩토리 메서드
 
     public static Refund create(Payment payment, Long amount, Long depositAmount, String idempotencyKey) {
         return Refund.builder()
@@ -73,7 +71,7 @@ public class Refund extends BaseIdAndUUIDAndTime {
                 .build();
     }
 
-    // === 도메인 로직 ===
+    // 도메인 상태 전이
 
     public void complete() {
         if (this.refundStatus == RefundStatus.COMPLETED) {
@@ -91,19 +89,19 @@ public class Refund extends BaseIdAndUUIDAndTime {
         this.items.add(item);
     }
 
-    // === DTO 변환 ===
+    // DTO 변환
 
     public PaymentRefundResponse toPaymentRefundResponse(Long pgRefundAmount, String tossOrderId) {
         boolean completed = this.refundStatus == RefundStatus.COMPLETED;
         String responseCode = completed ? "REFUND_COMPLETED" : "REFUND_PENDING";
-        String responseMessage = completed ? "환불이 완료되었습니다." : "환불 요청이 접수되었습니다.";
+        String responseMessage = completed ? "환불이 완료되었습니다" : "환불 요청이 접수되었습니다";
 
         return PaymentRefundResponse.builder()
                 .success(true)
                 .code(responseCode)
                 .message(responseMessage)
                 .data(PaymentRefundResponse.RefundData.builder()
-                        .refundId(this.getUuid())
+                        .refundUuid(this.getUuid())
                         .paymentId(this.payment.getUuid())
                         .orderUuid(this.payment.getOrderUuid())
                         .status(this.payment.getPaymentStatus())

--- a/payment/src/main/java/dukku/payment/boundedContext/payment/in/PaymentEventListener.java
+++ b/payment/src/main/java/dukku/payment/boundedContext/payment/in/PaymentEventListener.java
@@ -5,8 +5,6 @@ import dukku.common.shared.deposit.event.DepositDeductionFailedEvent;
 import dukku.common.shared.deposit.event.DepositRefundFailedEvent;
 import dukku.common.shared.deposit.event.DepositRefundedEvent;
 import dukku.common.shared.order.event.PaymentRollbackRequestEvent;
-import dukku.common.shared.payment.dto.PaymentRefundRequest;
-import dukku.common.shared.payment.dto.PaymentRefundResponse;
 import dukku.common.shared.payment.event.RefundCompletedEvent;
 import dukku.common.shared.payment.type.PaymentHistoryType;
 import dukku.common.shared.payment.type.PaymentStatus;
@@ -20,13 +18,11 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 /**
- * 결제 도메인 이벤트 리스너 (Inbound Adapter)
+ * 결제 도메인 이벤트 리스너
  *
- * <p>
- * 외부 시스템(주문, 예치금 등)에서 발생한 이벤트를 수신해 결제 도메인 로직 구동
+ * <p>주문과 예치금 도메인에서 전달된 이벤트를 수신해 결제 상태를 전이</p>
  */
 @Component
 @RequiredArgsConstructor
@@ -38,101 +34,66 @@ public class PaymentEventListener {
     private final EventPublisher eventPublisher;
 
     /**
-     * 예치금 차감 실패 시 보상 트랜잭션(결제 취소) 처리
-     *
-     * <p>
-     * DepositDeductionFailedEvent 수신 시 이미 승인된 PG 결제를 취소해 데이터 일관성 유지
+     * 예치금 차감 실패 시 결제 보상 트랜잭션 처리
      */
     @KafkaListener(topics = "deposit.deduction-failed", groupId = "${spring.application.name}-group")
     public void handle(DepositDeductionFailedEvent event) {
-        // 예치금 차감 실패는 주문 보상 결제 프로세스 트리거
-        log.warn("[결제 보상] 예치금 차감 실패 수신: orderUuid={}, reason={}",
-                event.orderUuid(), event.reason());
-
+        // 예치금 차감 실패를 결제 보상 흐름으로 전환
         paymentFacade.compensatePayment(event.orderUuid(), event.reason());
     }
 
     /**
-     * 주문 처리 실패 시 결제 롤백(자동 환불) 처리
+     * 주문 처리 실패 시 결제 롤백 이벤트 처리
      */
     @KafkaListener(topics = "payment.rollback", groupId = "${spring.application.name}-group")
     public void handle(PaymentRollbackRequestEvent event) {
-        // 주문 롤백 이벤트는 주문 단위의 모든 결제 건을 순차 환불 처리
-        log.info("[결제 롤백] 주문 처리 실패로 인한 자동 환불 시작: orderUuid={}, reason={}",
-                event.orderUuid(), event.reason());
-
-        List<Payment> payments = paymentSupport.findPaymentsByOrderUuid(event.orderUuid());
-
-        for (Payment payment : payments) {
-            try {
-                // 단건 환불을 위한 request 구성
-                PaymentRefundRequest refundRequest = PaymentRefundRequest.builder()
-                        .paymentId(payment.getUuid())
-                        .orderUuid(event.orderUuid())
-                        .refundAmount(payment.getAmount() - payment.getRefundTotal())
-                        .reason(event.reason())
-                        .build();
-
-                // 부분 실패가 전체 루프를 막지 않도록 결제 건 단위로 try-catch 격리
-                PaymentRefundResponse response = paymentFacade.refundPayment(refundRequest,
-                        "rollback-" + payment.getUuid());
-                if (response.isSuccess()) {
-                    log.info("[결제 롤백] 환불 완료: paymentUuid={}", payment.getUuid());
-                } else {
-                    log.error("[결제 롤백] PG 환불 실패: paymentUuid={}, code={}, message={}",
-                            payment.getUuid(), response.getCode(), response.getMessage());
-                }
-            } catch (Exception e) {
-                // 자동 롤백 프로세스 중 발생하는 모든 예외를 잡아 로그를 남겨야 함
-                // 여기서 예외를 놓치면 결제는 성공했는데 주문은 실패한 상태로 남을 수 있음 (데이터 불일치)
-                // 상위로 전파하면 다른 결제 건의 롤백이 중단될 수 있으므로, 여기서 예외를 먹고 CRITICAL 로그를 남겨 수동 조치 유도
-                log.error("[결제 롤백] 환불 처리 중 예외: paymentUuid={}, error={}",
-                        payment.getUuid(), e.getMessage());
-                // 예외는 로그 후 다음 결제 건 처리로 넘어가 전체 롤백 중단 방지
-            }
-        }
+        // 주문 단위 롤백 요청을 받아 결제 보상 실행
+        paymentFacade.compensatePayment(event.orderUuid(), event.reason());
     }
 
     /**
-     * 예치금 환불(복구) 성공 시 환불 Saga 완료 처리
+     * 예치금 환불 완료 이벤트 처리
      */
     @KafkaListener(topics = "deposit.refunded", groupId = "${spring.application.name}-group")
     public void handle(DepositRefundedEvent event) {
         paymentSupport.findRefundByUuid(event.refundUuid()).ifPresentOrElse(refund -> {
-            // 이미 완료된 환불이면 중복 이벤트로 보고 무시
+            // 이미 완료된 환불은 중복 이벤트로 간주
             if (refund.getRefundStatus() == RefundStatus.COMPLETED) {
+                log.warn("[결제 Saga 중복] 이미 완료된 환불 이벤트는 무시 refundUuid={}", event.refundUuid());
                 return;
             }
 
             refund.complete();
             paymentSupport.saveRefund(refund);
+
+            Payment payment = refund.getPayment();
             eventPublisher.publish(new RefundCompletedEvent(
                     refund.getUuid(),
-                    event.paymentUuid(),
-                    event.orderUuid(),
+                    payment.getUuid(),
+                    payment.getOrderUuid(),
                     refund.getRefundAmountTotal(),
                     refund.getRefundDepositTotal(),
-                    event.userUuid(),
+                    payment.getUserUuid(),
                     LocalDateTime.now()));
-            log.info("[환불 Saga] refundUuid={}, paymentUuid={}", event.refundUuid(), event.paymentUuid());
-        }, () -> log.warn("[환불 Saga] refund 이벤트 조회 실패: refundUuid={}, paymentUuid={}",
+        }, () -> log.warn("[결제 Saga 실패] deposit.refunded 조회 실패 refundUuid={}, paymentUuid={}",
                 event.refundUuid(), event.paymentUuid()));
     }
 
     /**
-     * 예치금 환불(복구) 실패 시 결제/환불 상태를 장애 상태로 전환
+     * 예치금 환불 실패 이벤트 처리
      */
     @KafkaListener(topics = "deposit.refund.failed", groupId = "${spring.application.name}-group")
     public void handle(DepositRefundFailedEvent event) {
-        // 환불 실패 시 refund 상태를 취소로 전환하고 주문 결제 상태도 장애로 반영
+        // 환불 엔티티를 취소 상태로 전환
         paymentSupport.findRefundByUuid(event.refundUuid()).ifPresentOrElse(refund -> {
             if (refund.getRefundStatus() == RefundStatus.COMPLETED) {
-                log.warn("[환불 Saga 실패] 이미 완료된 환불입니다. refundUuid={}", event.refundUuid());
+                log.warn("[결제 Saga 실패] 이미 완료된 환불 refundUuid={}", event.refundUuid());
                 return;
             }
+
             refund.cancel();
             paymentSupport.saveRefund(refund);
-        }, () -> log.warn("[환불 Saga 실패] refund 이벤트 조회 실패: refundUuid={}, paymentUuid={}",
+        }, () -> log.warn("[결제 Saga 실패] deposit.refund.failed 조회 실패 refundUuid={}, paymentUuid={}",
                 event.refundUuid(), event.paymentUuid()));
 
         paymentSupport.findPaymentByUuidOptional(event.paymentUuid()).ifPresentOrElse(payment -> {
@@ -143,14 +104,31 @@ public class PaymentEventListener {
             PaymentStatus originStatus = payment.getPaymentStatus();
             Long originAmountPg = payment.getAmountPg();
             Long originDeposit = payment.getPaymentDeposit();
+            PaymentHistoryType historyType = resolveRefundFailureHistoryType(originStatus);
 
             payment.rollbackFailedStatus();
             paymentSupport.savePayment(payment);
-            paymentSupport.createHistory(payment, PaymentHistoryType.PAYMENT_ROLLBACK_FAILED,
+            paymentSupport.createHistory(payment, historyType,
                     originStatus, originAmountPg, originDeposit);
 
-            log.error("[환불 Saga 실패] deposit.refund 실패: paymentUuid={}, reason={}",
+            log.error("[결제 Saga 실패] deposit.refund.failed 처리 paymentUuid={}, reason={}",
                     event.paymentUuid(), event.reason());
-        }, () -> log.warn("[환불 Saga 실패] paymentUuid 조회 실패: paymentUuid={}", event.paymentUuid()));
+        }, () -> log.warn("[결제 Saga 실패] payment 조회 실패 paymentUuid={}", event.paymentUuid()));
+    }
+
+    /**
+     * 환불 실패 전 상태를 기준으로 이력 타입 계산
+     *
+     * @param originStatus 환불 실패 직전 결제 상태
+     * @return 실패 이력 타입
+     */
+    private PaymentHistoryType resolveRefundFailureHistoryType(PaymentStatus originStatus) {
+        if (originStatus == PaymentStatus.CANCELED) {
+            return PaymentHistoryType.FULL_REFUND_FAILED;
+        }
+        if (originStatus == PaymentStatus.PARTIAL_CANCELED) {
+            return PaymentHistoryType.PARTIAL_REFUND_FAILED;
+        }
+        return PaymentHistoryType.PAYMENT_ROLLBACK_FAILED;
     }
 }

--- a/payment/src/test/java/dukku/payment/boundedContext/payment/app/RefundPaymentFailureHistoryIntegrationTest.java
+++ b/payment/src/test/java/dukku/payment/boundedContext/payment/app/RefundPaymentFailureHistoryIntegrationTest.java
@@ -1,0 +1,177 @@
+package dukku.payment.boundedContext.payment.app;
+
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.payment.dto.PaymentRefundRequest;
+import dukku.common.shared.payment.dto.PaymentRefundResponse;
+import dukku.common.shared.payment.type.PaymentHistoryType;
+import dukku.common.shared.payment.type.PaymentStatus;
+import dukku.common.shared.payment.type.PaymentType;
+import dukku.payment.boundedContext.payment.entity.Payment;
+import dukku.payment.boundedContext.payment.entity.PaymentHistory;
+import dukku.payment.boundedContext.payment.out.PaymentHistoryRepository;
+import dukku.payment.boundedContext.payment.out.PaymentOrderItemRepository;
+import dukku.payment.boundedContext.payment.out.PaymentRepository;
+import dukku.payment.boundedContext.payment.out.RefundItemRepository;
+import dukku.payment.boundedContext.payment.out.RefundRepository;
+import dukku.payment.boundedContext.payment.out.TossPaymentClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * PG 환불 실패 응답 시 결제 이력 기록(PAYMENT_ROLLBACK_FAILED)을 검증한 테스트
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+        "spring.datasource.url=jdbc:h2:mem:payment_refund_fail_history_it;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.kafka.listener.auto-startup=false",
+        "spring.kafka.bootstrap-servers=localhost:9092",
+        "spring.data.redis.host=localhost",
+        "spring.data.redis.port=6379",
+        "spring.elasticsearch.uris=http://localhost:9200",
+        "jwt.access.secret.key=dGhpcy1rZXktaXMtdGVzdC1rZXktYWNjZXNzLTAxMjM=",
+        "jwt.refresh.secret.key=dGhpcy1rZXktaXMtdGVzdC1rZXktcmVmcmVzaC0wMTI=",
+        "crypto.key=dGhpcy1rZXktaXMtdGVzdC1rZXktY3J5cHRvLTAxMjM="
+})
+@Transactional
+class RefundPaymentFailureHistoryIntegrationTest {
+
+    @Autowired
+    private RefundPaymentUseCase refundPaymentUseCase;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private PaymentHistoryRepository paymentHistoryRepository;
+
+    @Autowired
+    private RefundRepository refundRepository;
+
+    @Autowired
+    private RefundItemRepository refundItemRepository;
+
+    @Autowired
+    private PaymentOrderItemRepository paymentOrderItemRepository;
+
+    @MockitoBean
+    private TossPaymentClient tossPaymentClient;
+
+    @MockitoBean
+    private EventPublisher eventPublisher;
+
+    @BeforeEach
+    void cleanUp() {
+        paymentHistoryRepository.deleteAll();
+        refundItemRepository.deleteAll();
+        refundRepository.deleteAll();
+        paymentOrderItemRepository.deleteAll();
+        paymentRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("PG 환불 실패 시 전체 환불 요청은 PAYMENT_ROLLBACK_FAILED 이력이 기록된다")
+    void fullRefundFailureWritesPaymentRollbackFailedHistory() {
+        // given: 전체 환불 요청과 PG 취소 실패 응답 준비
+        Payment payment = createDonePayment(
+                20000L,
+                5000L,
+                15000L,
+                PaymentType.MIXED,
+                "pg-key-fail-full-1",
+                "toss-order-fail-full-1");
+
+        PaymentRefundRequest request = PaymentRefundRequest.builder()
+                .paymentId(payment.getUuid())
+                .orderUuid(payment.getOrderUuid())
+                .refundAmount(20000L)
+                .reason("customer_cancel_request")
+                .build();
+
+        when(tossPaymentClient.cancel(eq("pg-key-fail-full-1"), anyMap()))
+                .thenReturn(Map.of("statusCode", 500, "message", "pg fail"));
+
+        // when: 환불 유스케이스 실행
+        PaymentRefundResponse response = refundPaymentUseCase.execute(request, "idem-fail-full-1");
+
+        // then: 결제는 rollback-failed로 전이되고 PAYMENT_ROLLBACK_FAILED 이력이 남는다
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getCode()).isEqualTo("PG_CANCEL_FAILED");
+
+        Payment updated = paymentRepository.findByUuid(payment.getUuid()).orElseThrow();
+        assertThat(updated.getPaymentStatus()).isEqualTo(PaymentStatus.ROLLBACK_FAILED);
+
+        List<PaymentHistory> histories = paymentHistoryRepository.findByPaymentId(updated.getId());
+        assertThat(histories).hasSize(1);
+        assertThat(histories.get(0).getType()).isEqualTo(PaymentHistoryType.PAYMENT_ROLLBACK_FAILED);
+    }
+
+    @Test
+    @DisplayName("PG 환불 실패 시 부분 환불 요청은 PAYMENT_ROLLBACK_FAILED 이력이 기록된다")
+    void partialRefundFailureWritesPaymentRollbackFailedHistory() {
+        // given: 부분 환불 요청과 PG 취소 실패 응답 준비
+        Payment payment = createDonePayment(
+                20000L,
+                5000L,
+                15000L,
+                PaymentType.MIXED,
+                "pg-key-fail-partial-1",
+                "toss-order-fail-partial-1");
+
+        PaymentRefundRequest request = PaymentRefundRequest.builder()
+                .paymentId(payment.getUuid())
+                .orderUuid(payment.getOrderUuid())
+                .refundAmount(7000L)
+                .reason("customer_cancel_request")
+                .build();
+
+        when(tossPaymentClient.cancel(eq("pg-key-fail-partial-1"), anyMap()))
+                .thenReturn(Map.of("statusCode", 500, "message", "pg fail"));
+
+        // when: 환불 유스케이스 실행
+        PaymentRefundResponse response = refundPaymentUseCase.execute(request, "idem-fail-partial-1");
+
+        // then: 결제는 rollback-failed로 전이되고 PAYMENT_ROLLBACK_FAILED 이력이 남는다
+        assertThat(response.isSuccess()).isFalse();
+        assertThat(response.getCode()).isEqualTo("PG_CANCEL_FAILED");
+
+        Payment updated = paymentRepository.findByUuid(payment.getUuid()).orElseThrow();
+        assertThat(updated.getPaymentStatus()).isEqualTo(PaymentStatus.ROLLBACK_FAILED);
+
+        List<PaymentHistory> histories = paymentHistoryRepository.findByPaymentId(updated.getId());
+        assertThat(histories).hasSize(1);
+        assertThat(histories.get(0).getType()).isEqualTo(PaymentHistoryType.PAYMENT_ROLLBACK_FAILED);
+    }
+
+    private Payment createDonePayment(Long amount, Long depositAmount, Long pgAmount,
+                                      PaymentType paymentType, String pgPaymentKey, String tossOrderId) {
+        Payment payment = Payment.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                amount,
+                depositAmount,
+                pgAmount,
+                0L,
+                paymentType,
+                tossOrderId);
+        payment.approve(pgPaymentKey);
+        return paymentRepository.save(payment);
+    }
+}

--- a/payment/src/test/java/dukku/payment/boundedContext/payment/app/RefundSagaLifecycleIntegrationTest.java
+++ b/payment/src/test/java/dukku/payment/boundedContext/payment/app/RefundSagaLifecycleIntegrationTest.java
@@ -1,0 +1,312 @@
+package dukku.payment.boundedContext.payment.app;
+
+import dukku.common.global.event.DomainEvent;
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.deposit.event.DepositRefundFailedEvent;
+import dukku.common.shared.deposit.event.DepositRefundedEvent;
+import dukku.common.shared.deposit.type.DepositFailureCode;
+import dukku.common.shared.payment.dto.PaymentRefundRequest;
+import dukku.common.shared.payment.event.RefundCompletedEvent;
+import dukku.common.shared.payment.event.RefundRequestedEvent;
+import dukku.common.shared.payment.type.PaymentHistoryType;
+import dukku.common.shared.payment.type.PaymentStatus;
+import dukku.common.shared.payment.type.PaymentType;
+import dukku.common.shared.payment.type.RefundStatus;
+import dukku.payment.boundedContext.payment.entity.Payment;
+import dukku.payment.boundedContext.payment.entity.PaymentHistory;
+import dukku.payment.boundedContext.payment.entity.Refund;
+import dukku.payment.boundedContext.payment.in.PaymentEventListener;
+import dukku.payment.boundedContext.payment.out.PaymentHistoryRepository;
+import dukku.payment.boundedContext.payment.out.PaymentRepository;
+import dukku.payment.boundedContext.payment.out.RefundItemRepository;
+import dukku.payment.boundedContext.payment.out.RefundRepository;
+import dukku.payment.boundedContext.payment.out.TossPaymentClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * deposit.refunded / deposit.refund.failed 이벤트를 기준으로 환불 Saga 흐름 검증
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+        "spring.datasource.url=jdbc:h2:mem:payment_refund_saga_it;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.kafka.listener.auto-startup=false",
+        "spring.kafka.bootstrap-servers=localhost:9092",
+        "spring.data.redis.host=localhost",
+        "spring.data.redis.port=6379",
+        "spring.elasticsearch.uris=http://localhost:9200",
+        "jwt.access.secret.key=dGhpcy1rZXktaXMtdGVzdC1rZXktYWNjZXNzLTAxMjM=",
+        "jwt.refresh.secret.key=dGhpcy1rZXktaXMtdGVzdC1rZXktcmVmcmVzaC0wMTI=",
+        "crypto.key=dGhpcy1rZXktaXMtdGVzdC1rZXktY3J5cHRvLTAxMjM="
+})
+@Transactional
+class RefundSagaLifecycleIntegrationTest {
+
+    @Autowired
+    private RefundPaymentUseCase refundPaymentUseCase;
+
+    @Autowired
+    private PaymentEventListener paymentEventListener;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private RefundRepository refundRepository;
+
+    @Autowired
+    private RefundItemRepository refundItemRepository;
+
+    @Autowired
+    private PaymentHistoryRepository paymentHistoryRepository;
+
+    @MockitoBean
+    private TossPaymentClient tossPaymentClient;
+
+    @MockitoBean
+    private EventPublisher eventPublisher;
+
+    @BeforeEach
+    void cleanUp() {
+        paymentHistoryRepository.deleteAll();
+        refundItemRepository.deleteAll();
+        refundRepository.deleteAll();
+        paymentRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("deposit.refunded 이벤트에서 refund가 COMPLETED로 전환되고 Saga 흐름이 완료되는지 검증")
+    void sagaCompletesWhenDepositRefunded() {
+        // given: DONE 상태 결제에서 전체 환불 요청 준비
+        Payment payment = createDonePayment(
+                20000L,
+                15000L,
+                5000L,
+                PaymentType.MIXED,
+                "pg-key-saga-complete-1",
+                "toss-order-saga-complete-1");
+
+        PaymentRefundRequest request = PaymentRefundRequest.builder()
+                .paymentId(payment.getUuid())
+                .orderUuid(payment.getOrderUuid())
+                .refundAmount(20000L)
+                .reason("customer_cancel_request")
+                .build();
+
+        when(tossPaymentClient.cancel(eq("pg-key-saga-complete-1"), anyMap()))
+                .thenReturn(Map.of("statusCode", 200));
+
+        // when: 환불 요청 실행 후 deposit.refunded 이벤트 전달
+        refundPaymentUseCase.execute(request, "idem-saga-complete-1");
+
+        Refund refund = refundRepository.findByIdempotencyKey("idem-saga-complete-1").orElseThrow();
+        assertThat(refund.getRefundStatus()).isEqualTo(RefundStatus.PENDING);
+
+        paymentEventListener.handle(new DepositRefundedEvent(
+                refund.getUuid(),
+                payment.getUuid(),
+                payment.getOrderUuid(),
+                payment.getUserUuid(),
+                refund.getRefundDepositTotal()));
+
+        // then: refund가 COMPLETED가 되고 이벤트가 순서대로 발행되는지 확인
+        Refund updatedRefund = refundRepository.findByUuid(refund.getUuid()).orElseThrow();
+        assertThat(updatedRefund.getRefundStatus()).isEqualTo(RefundStatus.COMPLETED);
+
+        ArgumentCaptor<DomainEvent> eventCaptor = ArgumentCaptor.forClass(DomainEvent.class);
+        verify(eventPublisher, times(2)).publish(eventCaptor.capture());
+
+        List<DomainEvent> events = eventCaptor.getAllValues();
+        assertThat(events).hasSize(2);
+        assertThat(events.get(0)).isInstanceOf(RefundRequestedEvent.class);
+        assertThat(events.get(1)).isInstanceOf(RefundCompletedEvent.class);
+        assertThat(events).extracting(DomainEvent::getTopic)
+                .containsExactly("payment.refund-requested", "payment.refund-completed");
+    }
+
+    @Test
+    @DisplayName("deposit.refunded 이벤트에서 부분 환불은 PARTIAL_CANCELED를 유지한 채 COMPLETED 되는지 검증")
+    void partialSagaCompletesWhenDepositRefunded() {
+        // given: 부분 환불 요청 준비
+        Payment payment = createDonePayment(
+                20000L,
+                15000L,
+                5000L,
+                PaymentType.MIXED,
+                "pg-key-saga-partial-complete-1",
+                "toss-order-saga-partial-complete-1");
+
+        PaymentRefundRequest request = PaymentRefundRequest.builder()
+                .paymentId(payment.getUuid())
+                .orderUuid(payment.getOrderUuid())
+                .refundAmount(7000L)
+                .reason("customer_partial_cancel")
+                .build();
+
+        // when: 환불 요청 실행 후 deposit.refunded 이벤트 전달
+        refundPaymentUseCase.execute(request, "idem-saga-partial-complete-1");
+
+        Refund refund = refundRepository.findByIdempotencyKey("idem-saga-partial-complete-1").orElseThrow();
+        Payment afterRequest = paymentRepository.findByUuid(payment.getUuid()).orElseThrow();
+        assertThat(refund.getRefundStatus()).isEqualTo(RefundStatus.PENDING);
+        assertThat(afterRequest.getPaymentStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+
+        paymentEventListener.handle(new DepositRefundedEvent(
+                refund.getUuid(),
+                payment.getUuid(),
+                payment.getOrderUuid(),
+                payment.getUserUuid(),
+                refund.getRefundDepositTotal()));
+
+        // then: refund만 COMPLETED로 바뀌고 payment는 PARTIAL_CANCELED 유지
+        Refund updatedRefund = refundRepository.findByUuid(refund.getUuid()).orElseThrow();
+        Payment updatedPayment = paymentRepository.findByUuid(payment.getUuid()).orElseThrow();
+        assertThat(updatedRefund.getRefundStatus()).isEqualTo(RefundStatus.COMPLETED);
+        assertThat(updatedPayment.getPaymentStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+
+        ArgumentCaptor<DomainEvent> eventCaptor = ArgumentCaptor.forClass(DomainEvent.class);
+        verify(eventPublisher, times(2)).publish(eventCaptor.capture());
+
+        List<DomainEvent> events = eventCaptor.getAllValues();
+        assertThat(events).hasSize(2);
+        assertThat(events.get(0)).isInstanceOf(RefundRequestedEvent.class);
+        assertThat(events.get(1)).isInstanceOf(RefundCompletedEvent.class);
+        assertThat(events).extracting(DomainEvent::getTopic)
+                .containsExactly("payment.refund-requested", "payment.refund-completed");
+    }
+
+    @Test
+    @DisplayName("deposit.refund.failed 이벤트에서 FULL 환불이 ROLLBACK_FAILED로 전환되며 FULL_REFUND_FAILED 이력이 남는지 검증")
+    void sagaFailureRecordsFullRefundFailedHistory() {
+        // given: 전체 환불 요청 준비
+        Payment payment = createDonePayment(
+                20000L,
+                15000L,
+                5000L,
+                PaymentType.MIXED,
+                "pg-key-saga-fail-1",
+                "toss-order-saga-fail-1");
+
+        PaymentRefundRequest request = PaymentRefundRequest.builder()
+                .paymentId(payment.getUuid())
+                .orderUuid(payment.getOrderUuid())
+                .refundAmount(20000L)
+                .reason("customer_cancel_request")
+                .build();
+
+        when(tossPaymentClient.cancel(eq("pg-key-saga-fail-1"), anyMap()))
+                .thenReturn(Map.of("statusCode", 200));
+
+        // when: 환불 요청 실행 후 deposit.refund.failed 이벤트 전달
+        refundPaymentUseCase.execute(request, "idem-saga-fail-1");
+
+        Refund refund = refundRepository.findByIdempotencyKey("idem-saga-fail-1").orElseThrow();
+        paymentEventListener.handle(new DepositRefundFailedEvent(
+                refund.getUuid(),
+                payment.getOrderUuid(),
+                payment.getUuid(),
+                payment.getUserUuid(),
+                refund.getRefundDepositTotal(),
+                DepositFailureCode.PERSISTENCE_ERROR,
+                true,
+                "forced failure",
+                LocalDateTime.now()));
+
+        // then: payment는 rollback-failed, refund는 canceled, 이력은 FULL_REFUND_FAILED 포함
+        Payment updatedPayment = paymentRepository.findByUuid(payment.getUuid()).orElseThrow();
+        Refund updatedRefund = refundRepository.findByUuid(refund.getUuid()).orElseThrow();
+
+        assertThat(updatedPayment.getPaymentStatus()).isEqualTo(PaymentStatus.ROLLBACK_FAILED);
+        assertThat(updatedRefund.getRefundStatus()).isEqualTo(RefundStatus.CANCELED);
+
+        List<PaymentHistory> histories = paymentHistoryRepository.findByPaymentId(updatedPayment.getId());
+        assertThat(histories).extracting(PaymentHistory::getType)
+                .contains(PaymentHistoryType.FULL_REFUND_SUCCESS, PaymentHistoryType.FULL_REFUND_FAILED);
+    }
+
+    @Test
+    @DisplayName("deposit.refund.failed 이벤트에서 부분 환불이 ROLLBACK_FAILED로 전환되며 PARTIAL_REFUND_FAILED 이력이 남는지 검증")
+    void sagaFailureRecordsPartialRefundFailedHistory() {
+        // given: 부분 환불 요청 준비
+        Payment payment = createDonePayment(
+                20000L,
+                15000L,
+                5000L,
+                PaymentType.MIXED,
+                "pg-key-saga-partial-fail-1",
+                "toss-order-saga-partial-fail-1");
+
+        PaymentRefundRequest request = PaymentRefundRequest.builder()
+                .paymentId(payment.getUuid())
+                .orderUuid(payment.getOrderUuid())
+                .refundAmount(7000L)
+                .reason("customer_partial_cancel")
+                .build();
+
+        // when: 환불 요청 실행 후 deposit.refund.failed 이벤트 전달
+        refundPaymentUseCase.execute(request, "idem-saga-partial-fail-1");
+
+        Refund refund = refundRepository.findByIdempotencyKey("idem-saga-partial-fail-1").orElseThrow();
+        Payment afterRequest = paymentRepository.findByUuid(payment.getUuid()).orElseThrow();
+        assertThat(afterRequest.getPaymentStatus()).isEqualTo(PaymentStatus.PARTIAL_CANCELED);
+
+        paymentEventListener.handle(new DepositRefundFailedEvent(
+                refund.getUuid(),
+                payment.getOrderUuid(),
+                payment.getUuid(),
+                payment.getUserUuid(),
+                refund.getRefundDepositTotal(),
+                DepositFailureCode.PERSISTENCE_ERROR,
+                true,
+                "forced partial failure",
+                LocalDateTime.now()));
+
+        // then: payment는 rollback-failed, refund는 canceled, 이력은 PARTIAL_REFUND_FAILED 포함
+        Payment updatedPayment = paymentRepository.findByUuid(payment.getUuid()).orElseThrow();
+        Refund updatedRefund = refundRepository.findByUuid(refund.getUuid()).orElseThrow();
+
+        assertThat(updatedPayment.getPaymentStatus()).isEqualTo(PaymentStatus.ROLLBACK_FAILED);
+        assertThat(updatedRefund.getRefundStatus()).isEqualTo(RefundStatus.CANCELED);
+
+        List<PaymentHistory> histories = paymentHistoryRepository.findByPaymentId(updatedPayment.getId());
+        assertThat(histories).extracting(PaymentHistory::getType)
+                .contains(PaymentHistoryType.PARTIAL_REFUND_SUCCESS, PaymentHistoryType.PARTIAL_REFUND_FAILED);
+    }
+
+    private Payment createDonePayment(Long amount, Long depositAmount, Long pgAmount,
+                                      PaymentType paymentType, String pgPaymentKey, String tossOrderId) {
+        Payment payment = Payment.create(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                amount,
+                depositAmount,
+                pgAmount,
+                0L,
+                paymentType,
+                tossOrderId);
+        payment.approve(pgPaymentKey);
+        return paymentRepository.save(payment);
+    }
+}

--- a/payment/src/test/java/dukku/payment/boundedContext/payment/in/PaymentEventListenerHappyPathTest.java
+++ b/payment/src/test/java/dukku/payment/boundedContext/payment/in/PaymentEventListenerHappyPathTest.java
@@ -2,9 +2,13 @@ package dukku.payment.boundedContext.payment.in;
 
 import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.deposit.event.DepositRefundFailedEvent;
+import dukku.common.shared.deposit.event.DepositRefundedEvent;
+import dukku.common.shared.deposit.type.DepositFailureCode;
+import dukku.common.shared.payment.event.RefundCompletedEvent;
 import dukku.common.shared.payment.type.PaymentHistoryType;
 import dukku.common.shared.payment.type.PaymentStatus;
 import dukku.common.shared.payment.type.PaymentType;
+import dukku.common.shared.payment.type.RefundStatus;
 import dukku.payment.boundedContext.payment.app.PaymentFacade;
 import dukku.payment.boundedContext.payment.app.PaymentSupport;
 import dukku.payment.boundedContext.payment.entity.Payment;
@@ -20,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -27,6 +32,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+/**
+ * deposit.refunded / deposit.refund.failed 이벤트에 대한 PaymentEventListener 동작 테스트
+ */
 class PaymentEventListenerHappyPathTest {
 
     @Mock
@@ -42,8 +50,86 @@ class PaymentEventListenerHappyPathTest {
     private PaymentEventListener listener;
 
     @Test
-    @DisplayName("deposit.refund.failed 이벤트를 받으면 refund를 취소하고 payment를 ROLLBACK_FAILED로 전이한다")
-    void handleRefundFailFlow() {
+    @DisplayName("deposit.refunded 이벤트에서 PENDING refund가 COMPLETED로 전환되는지 검증")
+    void handleDepositRefundedCompletesPendingRefund() {
+        // given: PENDING 상태 환불과 결제 준비
+        UUID orderUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        UUID paymentUuid = UUID.randomUUID();
+        UUID refundUuid = UUID.randomUUID();
+
+        Payment payment = Payment.create(
+                orderUuid,
+                userUuid,
+                20000L,
+                15000L,
+                5000L,
+                0L,
+                PaymentType.MIXED,
+                "order-refunded-1");
+        payment.approve("pg-key-refunded-1");
+
+        Refund refund = payment.createRefund(7000L, 7000L, "idem-refunded-1");
+
+        when(paymentSupport.findRefundByUuid(refundUuid)).thenReturn(Optional.of(refund));
+
+        // when: deposit.refunded 이벤트 수신
+        listener.handle(new DepositRefundedEvent(
+                refundUuid,
+                paymentUuid,
+                orderUuid,
+                userUuid,
+                7000L));
+
+        // then: refund 상태 전환과 완료 이벤트 발행 확인
+        assertThat(refund.getRefundStatus()).isEqualTo(RefundStatus.COMPLETED);
+        verify(paymentSupport).saveRefund(refund);
+        verify(eventPublisher).publish(any(RefundCompletedEvent.class));
+    }
+
+    @Test
+    @DisplayName("deposit.refunded 이벤트에서 이미 COMPLETED 상태인 refund는 건너뛴다")
+    void handleDepositRefundedSkipsWhenAlreadyCompleted() {
+        // given: 이미 COMPLETED 상태인 refund 준비
+        UUID orderUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        UUID paymentUuid = UUID.randomUUID();
+        UUID refundUuid = UUID.randomUUID();
+
+        Payment payment = Payment.create(
+                orderUuid,
+                userUuid,
+                20000L,
+                15000L,
+                5000L,
+                0L,
+                PaymentType.MIXED,
+                "order-refunded-2");
+        payment.approve("pg-key-refunded-2");
+
+        Refund refund = payment.createRefund(7000L, 7000L, "idem-refunded-2");
+        refund.complete();
+
+        when(paymentSupport.findRefundByUuid(refundUuid)).thenReturn(Optional.of(refund));
+
+        // when: 동일 refund 대상의 deposit.refunded 이벤트 수신
+        listener.handle(new DepositRefundedEvent(
+                refundUuid,
+                paymentUuid,
+                orderUuid,
+                userUuid,
+                7000L));
+
+        // then: 저장과 완료 이벤트 발행이 생략되는지 확인
+        assertThat(refund.getRefundStatus()).isEqualTo(RefundStatus.COMPLETED);
+        verify(paymentSupport, never()).saveRefund(refund);
+        verify(eventPublisher, never()).publish(any(RefundCompletedEvent.class));
+    }
+
+    @Test
+    @DisplayName("deposit.refund.failed 이벤트에서 DONE 상태 환불이 PAYMENT_ROLLBACK_FAILED 이력으로 전환되는지 검증")
+    void handleRefundFailFromDoneCreatesRollbackFailedHistory() {
+        // given: DONE 상태 결제와 환불 준비
         UUID orderUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
         UUID paymentUuid = UUID.randomUUID();
@@ -72,7 +158,7 @@ class PaymentEventListenerHappyPathTest {
                 paymentUuid,
                 userUuid,
                 3000L,
-                dukku.common.shared.deposit.type.DepositFailureCode.PERSISTENCE_ERROR,
+                DepositFailureCode.PERSISTENCE_ERROR,
                 true,
                 "rollback failed",
                 LocalDateTime.now());
@@ -80,8 +166,10 @@ class PaymentEventListenerHappyPathTest {
         when(paymentSupport.findRefundByUuid(refundUuid)).thenReturn(Optional.of(refund));
         when(paymentSupport.findPaymentByUuidOptional(paymentUuid)).thenReturn(Optional.of(payment));
 
+        // when: deposit.refund.failed 이벤트 수신
         listener.handle(event);
 
+        // then: refund 취소와 payment rollback-failed 이력 기록 확인
         verify(paymentSupport).saveRefund(refund);
         verify(paymentSupport).savePayment(payment);
         verify(paymentSupport).createHistory(
@@ -93,8 +181,119 @@ class PaymentEventListenerHappyPathTest {
     }
 
     @Test
-    @DisplayName("이미 ROLLBACK_FAILED 상태면 payment 이력은 중복 반영하지 않는다")
+    @DisplayName("deposit.refund.failed 이벤트에서 CANCELED 상태가 FULL_REFUND_FAILED 이력으로 전환되는지 검증")
+    void handleRefundFailFromCanceledCreatesFullFailedHistory() {
+        // given: CANCELED 상태 결제와 환불 준비
+        UUID orderUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        UUID paymentUuid = UUID.randomUUID();
+        UUID refundUuid = UUID.randomUUID();
+
+        Payment payment = Payment.create(
+                orderUuid,
+                userUuid,
+                20000L,
+                15000L,
+                5000L,
+                0L,
+                PaymentType.MIXED,
+                "order-2");
+        payment.approve("pg-key-2");
+        payment.partialCancel(20000L, 5000L, 15000L);
+
+        Refund refund = payment.createRefund(20000L, 15000L, "idem-2");
+
+        PaymentStatus originStatus = payment.getPaymentStatus();
+        Long originPg = payment.getAmountPg();
+        Long originDeposit = payment.getPaymentDeposit();
+
+        DepositRefundFailedEvent event = new DepositRefundFailedEvent(
+                refundUuid,
+                orderUuid,
+                paymentUuid,
+                userUuid,
+                15000L,
+                DepositFailureCode.PERSISTENCE_ERROR,
+                true,
+                "rollback failed",
+                LocalDateTime.now());
+
+        when(paymentSupport.findRefundByUuid(refundUuid)).thenReturn(Optional.of(refund));
+        when(paymentSupport.findPaymentByUuidOptional(paymentUuid)).thenReturn(Optional.of(payment));
+
+        // when: deposit.refund.failed 이벤트 수신
+        listener.handle(event);
+
+        // then: FULL_REFUND_FAILED 이력 기록 확인
+        verify(paymentSupport).saveRefund(refund);
+        verify(paymentSupport).savePayment(payment);
+        verify(paymentSupport).createHistory(
+                eq(payment),
+                eq(PaymentHistoryType.FULL_REFUND_FAILED),
+                eq(originStatus),
+                eq(originPg),
+                eq(originDeposit));
+    }
+
+    @Test
+    @DisplayName("deposit.refund.failed 이벤트에서 PARTIAL_CANCELED 상태가 PARTIAL_REFUND_FAILED 이력으로 전환되는지 검증")
+    void handleRefundFailFromPartialCanceledCreatesPartialFailedHistory() {
+        // given: PARTIAL_CANCELED 상태 결제와 환불 준비
+        UUID orderUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+        UUID paymentUuid = UUID.randomUUID();
+        UUID refundUuid = UUID.randomUUID();
+
+        Payment payment = Payment.create(
+                orderUuid,
+                userUuid,
+                20000L,
+                15000L,
+                5000L,
+                0L,
+                PaymentType.MIXED,
+                "order-3");
+        payment.approve("pg-key-3");
+        payment.partialCancel(5000L, 0L, 5000L);
+
+        Refund refund = payment.createRefund(5000L, 5000L, "idem-3");
+
+        PaymentStatus originStatus = payment.getPaymentStatus();
+        Long originPg = payment.getAmountPg();
+        Long originDeposit = payment.getPaymentDeposit();
+
+        DepositRefundFailedEvent event = new DepositRefundFailedEvent(
+                refundUuid,
+                orderUuid,
+                paymentUuid,
+                userUuid,
+                5000L,
+                DepositFailureCode.PERSISTENCE_ERROR,
+                true,
+                "rollback failed",
+                LocalDateTime.now());
+
+        when(paymentSupport.findRefundByUuid(refundUuid)).thenReturn(Optional.of(refund));
+        when(paymentSupport.findPaymentByUuidOptional(paymentUuid)).thenReturn(Optional.of(payment));
+
+        // when: deposit.refund.failed 이벤트 수신
+        listener.handle(event);
+
+        // then: PARTIAL_REFUND_FAILED 이력 기록 확인
+        verify(paymentSupport).saveRefund(refund);
+        verify(paymentSupport).savePayment(payment);
+        verify(paymentSupport).createHistory(
+                eq(payment),
+                eq(PaymentHistoryType.PARTIAL_REFUND_FAILED),
+                eq(originStatus),
+                eq(originPg),
+                eq(originDeposit));
+    }
+
+    @Test
+    @DisplayName("ROLLBACK_FAILED 상태에서 rollback-failed 이벤트가 중복 처리되지 않는지 검증")
     void skipRollbackDup() {
+        // given: rollback-failed 상태 결제와 환불 준비
         UUID orderUuid = UUID.randomUUID();
         UUID userUuid = UUID.randomUUID();
         UUID paymentUuid = UUID.randomUUID();
@@ -108,10 +307,10 @@ class PaymentEventListenerHappyPathTest {
                 10000L,
                 0L,
                 PaymentType.NORMAL,
-                "order-2");
+                "order-4");
         payment.rollbackFailedStatus();
 
-        Refund refund = payment.createRefund(10000L, 0L, "idem-2");
+        Refund refund = payment.createRefund(10000L, 0L, "idem-4");
 
         DepositRefundFailedEvent event = new DepositRefundFailedEvent(
                 refundUuid,
@@ -119,7 +318,7 @@ class PaymentEventListenerHappyPathTest {
                 paymentUuid,
                 userUuid,
                 10000L,
-                dukku.common.shared.deposit.type.DepositFailureCode.PERSISTENCE_ERROR,
+                DepositFailureCode.PERSISTENCE_ERROR,
                 true,
                 "rollback failed",
                 LocalDateTime.now());
@@ -127,8 +326,10 @@ class PaymentEventListenerHappyPathTest {
         when(paymentSupport.findRefundByUuid(refundUuid)).thenReturn(Optional.of(refund));
         when(paymentSupport.findPaymentByUuidOptional(paymentUuid)).thenReturn(Optional.of(payment));
 
+        // when: deposit.refund.failed 이벤트 수신
         listener.handle(event);
 
+        // then: payment 저장과 이력 생성이 생략되고 refund만 저장되는지 확인
         verify(paymentSupport).saveRefund(refund);
         verify(paymentSupport, never()).savePayment(any(Payment.class));
         verify(paymentSupport, never()).createHistory(any(Payment.class), any(PaymentHistoryType.class),


### PR DESCRIPTION
## PR 제목

[Payment] 환불에 대한 멱등성 구현(order) #192

---

## 개요

**#192 구현 (1단계)**
- 환불에 대한 멱등성을 구현합니다. 
- PR이 과도하게 두꺼워져 리뷰하기 복잡해지는 것을 막기 위해 단계적으로 PR을 작성합니다.
- 이 PR에는 Order 도메인에 대한 멱등성 작업만 반영합니다. (deposit은 별도 작업)

**환불에 대한 멱등성 처리 필요**
- 동일 환불 완료 이벤트를 중복해서 수신했을 경우 중복해서 차감이 발생할 수 있음 (에러로 인한 재전달로 같은 이벤트가 2번 이상 중복 수신된 경우 등)
- 잠재적 이슈상황에 대한 재현과 히스토리를 기록하기 위해 작업 분리
- refundUuid를 멱등키로 사용하여 환불의 중복처리를 막아야 함
- 멱등성 구현하는 방식에 대해 결정하고 구현해야 함


---

## 상세 내용

**환불 완료 이벤트 멱등 처리 추가**
SHA : be0de4a750758882724da5123c39e0c3ddbd186d
- ProcessedRefundEvent 엔티티/리포지토리를 추가해 refundUuid 기준 중복 반영을 차단
- UpdateOrderRefundStatusUseCase에 refundUuid 파라미터와 환불 금액 범위 예외를 반영
- OrderEventListener/OrderSupport 경로를 멱등 흐름 기준으로 정렬


**환불 실패 이력 분기와 응답 필드 정렬 (id -> uuid 리팩토링)**
SHA : 617529ebacb4104bec11f57e05841bbb7e3d297d
- #188 에서 요청된 추가 리팩토링 사항 반영
- PaymentEventListener에 originStatus 기준 실패 이력 타입 분기 반영
- PaymentRefundResponse와 Refund 매핑을 refundUuid 기준으로 통일
- PaymentApiDocs 및 환불 응답 관련 문구를 현재 구현에 맞게 정리

**멱등성 대응 누락 수정**
SHA : 577944a0634891dd08239686bc999dfec619e885
- 멱등성 처리를 위한 검증 로직이 누락되어 테스트가 잘못된 동작을 하고 있던 부분을 수정
- 잘못 작성된 테스트가 통과해버리는 상황을 수정

## 테스트

**환불 완료 멱등/상태 전이 시나리오 보강**
SHA : c2f8a9730cd5d8727ae03f2faba5e0a196600971
- UpdateOrderRefundStatusUseCase 테스트에 부분 환불/범위 예외 케이스 추가
- OrderEventListener 테스트에 중복 refundUuid 및 상이한 refundUuid 경계 추가

**환불 Saga 실패/완료 경계 시나리오 보강**
SHA : 7e1f6ba859529e4702dda4cd62faa95df9c1e79b
- PaymentEventListenerHappyPathTest에 deposit.refunded 및 상태별 refund.failed 이력 케이스 추가
- RefundPaymentFailureHistoryIntegrationTest를 PG 실패 시 PAYMENT_ROLLBACK_FAILED 규칙으로 정렬
- RefundSagaLifecycleIntegrationTest에 full/partial 환불 완료 및 실패 흐름 검증 보강

**멱등성 대응 누락 수정**
SHA : 577944a0634891dd08239686bc999dfec619e885
- 동일 refundUuid를 여러 번 받으면 최초 한 번만 반영되는 테스트의 비정상 동작 수정
- 비정상인데 테스트 통과시키려고 잘못된 값을 넣고 있던 부분 수정
- 메소드명 짧게 단축


---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [x] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

- **중점적으로 봐주면 좋은 부분**:

- **고민했던 설계 포인트**:

각 처리 방식에 대해 다음과 같은 이슈가 있어 최종적으로 유사 inbox를 이용한 이벤트 처리 기록을 만들어서 멱등성 처리를 구현 진행

**order_history 확장 방식**
- refundUuid 컬럼 추가하고 UNIQUE(refund_uuid, history_type)로 중복 차단하는 방식
- history 테이블에 동일 Uuid로 여러 로그가 찍혀야 하는 경우 unique를 사용할 수 없음

**유사 inbox 패턴**
- 본인 담당이 아닌 도메인에 테이블을 추가해야 함
- 실제 inbox 패턴이 아니고 단순히 멱등성 키를 저장하는 목적이어서 outbox 패턴 도입 시 리팩토링 필요

**redis를 이용한 필터**
- 구현이 상대적으로 복잡함 (관련 구현 경험 없음)

- **리뷰 시 특히 피드백 받고 싶은 부분**:
- 신규 테이블로 멱등성 처리한 부분이 적절한 설계였을지
- 상태 전이가 적절하게 이루어지고 있는지