### PR TITLE
[Payment] 환불에 대한 멱등성 구현(deposit) #192

### DIFF
--- a/deposit/src/main/java/dukku/deposit/boundedContext/deposit/app/DepositSupport.java
+++ b/deposit/src/main/java/dukku/deposit/boundedContext/deposit/app/DepositSupport.java
@@ -2,8 +2,10 @@ package dukku.deposit.boundedContext.deposit.app;
 
 import dukku.deposit.boundedContext.deposit.entity.Deposit;
 import dukku.deposit.boundedContext.deposit.entity.DepositHistory;
+import dukku.deposit.boundedContext.deposit.entity.ProcessedRefundEvent;
 import dukku.deposit.boundedContext.deposit.out.DepositHistoryRepository;
 import dukku.deposit.boundedContext.deposit.out.DepositRepository;
+import dukku.deposit.boundedContext.deposit.out.ProcessedRefundEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,6 +20,7 @@ public class DepositSupport {
 
     private final DepositRepository depositRepository;
     private final DepositHistoryRepository depositHistoryRepository;
+    private final ProcessedRefundEventRepository processedRefundEventRepository;
 
     public Optional<Deposit> findByUserUuid(UUID userUuid) {
         return depositRepository.findByUserUuid(userUuid);
@@ -52,5 +55,14 @@ public class DepositSupport {
      */
     public boolean existsByOrderItemUuid(UUID orderItemUuid) {
         return depositHistoryRepository.existsByOrderItemUuid(orderItemUuid);
+    }
+
+    @org.springframework.transaction.annotation.Transactional
+    public boolean tryMarkRefundCompleted(UUID refundUuid, UUID orderUuid, Long refundAmount) {
+        if (processedRefundEventRepository.existsByRefundUuid(refundUuid)) {
+            return false;
+        }
+        processedRefundEventRepository.save(ProcessedRefundEvent.create(refundUuid, orderUuid, refundAmount));
+        return true;
     }
 }

--- a/deposit/src/main/java/dukku/deposit/boundedContext/deposit/app/RefundDepositUseCase.java
+++ b/deposit/src/main/java/dukku/deposit/boundedContext/deposit/app/RefundDepositUseCase.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class RefundDepositUseCase {
 
+    private final DepositSupport depositSupport;
     private final IncreaseDepositUseCase increaseDepositUseCase;
     private final DecreaseDepositUseCase decreaseDepositUseCase;
     private final EventPublisher eventPublisher;
@@ -45,6 +46,10 @@ public class RefundDepositUseCase {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void execute(UUID userUuid, Long amount, UUID orderUuid, UUID paymentUuid, UUID refundUuid) {
         if (amount == null || amount <= 0) {
+            return;
+        }
+
+        if (!depositSupport.tryMarkRefundCompleted(refundUuid, orderUuid, amount)) {
             return;
         }
 

--- a/deposit/src/main/java/dukku/deposit/boundedContext/deposit/entity/ProcessedRefundEvent.java
+++ b/deposit/src/main/java/dukku/deposit/boundedContext/deposit/entity/ProcessedRefundEvent.java
@@ -1,0 +1,66 @@
+package dukku.deposit.boundedContext.deposit.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(name = "processed_refund_events", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_processed_refund_events_refund_uuid", columnNames = "refund_uuid")
+})
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+/**
+ * 이미 처리된 환불 이벤트를 추적해 중복 반영을 방지하기 위한 엔티티
+ */
+public class ProcessedRefundEvent {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(nullable = false, updatable = false)
+    private Integer id;
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(name = "refund_uuid", nullable = false, updatable = false, columnDefinition = "uuid")
+    private UUID refundUuid;
+
+    @JdbcTypeCode(SqlTypes.UUID)
+    @Column(name = "order_uuid", nullable = false, updatable = false, columnDefinition = "uuid")
+    private UUID orderUuid;
+
+    @Column(name = "refund_amount", nullable = false, updatable = false)
+    private Long refundAmount;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static ProcessedRefundEvent create(UUID refundUuid, UUID orderUuid, Long refundAmount) {
+        return ProcessedRefundEvent.builder()
+                .refundUuid(refundUuid)
+                .orderUuid(orderUuid)
+                .refundAmount(refundAmount)
+                .build();
+    }
+}

--- a/deposit/src/main/java/dukku/deposit/boundedContext/deposit/out/ProcessedRefundEventRepository.java
+++ b/deposit/src/main/java/dukku/deposit/boundedContext/deposit/out/ProcessedRefundEventRepository.java
@@ -1,0 +1,13 @@
+package dukku.deposit.boundedContext.deposit.out;
+
+import dukku.deposit.boundedContext.deposit.entity.ProcessedRefundEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+/**
+ * 환불 이벤트 처리 여부를 조회해 중복 반영을 차단하는 레포지토리
+ */
+public interface ProcessedRefundEventRepository extends JpaRepository<ProcessedRefundEvent, Integer> {
+    boolean existsByRefundUuid(UUID refundUuid);
+}

--- a/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/RefundDepositUseCaseHappyPathTest.java
+++ b/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/RefundDepositUseCaseHappyPathTest.java
@@ -16,10 +16,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RefundDepositUseCaseHappyPathTest {
+
+    @Mock
+    private DepositSupport depositSupport;
 
     @Mock
     private IncreaseDepositUseCase increaseDepositUseCase;
@@ -43,6 +50,9 @@ class RefundDepositUseCaseHappyPathTest {
         UUID refundUuid = UUID.randomUUID();
         Long refundAmount = 2000L;
 
+        when(depositSupport.tryMarkRefundCompleted(eq(refundUuid), eq(orderUuid), eq(refundAmount)))
+                .thenReturn(true);
+
         // when: 환불 롤백 유스케이스를 실행한다.
         useCase.execute(userUuid, refundAmount, orderUuid, paymentUuid, refundUuid);
 
@@ -64,5 +74,27 @@ class RefundDepositUseCaseHappyPathTest {
         assertThat(event.orderUuid()).isEqualTo(orderUuid);
         assertThat(event.userUuid()).isEqualTo(userUuid);
         assertThat(event.amount()).isEqualTo(refundAmount);
+    }
+
+    @Test
+    @DisplayName("이미 처리된 refundUuid면 환불 로직을 실행하지 않는다")
+    void duplicateRefundIsIgnored() {
+        // given
+        UUID userUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+        UUID paymentUuid = UUID.randomUUID();
+        UUID refundUuid = UUID.randomUUID();
+        Long refundAmount = 2000L;
+
+        when(depositSupport.tryMarkRefundCompleted(eq(refundUuid), eq(orderUuid), eq(refundAmount)))
+                .thenReturn(false);
+
+        // when
+        useCase.execute(userUuid, refundAmount, orderUuid, paymentUuid, refundUuid);
+
+        // then
+        verify(increaseDepositUseCase, never()).increase(any(), any(), any(), any());
+        verify(decreaseDepositUseCase, never()).decrease(any(), any(), any(), any());
+        verify(eventPublisher, never()).publish(any());
     }
 }

--- a/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/RefundDepositUseCaseKafkaIntegrationTest.java
+++ b/deposit/src/test/java/dukku/deposit/boundedContext/deposit/app/RefundDepositUseCaseKafkaIntegrationTest.java
@@ -7,6 +7,7 @@ import dukku.deposit.boundedContext.deposit.entity.Deposit;
 import dukku.deposit.boundedContext.deposit.entity.DepositHistory;
 import dukku.deposit.boundedContext.deposit.out.DepositHistoryRepository;
 import dukku.deposit.boundedContext.deposit.out.DepositRepository;
+import dukku.deposit.boundedContext.deposit.out.ProcessedRefundEventRepository;
 import dukku.deposit.global.SystemDepositInitData;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -72,6 +73,9 @@ class RefundDepositUseCaseKafkaIntegrationTest {
     private DepositHistoryRepository depositHistoryRepository;
 
     @Autowired
+    private ProcessedRefundEventRepository processedRefundEventRepository;
+
+    @Autowired
     private EmbeddedKafkaBroker embeddedKafkaBroker;
 
     @Autowired
@@ -79,6 +83,7 @@ class RefundDepositUseCaseKafkaIntegrationTest {
 
     @BeforeEach
     void cleanUp() {
+        processedRefundEventRepository.deleteAll();
         depositHistoryRepository.deleteAll();
         depositRepository.deleteAll();
     }
@@ -196,6 +201,74 @@ class RefundDepositUseCaseKafkaIntegrationTest {
         } finally {
             consumer.close();
         }
+    }
+
+    @Test
+    @DisplayName("서로 다른 refundUuid는 각각 별도로 반영된다")
+    void differentRefundUuidsAppliedSeparately() {
+        // given
+        UUID userUuid = UUID.randomUUID();
+        depositRepository.save(Deposit.builder()
+                .userUuid(userUuid)
+                .depositUuid(UUID.randomUUID())
+                .balance(5000L)
+                .version(0)
+                .build());
+        depositRepository.save(Deposit.builder()
+                .userUuid(SystemDepositInitData.SYSTEM_USER_UUID)
+                .depositUuid(UUID.randomUUID())
+                .balance(1_000_000L)
+                .version(0)
+                .build());
+
+        UUID orderUuid = UUID.randomUUID();
+        UUID paymentUuid = UUID.randomUUID();
+
+        // when: 서로 다른 refundUuid로 각각 실행
+        refundDepositUseCase.execute(userUuid, 2000L, orderUuid, paymentUuid, UUID.randomUUID());
+        refundDepositUseCase.execute(userUuid, 1000L, orderUuid, paymentUuid, UUID.randomUUID());
+
+        // then: 둘 다 반영되어 5000 + 2000 + 1000 = 8000
+        Deposit after = depositRepository.findByUserUuid(userUuid).orElseThrow();
+        assertThat(after.getBalance()).isEqualTo(8000L);
+
+        Deposit systemAfter = depositRepository.findByUserUuid(SystemDepositInitData.SYSTEM_USER_UUID).orElseThrow();
+        assertThat(systemAfter.getBalance()).isEqualTo(997000L);
+    }
+
+    @Test
+    @DisplayName("동일 refundUuid로 두 번 실행하면 두 번째는 무시되어 예치금이 한 번만 복구된다")
+    void duplicateRefundIsIgnored() {
+        // given
+        UUID userUuid = UUID.randomUUID();
+        depositRepository.save(Deposit.builder()
+                .userUuid(userUuid)
+                .depositUuid(UUID.randomUUID())
+                .balance(5000L)
+                .version(0)
+                .build());
+        depositRepository.save(Deposit.builder()
+                .userUuid(SystemDepositInitData.SYSTEM_USER_UUID)
+                .depositUuid(UUID.randomUUID())
+                .balance(1_000_000L)
+                .version(0)
+                .build());
+
+        UUID paymentUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+        UUID refundUuid = UUID.randomUUID();
+        Long refundAmount = 3000L;
+
+        // when: 동일 refundUuid로 두 번 실행
+        refundDepositUseCase.execute(userUuid, refundAmount, orderUuid, paymentUuid, refundUuid);
+        refundDepositUseCase.execute(userUuid, refundAmount, orderUuid, paymentUuid, refundUuid);
+
+        // then: 한 번만 반영되어 8000원
+        Deposit after = depositRepository.findByUserUuid(userUuid).orElseThrow();
+        assertThat(after.getBalance()).isEqualTo(8000L);
+
+        Deposit systemAfter = depositRepository.findByUserUuid(SystemDepositInitData.SYSTEM_USER_UUID).orElseThrow();
+        assertThat(systemAfter.getBalance()).isEqualTo(997000L);
     }
 
     private Consumer<String, String> createConsumer(String topic) {


### PR DESCRIPTION
## PR 제목

[Payment] 환불에 대한 멱등성 구현(deposit) #192

---

## 개요

#192 구현 (2단계)
#194 후속 작업

- 환불에 대한 멱등성을 구현합니다.
- PR이 과도하게 두꺼워져 리뷰하기 복잡해지는 것을 막기 위해 단계적으로 PR을 작성합니다.
- 이 PR에는 Deposit 도메인에 대한 멱등성 작업만 반영합니다. 

**환불에 대한 멱등성 처리 필요**

- 동일 환불 완료 이벤트를 중복해서 수신했을 경우 중복해서 차감이 발생할 수 있음 (에러로 인한 재전달로 같은 이벤트가 2번 이상 중복 수신된 경우 등)
- 잠재적 이슈상황에 대한 재현과 히스토리를 기록하기 위해 작업 분리
- refundUuid를 멱등키로 사용하여 환불의 중복처리를 막아야 함
- 멱등성 구현하는 방식에 대해 결정하고 구현해야 함


---

## 상세 내용

**환불 이벤트 멱등 처리 추가**
SHA : 5cdf46a2e93cbefc8d2aae4a8c754d0da08871eb
- ProcessedRefundEvent 엔티티 및 리포지토리 신규 생성
- DepositSupport에 tryMarkRefundCompleted() 메서드 추가
- RefundDepositUseCase 진입부에 refundUuid 기반 중복 처리 방지 적용


## 테스트

**환불 멱등성 및 부분환불 시나리오 보강**
SHA : f51bd029f0918af840f07b7755ceff0eb73d9c5c
- RefundDepositUseCaseHappyPathTest에 중복 refundUuid 무시 케이스 추가
- RefundDepositUseCaseKafkaIntegrationTest에 중복 환불 무시 및 서로 다른 refundUuid 개별 반영 케이스 추가
- BeforeEach에 ProcessedRefundEventRepository 정리 추가


---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [x] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:

#192 와 동일