### PR TITLE
[Logging] TraceId 추적 로깅 시스템 구축 및 알림설정 #175

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ out/
 
 # Secrets / Env
 .env
-.env.*
+!.env.example
 *.pem
 *.key
 *.crt

--- a/ai/src/main/resources/application.yml
+++ b/ai/src/main/resources/application.yml
@@ -2,10 +2,11 @@ server:
   port: 8089
 
 spring:
-  config:
-    import: classpath:application-common.yml
   application:
     name: ai
+
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}
 
   datasource:
     url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ai_service}?sslmode=${DB_SSLMODE:disable}

--- a/auth/src/main/resources/logback-spring.xml
+++ b/auth/src/main/resources/logback-spring.xml
@@ -53,6 +53,14 @@
     <!-- 3. Kafka Appender (중앙 로그 수집)              -->
     <!-- ============================================ -->
     <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
+        <!-- INFO 이상만 Kafka로 전송 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+
+        <!-- traceId가 있는 로그만 Kafka로 전송 (MDC 컨텍스트 필터) -->
+        <filter class="dukku.common.global.logging.MdcTraceFilter"/>
+
         <!-- Kafka Topic 이름 -->
         <topic>msa-logs</topic>
 

--- a/auth/src/main/resources/logback-spring.xml
+++ b/auth/src/main/resources/logback-spring.xml
@@ -57,7 +57,9 @@
         <topic>msa-logs</topic>
 
         <!-- Key Partitioning: 같은 서비스 로그는 같은 파티션으로 -->
-        <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.ThreadNameKeyingStrategy"/>
+        <keyingStrategy class="dukku.common.global.logging.ServiceNameKeyingStrategy">
+            <serviceName>${SERVICE_NAME}</serviceName>
+        </keyingStrategy>
 
         <!-- 전송 실패 시 처리 (콘솔로 fallback) -->
         <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy"/>
@@ -105,8 +107,12 @@
     <springProfile name="dev">
         <root level="DEBUG">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>
@@ -122,8 +128,12 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>

--- a/common/src/main/java/dukku/common/global/config/MetricsConfig.java
+++ b/common/src/main/java/dukku/common/global/config/MetricsConfig.java
@@ -1,0 +1,21 @@
+package dukku.common.global.config;
+
+import io.micrometer.core.aop.CountedAspect;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+
+    @Bean
+    public TimedAspect timedAspect(MeterRegistry meterRegistry) {
+        return new TimedAspect(meterRegistry);
+    }
+
+    @Bean
+    public CountedAspect countedAspect(MeterRegistry meterRegistry) {
+        return new CountedAspect(meterRegistry);
+    }
+}

--- a/common/src/main/java/dukku/common/global/logging/MdcTraceFilter.java
+++ b/common/src/main/java/dukku/common/global/logging/MdcTraceFilter.java
@@ -1,0 +1,29 @@
+package dukku.common.global.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+import java.util.Map;
+
+/**
+ * MDC에 traceId가 존재하는 로그만 통과시키는 Logback 필터.
+ * Kafka appender에 적용하여 HTTP 요청 컨텍스트가 있는 로그만 전송한다.
+ */
+public class MdcTraceFilter extends Filter<ILoggingEvent> {
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        Map<String, String> mdc = event.getMDCPropertyMap();
+        if (mdc == null) {
+            return FilterReply.DENY;
+        }
+
+        String traceId = mdc.get("traceId");
+        if (traceId == null || traceId.isBlank()) {
+            return FilterReply.DENY;
+        }
+
+        return FilterReply.NEUTRAL;
+    }
+}

--- a/common/src/main/java/dukku/common/global/logging/ServiceNameKeyingStrategy.java
+++ b/common/src/main/java/dukku/common/global/logging/ServiceNameKeyingStrategy.java
@@ -1,0 +1,20 @@
+package dukku.common.global.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.github.danielwegener.logback.kafka.keying.KeyingStrategy;
+
+import java.nio.charset.StandardCharsets;
+
+public class ServiceNameKeyingStrategy implements KeyingStrategy<ILoggingEvent> {
+
+    private byte[] serviceNameBytes;
+
+    public void setServiceName(String serviceName) {
+        this.serviceNameBytes = serviceName.getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public byte[] createKey(ILoggingEvent event) {
+        return serviceNameBytes;
+    }
+}

--- a/deposit/src/main/resources/logback-spring.xml
+++ b/deposit/src/main/resources/logback-spring.xml
@@ -52,6 +52,14 @@
     <!-- 3. Kafka Appender (중앙 로그 수집)              -->
     <!-- ============================================ -->
     <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
+        <!-- INFO 이상만 Kafka로 전송 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+
+        <!-- traceId가 있는 로그만 Kafka로 전송 (MDC 컨텍스트 필터) -->
+        <filter class="dukku.common.global.logging.MdcTraceFilter"/>
+
         <!-- Kafka Topic 이름 -->
         <topic>msa-logs</topic>
 

--- a/deposit/src/main/resources/logback-spring.xml
+++ b/deposit/src/main/resources/logback-spring.xml
@@ -56,7 +56,9 @@
         <topic>msa-logs</topic>
 
         <!-- Key Partitioning: 같은 서비스 로그는 같은 파티션으로 -->
-        <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.ThreadNameKeyingStrategy"/>
+        <keyingStrategy class="dukku.common.global.logging.ServiceNameKeyingStrategy">
+            <serviceName>${SERVICE_NAME}</serviceName>
+        </keyingStrategy>
 
         <!-- 전송 실패 시 처리 (콘솔로 fallback) -->
         <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy"/>
@@ -104,8 +106,12 @@
     <springProfile name="dev">
         <root level="DEBUG">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>
@@ -121,8 +127,12 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>

--- a/docker-compose.local.redpanda.yml
+++ b/docker-compose.local.redpanda.yml
@@ -93,5 +93,5 @@ volumes:
 # 네트워크 (기존 서비스와 연결)
 # ============================================
 networks:
-  semicolon-network:
-    driver: bridge
+  team05-network:
+    external: true

--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,0 +1,4 @@
+# Grafana ERROR 로그 알림용 Slack Incoming Webhook URL
+# 팀 Slack 채널에서 Incoming Webhook을 생성한 뒤 URL을 입력하세요.
+# 이 파일을 .env로 복사하여 사용합니다: cp .env.example .env
+SLACK_WEBHOOK_URL_GRAFANA_ERROR=your-slack-webhook-url-here

--- a/monitoring/docker-compose.local.monitoring.yml
+++ b/monitoring/docker-compose.local.monitoring.yml
@@ -39,6 +39,8 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
       # 시간대 설정
       - GF_DATE_FORMATS_DEFAULT_TIMEZONE=Asia/Seoul
+      # Infinity 플러그인 (Log API 연동용)
+      - GF_INSTALL_PLUGINS=yesoreyeram-infinity-datasource
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
@@ -50,11 +52,32 @@ services:
       - team05-network
     depends_on:
       - prometheus
+      - mongodb
+  # 로그 데이터 저장
+  mongodb:
+    image: mongo:7
+    container_name: semicolon-mongodb
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_DATABASE: log_service
+    volumes:
+      - mongodb_data:/data/db
+      - ./mongodb/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
+    healthcheck:
+      test: [ "CMD", "mongosh", "--eval", "db.adminCommand('ping')" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - team05-network
 
 # 영구 볼륨 정의
 volumes:
   prometheus_data:
   grafana_data:
+  mongodb_data:
+    driver: local
 
 # 네트워크 정의
 networks:

--- a/monitoring/docker-compose.local.monitoring.yml
+++ b/monitoring/docker-compose.local.monitoring.yml
@@ -27,6 +27,8 @@ services:
   grafana:
     image: grafana/grafana:latest
     container_name: semicolon-grafana
+    env_file:
+      - .env
     environment:
       # 기본 관리자 계정 (운영 환경에서는 반드시 변경!)
       - GF_SECURITY_ADMIN_USER=admin
@@ -37,6 +39,9 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
       # 시간대 설정
       - GF_DATE_FORMATS_DEFAULT_TIMEZONE=Asia/Seoul
+      # Unified Alerting 활성화
+      - GF_UNIFIED_ALERTING_ENABLED=true
+      - GF_ALERTING_ENABLED=false
       # Infinity 플러그인 (Log API 연동용)
       - GF_INSTALL_PLUGINS=yesoreyeram-infinity-datasource
     volumes:

--- a/monitoring/docker-compose.local.monitoring.yml
+++ b/monitoring/docker-compose.local.monitoring.yml
@@ -1,7 +1,5 @@
 # Prometheus + Grafana 모니터링 스택
 # 사용법: docker-compose up -d (monitoring 폴더에서 실행)
-version: "3.8"
-
 services:
   # Prometheus - 메트릭 수집 및 저장
   prometheus:

--- a/monitoring/grafana/provisioning/alerting/alert-rules.yml
+++ b/monitoring/grafana/provisioning/alerting/alert-rules.yml
@@ -1,0 +1,66 @@
+# Grafana Alert Rules Provisioning
+# ERROR 로그 발생 시 Slack 알림
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: "Error Log Alerts"
+    folder: "Logs"
+    interval: "1m"
+    rules:
+      - uid: "error-log-detected"
+        title: "ERROR 로그 발생"
+        condition: "C"
+        data:
+          # A: Prometheus에서 최근 5분간 ERROR 로그 증가량 조회
+          - refId: "A"
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: "PBFA97CFB590B2093"
+            model:
+              refId: "A"
+              expr: 'sum(increase(log_messages_total{level="ERROR"}[5m])) by (service)'
+              intervalMs: 60000
+              maxDataPoints: 43200
+          # B: A의 마지막 값 추출 (Reduce)
+          - refId: "B"
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: "__expr__"
+            model:
+              refId: "B"
+              type: "reduce"
+              expression: "A"
+              reducer: "last"
+              conditions:
+                - type: "query"
+                  evaluator:
+                    type: "gt"
+                    params: [0]
+          # C: 임계값 조건 (0보다 크면 발동)
+          - refId: "C"
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: "__expr__"
+            model:
+              refId: "C"
+              type: "threshold"
+              expression: "B"
+              conditions:
+                - type: "query"
+                  evaluator:
+                    type: "gt"
+                    params:
+                      - 0
+        for: "0s"
+        noDataState: "OK"
+        execErrState: "OK"
+        labels:
+          severity: "critical"
+        annotations:
+          summary: "ERROR 로그가 감지되었습니다."
+          description: "최근 5분간 ERROR 레벨 로그가 발생했습니다. Grafana Log Dashboard에서 상세 내용을 확인하세요."
+          dashboard_url: "/d/log-overview/log-overview?var-level=ERROR"

--- a/monitoring/grafana/provisioning/alerting/notification-policies.yml
+++ b/monitoring/grafana/provisioning/alerting/notification-policies.yml
@@ -1,0 +1,13 @@
+# Grafana Notification Policies Provisioning
+# 알림 라우팅 정책: 모든 alert를 Slack으로 전송
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: "Slack Error Alerts"
+    group_by:
+      - grafana_folder
+      - alertname
+    group_wait: "30s"
+    group_interval: "5m"
+    repeat_interval: "1h"

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -79,3 +79,14 @@ providers:
     options:
       path: /var/lib/grafana/dashboards/infra
       foldersFromFilesStructure: false
+
+  - name: 'Logs'
+    orgId: 1
+    folder: 'Logs'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards/logs
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/log-api.yml
+++ b/monitoring/grafana/provisioning/datasources/log-api.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Log-API
+    type: yesoreyeram-infinity-datasource
+    access: proxy
+    isDefault: false
+    editable: true
+    jsonData:
+      url: http://host.docker.internal:8085

--- a/monitoring/grafana/provisioning/datasources/log-api.yml
+++ b/monitoring/grafana/provisioning/datasources/log-api.yml
@@ -3,7 +3,9 @@ apiVersion: 1
 datasources:
   - name: Log-API
     type: yesoreyeram-infinity-datasource
+    uid: PCA84556805E1F3AF
     access: proxy
+    url: http://host.docker.internal:8085
     isDefault: false
     editable: true
     jsonData:

--- a/monitoring/log-consumer/build.gradle
+++ b/monitoring/log-consumer/build.gradle
@@ -3,10 +3,25 @@ description = 'log-consumer'
 bootJar { enabled = true }
 
 dependencies {
-    implementation project(':common')
+    // Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-    // MongoDB (common에 없는 의존성)
+    // MongoDB
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+    // Kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    // Jackson
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    // Actuator + Prometheus 메트릭
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/monitoring/log-consumer/build.gradle
+++ b/monitoring/log-consumer/build.gradle
@@ -1,0 +1,12 @@
+description = 'log-consumer'
+
+bootJar { enabled = true }
+
+dependencies {
+    implementation project(':common')
+
+    // MongoDB (common에 없는 의존성)
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/LogConsumerApplication.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/LogConsumerApplication.java
@@ -3,15 +3,13 @@ package dukku.logconsumer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(
-        scanBasePackages = {"dukku.logconsumer", "dukku.common"},
-        excludeName = {
-                "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
-                "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration",
-                "org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration",
-                "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration"
-        }
-)
+@SpringBootApplication(excludeName = {
+        "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration",
+        "org.springframework.boot.jdbc.autoconfigure.DataSourceInitializationAutoConfiguration",
+        "org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration",
+        "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
+        "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration"
+})
 public class LogConsumerApplication {
 
     public static void main(String[] args) {

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/LogConsumerApplication.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/LogConsumerApplication.java
@@ -1,0 +1,20 @@
+package dukku.logconsumer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(
+        scanBasePackages = {"dukku.logconsumer", "dukku.common"},
+        excludeName = {
+                "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
+                "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration",
+                "org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration",
+                "org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration"
+        }
+)
+public class LogConsumerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(LogConsumerApplication.class, args);
+    }
+}

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/config/KafkaConsumerConfig.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/config/KafkaConsumerConfig.java
@@ -1,0 +1,45 @@
+package dukku.logconsumer.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        return factory;
+    }
+}

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/config/KafkaConsumerConfig.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/config/KafkaConsumerConfig.java
@@ -1,10 +1,12 @@
 package dukku.logconsumer.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
@@ -13,8 +15,14 @@ import org.springframework.kafka.listener.ContainerProperties;
 import java.util.HashMap;
 import java.util.Map;
 
+@EnableKafka
 @Configuration
 public class KafkaConsumerConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/config/MongoConfig.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/config/MongoConfig.java
@@ -1,0 +1,30 @@
+package dukku.logconsumer.config;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+
+@Configuration
+public class MongoConfig extends AbstractMongoClientConfiguration {
+
+    @Value("${spring.data.mongodb.host:localhost}")
+    private String host;
+
+    @Value("${spring.data.mongodb.port:27017}")
+    private int port;
+
+    @Value("${spring.data.mongodb.database:log_service}")
+    private String database;
+
+    @Override
+    protected String getDatabaseName() {
+        return database;
+    }
+
+    @Override
+    public MongoClient mongoClient() {
+        return MongoClients.create("mongodb://" + host + ":" + port);
+    }
+}

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/consumer/LogKafkaConsumer.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/consumer/LogKafkaConsumer.java
@@ -21,14 +21,20 @@ public class LogKafkaConsumer {
 
     private final LogRepository logRepository;
     private final ObjectMapper objectMapper;
+    private final LogMetrics logMetrics;
 
     @KafkaListener(topics = "msa-logs", groupId = "log-consumer-group")
     public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
         try {
             JsonNode node = objectMapper.readTree(record.value());
 
+            String traceId = textOrNull(node, "traceId");
+            if (traceId == null || traceId.isBlank()) {
+                return;
+            }
+
             LogDoc doc = LogDoc.builder()
-                    .traceId(textOrNull(node, "traceId"))
+                    .traceId(traceId)
                     .spanId(textOrNull(node, "spanId"))
                     .userId(textOrNull(node, "userId"))
                     .serviceName(textOrNull(node, "serviceName"))
@@ -44,6 +50,7 @@ public class LogKafkaConsumer {
                     .build();
 
             logRepository.save(doc);
+            logMetrics.incrementLogCount(doc.getServiceName(), doc.getLevel());
         } catch (Exception e) {
             log.error("로그 메시지 파싱/저장 실패 - offset: {}, value: {}", record.offset(), record.value(), e);
         } finally {

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/consumer/LogKafkaConsumer.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/consumer/LogKafkaConsumer.java
@@ -1,0 +1,72 @@
+package dukku.logconsumer.consumer;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dukku.logconsumer.document.LogDoc;
+import dukku.logconsumer.repository.LogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LogKafkaConsumer {
+
+    private final LogRepository logRepository;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "msa-logs", groupId = "log-consumer-group")
+    public void consume(ConsumerRecord<String, String> record, Acknowledgment ack) {
+        try {
+            JsonNode node = objectMapper.readTree(record.value());
+
+            LogDoc doc = LogDoc.builder()
+                    .traceId(textOrNull(node, "traceId"))
+                    .spanId(textOrNull(node, "spanId"))
+                    .userId(textOrNull(node, "userId"))
+                    .serviceName(textOrNull(node, "serviceName"))
+                    .level(textOrNull(node, "level"))
+                    .message(textOrNull(node, "message"))
+                    .loggerName(textOrNull(node, "logger_name"))
+                    .threadName(textOrNull(node, "thread_name"))
+                    .requestUri(textOrNull(node, "requestUri"))
+                    .requestMethod(textOrNull(node, "requestMethod"))
+                    .clientIp(textOrNull(node, "clientIp"))
+                    .timestamp(parseTimestamp(node))
+                    .stackTrace(textOrNull(node, "stack_trace"))
+                    .build();
+
+            logRepository.save(doc);
+        } catch (Exception e) {
+            log.error("로그 메시지 파싱/저장 실패 - offset: {}, value: {}", record.offset(), record.value(), e);
+        } finally {
+            ack.acknowledge();
+        }
+    }
+
+    private String textOrNull(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return (value != null && !value.isNull()) ? value.asText() : null;
+    }
+
+    private Instant parseTimestamp(JsonNode node) {
+        JsonNode tsNode = node.get("@timestamp");
+        if (tsNode == null || tsNode.isNull()) {
+            return Instant.now();
+        }
+
+        try {
+            return Instant.parse(tsNode.asText());
+        } catch (DateTimeParseException e) {
+            log.warn("타임스탬프 파싱 실패, 현재 시각 사용: {}", tsNode.asText());
+            return Instant.now();
+        }
+    }
+}

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/consumer/LogMetrics.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/consumer/LogMetrics.java
@@ -1,0 +1,24 @@
+package dukku.logconsumer.consumer;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LogMetrics {
+
+    private final MeterRegistry meterRegistry;
+
+    public LogMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    public void incrementLogCount(String serviceName, String level) {
+        Counter.builder("log_messages_total")
+                .tag("service", serviceName != null ? serviceName : "unknown")
+                .tag("level", level != null ? level : "unknown")
+                .description("서비스별/레벨별 수신 로그 메시지 수")
+                .register(meterRegistry)
+                .increment();
+    }
+}

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/controller/LogQueryController.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/controller/LogQueryController.java
@@ -1,0 +1,62 @@
+package dukku.logconsumer.controller;
+
+import dukku.logconsumer.document.LogDoc;
+import dukku.logconsumer.repository.LogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/logs")
+@RequiredArgsConstructor
+public class LogQueryController {
+
+    private final LogRepository logRepository;
+    private final MongoTemplate mongoTemplate;
+
+    @GetMapping("/trace/{traceId}")
+    public List<LogDoc> getByTraceId(@PathVariable String traceId) {
+        return logRepository.findByTraceIdOrderByTimestampAsc(traceId);
+    }
+
+    @GetMapping("/errors/{serviceName}")
+    public Page<LogDoc> getErrors(
+            @PathVariable String serviceName,
+            @PageableDefault(size = 20, sort = "timestamp", direction = Sort.Direction.DESC) Pageable pageable) {
+        return logRepository.findByServiceNameAndLevel(serviceName, "ERROR", pageable);
+    }
+
+    @GetMapping
+    public Page<LogDoc> getLogs(
+            @RequestParam(required = false) String serviceName,
+            @RequestParam(required = false) String level,
+            @PageableDefault(size = 20, sort = "timestamp", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Query query = new Query().with(pageable);
+
+        if (serviceName != null) {
+            query.addCriteria(Criteria.where("serviceName").is(serviceName));
+        }
+        if (level != null) {
+            query.addCriteria(Criteria.where("level").is(level));
+        }
+
+        long total = mongoTemplate.count(Query.of(query).limit(-1).skip(-1), LogDoc.class);
+        List<LogDoc> content = mongoTemplate.find(query, LogDoc.class);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+}

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/document/LogDoc.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/document/LogDoc.java
@@ -1,0 +1,70 @@
+package dukku.logconsumer.document;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(collection = "service_logs")
+@CompoundIndex(def = "{'serviceName': 1, 'level': 1, 'timestamp': -1}")
+public class LogDoc {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String traceId;
+
+    private String spanId;
+
+    private String userId;
+
+    private String serviceName;
+
+    private String level;
+
+    private String message;
+
+    private String loggerName;
+
+    private String threadName;
+
+    private String requestUri;
+
+    private String requestMethod;
+
+    private String clientIp;
+
+    @Indexed(expireAfter = "30d")
+    private Instant timestamp;
+
+    private String stackTrace;
+
+    @Builder
+    public LogDoc(String traceId, String spanId, String userId, String serviceName,
+                  String level, String message, String loggerName, String threadName,
+                  String requestUri, String requestMethod, String clientIp,
+                  Instant timestamp, String stackTrace) {
+        this.traceId = traceId;
+        this.spanId = spanId;
+        this.userId = userId;
+        this.serviceName = serviceName;
+        this.level = level;
+        this.message = message;
+        this.loggerName = loggerName;
+        this.threadName = threadName;
+        this.requestUri = requestUri;
+        this.requestMethod = requestMethod;
+        this.clientIp = clientIp;
+        this.timestamp = timestamp;
+        this.stackTrace = stackTrace;
+    }
+}

--- a/monitoring/log-consumer/src/main/java/dukku/logconsumer/repository/LogRepository.java
+++ b/monitoring/log-consumer/src/main/java/dukku/logconsumer/repository/LogRepository.java
@@ -1,0 +1,20 @@
+package dukku.logconsumer.repository;
+
+import dukku.logconsumer.document.LogDoc;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface LogRepository extends MongoRepository<LogDoc, String> {
+
+    List<LogDoc> findByTraceIdOrderByTimestampAsc(String traceId);
+
+    Page<LogDoc> findByServiceNameAndLevel(String serviceName, String level, Pageable pageable);
+
+    List<LogDoc> findByServiceNameAndLevelOrderByTimestampDesc(String serviceName, String level);
+
+    Page<LogDoc> findByServiceNameAndTimestampBetween(String serviceName, Instant from, Instant to, Pageable pageable);
+}

--- a/monitoring/log-consumer/src/main/resources/application.yml
+++ b/monitoring/log-consumer/src/main/resources/application.yml
@@ -7,7 +7,9 @@ spring:
 
   data:
     mongodb:
-      uri: mongodb://localhost:27017/log_service
+      host: localhost
+      port: 27017
+      database: log_service
 
   kafka:
     bootstrap-servers: localhost:19092

--- a/monitoring/log-consumer/src/main/resources/application.yml
+++ b/monitoring/log-consumer/src/main/resources/application.yml
@@ -1,0 +1,31 @@
+server:
+  port: 8085
+
+spring:
+  application:
+    name: log-consumer
+
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/log_service
+
+  kafka:
+    bootstrap-servers: localhost:19092
+    consumer:
+      group-id: log-consumer-group
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    listener:
+      ack-mode: manual
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus, info
+  metrics:
+    export:
+      prometheus:
+        enabled: true

--- a/monitoring/log-consumer/src/main/resources/application.yml
+++ b/monitoring/log-consumer/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8085
+  port: 9000
 
 spring:
   application:

--- a/monitoring/log-consumer/src/main/resources/logback-spring.xml
+++ b/monitoring/log-consumer/src/main/resources/logback-spring.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <springProperty scope="context" name="SERVICE_NAME" source="spring.application.name" defaultValue="log-consumer"/>
+
+    <property name="LOG_PATH" value="./log"/>
+
+    <!-- 콘솔 Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 파일 Appender (백업용) -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${SERVICE_NAME}.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${SERVICE_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>14</maxHistory>
+            <totalSizeCap>2GB</totalSizeCap>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Kafka Appender 제외 (무한 루프 방지: log-consumer 자체 로그가 Kafka로 전송되면 안 됨) -->
+
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
+        <logger name="org.apache.kafka" level="WARN"/>
+        <logger name="org.springframework.data.mongodb" level="DEBUG"/>
+    </springProfile>
+
+    <springProfile name="release,prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+
+        <logger name="org.apache.kafka" level="WARN"/>
+    </springProfile>
+
+    <springProfile name="test">
+        <root level="WARN">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <!-- 프로파일 미지정 시 기본 설정 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/monitoring/mongodb/init-mongo.js
+++ b/monitoring/mongodb/init-mongo.js
@@ -1,31 +1,8 @@
-// DB 선택 (application.yml의 mongodb uri와 일치)
+// MongoDB 초기화 스크립트
 db = db.getSiblingDB('log_service');
 
-// 컬렉션 생성
+// 로그 컬렉션 생성 (명시적)
 db.createCollection('service_logs');
 
-// 1. traceId 인덱스 (분산 추적)
-db.service_logs.createIndex(
-  { "traceId": 1 },
-  { name: "idx_traceId" }
-);
-
-// 2. 복합 인덱스 (서비스별 + 레벨별 + 시간순)
-db.service_logs.createIndex(
-  { "serviceName": 1, "level": 1, "timestamp": -1 },
-  { name: "idx_service_level_time" }
-);
-
-// 3. TTL 인덱스 (30일 후 자동 삭제)
-db.service_logs.createIndex(
-  { "timestamp": 1 },
-  { expireAfterSeconds: 2592000, name: "idx_ttl_30days" }
-);
-
-// 4. 텍스트 검색 인덱스 (메시지 검색용)
-db.service_logs.createIndex(
-  { "message": "text" },
-  { name: "idx_message_text" }
-);
-
-print("=== log_service 컬렉션 및 인덱스 생성 완료 ===");
+// 인덱스는 Spring Data MongoDB의 @CompoundIndex, @Indexed가 자동 생성
+print('MongoDB initialized: log_service database created');

--- a/monitoring/mongodb/init-mongo.js
+++ b/monitoring/mongodb/init-mongo.js
@@ -1,0 +1,31 @@
+// DB 선택 (application.yml의 mongodb uri와 일치)
+db = db.getSiblingDB('log_service');
+
+// 컬렉션 생성
+db.createCollection('service_logs');
+
+// 1. traceId 인덱스 (분산 추적)
+db.service_logs.createIndex(
+  { "traceId": 1 },
+  { name: "idx_traceId" }
+);
+
+// 2. 복합 인덱스 (서비스별 + 레벨별 + 시간순)
+db.service_logs.createIndex(
+  { "serviceName": 1, "level": 1, "timestamp": -1 },
+  { name: "idx_service_level_time" }
+);
+
+// 3. TTL 인덱스 (30일 후 자동 삭제)
+db.service_logs.createIndex(
+  { "timestamp": 1 },
+  { expireAfterSeconds: 2592000, name: "idx_ttl_30days" }
+);
+
+// 4. 텍스트 검색 인덱스 (메시지 검색용)
+db.service_logs.createIndex(
+  { "message": "text" },
+  { name: "idx_message_text" }
+);
+
+print("=== log_service 컬렉션 및 인덱스 생성 완료 ===");

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -36,6 +36,17 @@ scrape_configs:
           application: 'semicolon'
           environment: 'local'
 
+  # Log Consumer 메트릭 수집
+  - job_name: 'log-consumer'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 10s
+    static_configs:
+      - targets:
+          - 'host.docker.internal:8085'
+        labels:
+          application: 'log-consumer'
+          environment: 'local'
+
   # Prometheus 자체 모니터링
   - job_name: 'prometheus'
     static_configs:

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -25,7 +25,13 @@ scrape_configs:
     static_configs:
       - targets:
           # Windows/Mac에서 로컬 Spring Boot 앱에 접근
-          - 'host.docker.internal:8080'
+          - 'host.docker.internal:8080'   # gateway
+          - 'host.docker.internal:8083'   # product
+          - 'host.docker.internal:8084'   # order
+          - 'host.docker.internal:8086'   # payment
+          - 'host.docker.internal:8087'   # deposit
+          - 'host.docker.internal:8088'   # settlement
+          - 'host.docker.internal:8089'   # ai
         labels:
           application: 'semicolon'
           environment: 'local'

--- a/order/src/main/resources/logback-spring.xml
+++ b/order/src/main/resources/logback-spring.xml
@@ -52,6 +52,14 @@
     <!-- 3. Kafka Appender (중앙 로그 수집)              -->
     <!-- ============================================ -->
     <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
+        <!-- INFO 이상만 Kafka로 전송 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+
+        <!-- traceId가 있는 로그만 Kafka로 전송 (MDC 컨텍스트 필터) -->
+        <filter class="dukku.common.global.logging.MdcTraceFilter"/>
+
         <!-- Kafka Topic 이름 -->
         <topic>msa-logs</topic>
 

--- a/order/src/main/resources/logback-spring.xml
+++ b/order/src/main/resources/logback-spring.xml
@@ -56,7 +56,9 @@
         <topic>msa-logs</topic>
 
         <!-- Key Partitioning: 같은 서비스 로그는 같은 파티션으로 -->
-        <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.ThreadNameKeyingStrategy"/>
+        <keyingStrategy class="dukku.common.global.logging.ServiceNameKeyingStrategy">
+            <serviceName>${SERVICE_NAME}</serviceName>
+        </keyingStrategy>
 
         <!-- 전송 실패 시 처리 (콘솔로 fallback) -->
         <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy"/>
@@ -104,8 +106,12 @@
     <springProfile name="dev">
         <root level="DEBUG">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>
@@ -121,8 +127,12 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>

--- a/payment/src/main/resources/logback-spring.xml
+++ b/payment/src/main/resources/logback-spring.xml
@@ -52,6 +52,14 @@
     <!-- 3. Kafka Appender (중앙 로그 수집)              -->
     <!-- ============================================ -->
     <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
+        <!-- INFO 이상만 Kafka로 전송 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+
+        <!-- traceId가 있는 로그만 Kafka로 전송 (MDC 컨텍스트 필터) -->
+        <filter class="dukku.common.global.logging.MdcTraceFilter"/>
+
         <!-- Kafka Topic 이름 -->
         <topic>msa-logs</topic>
 

--- a/payment/src/main/resources/logback-spring.xml
+++ b/payment/src/main/resources/logback-spring.xml
@@ -56,7 +56,9 @@
         <topic>msa-logs</topic>
 
         <!-- Key Partitioning: 같은 서비스 로그는 같은 파티션으로 -->
-        <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.ThreadNameKeyingStrategy"/>
+        <keyingStrategy class="dukku.common.global.logging.ServiceNameKeyingStrategy">
+            <serviceName>${SERVICE_NAME}</serviceName>
+        </keyingStrategy>
 
         <!-- 전송 실패 시 처리 (콘솔로 fallback) -->
         <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy"/>
@@ -104,8 +106,12 @@
     <springProfile name="dev">
         <root level="DEBUG">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>
@@ -121,8 +127,12 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>

--- a/product/src/main/resources/logback-spring.xml
+++ b/product/src/main/resources/logback-spring.xml
@@ -52,6 +52,14 @@
     <!-- 3. Kafka Appender (중앙 로그 수집)              -->
     <!-- ============================================ -->
     <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
+        <!-- INFO 이상만 Kafka로 전송 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+
+        <!-- traceId가 있는 로그만 Kafka로 전송 (MDC 컨텍스트 필터) -->
+        <filter class="dukku.common.global.logging.MdcTraceFilter"/>
+
         <!-- Kafka Topic 이름 -->
         <topic>msa-logs</topic>
 

--- a/product/src/main/resources/logback-spring.xml
+++ b/product/src/main/resources/logback-spring.xml
@@ -56,7 +56,9 @@
         <topic>msa-logs</topic>
 
         <!-- Key Partitioning: 같은 서비스 로그는 같은 파티션으로 -->
-        <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.ThreadNameKeyingStrategy"/>
+        <keyingStrategy class="dukku.common.global.logging.ServiceNameKeyingStrategy">
+            <serviceName>${SERVICE_NAME}</serviceName>
+        </keyingStrategy>
 
         <!-- 전송 실패 시 처리 (콘솔로 fallback) -->
         <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy"/>
@@ -104,8 +106,12 @@
     <springProfile name="dev">
         <root level="DEBUG">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>
@@ -121,8 +127,12 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,3 +10,5 @@ include 'order'
 include 'payment'
 include 'coupon'
 include 'ai'
+include 'log-consumer'
+project(':log-consumer').projectDir = file('monitoring/log-consumer')

--- a/settlement/src/main/java/dukku/settlement/boundedContext/settlement/app/CreateSettlementUseCase.java
+++ b/settlement/src/main/java/dukku/settlement/boundedContext/settlement/app/CreateSettlementUseCase.java
@@ -7,6 +7,7 @@ import dukku.common.shared.deposit.out.depositApiClient.DepositApiClient;
 import dukku.common.shared.order.out.OrderApiClient;
 import dukku.common.shared.payment.dto.PaymentInternalResponse;
 import dukku.common.shared.payment.out.PaymentApiClient;
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,6 +37,7 @@ public class CreateSettlementUseCase {
     private final DepositApiClient depositApiClient;
     private final OrderApiClient orderApiClient;
     private final PaymentApiClient paymentApiClient;
+    private final SettlementMetrics settlementMetrics;
 
     @Value("${batch.settlement.fee-rate}")
     private BigDecimal feeRate;
@@ -47,6 +49,7 @@ public class CreateSettlementUseCase {
      * @param endDateTime   조회 종료 일시
      * @return 생성된 Settlement 목록
      */
+    @Timed(value = "business_settlement_processing_time_seconds", description = "정산 배치 처리 소요 시간")
     @Transactional
     public List<Settlement> execute(LocalDateTime startDateTime, LocalDateTime endDateTime) {
         log.info("[정산 생성] 배치 실행. 조회 기간: {} ~ {}", startDateTime, endDateTime);
@@ -94,6 +97,9 @@ public class CreateSettlementUseCase {
             );
 
             settlementSupport.save(settlement);
+
+            settlementMetrics.incrementCreated();
+            settlementMetrics.addAmount(settlement.getSettlementAmount());
 
             log.debug("[정산 생성] settlementUuid={}, orderItemUuid={}, sellerUuid={}, amount={}",
                     settlement.getUuid(), orderItem.orderItemUuid(), orderItem.sellerUuid(), orderItem.productPrice());

--- a/settlement/src/main/java/dukku/settlement/boundedContext/settlement/app/RetrySettlementUseCase.java
+++ b/settlement/src/main/java/dukku/settlement/boundedContext/settlement/app/RetrySettlementUseCase.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 public class RetrySettlementUseCase {
 
     private final SettlementSupport settlementSupport;
+    private final SettlementMetrics settlementMetrics;
 
     @Transactional
     public Settlement execute(UUID settlementUuid) {
@@ -27,6 +28,8 @@ public class RetrySettlementUseCase {
         Settlement settlement = settlementSupport.findByUuid(settlementUuid);
         settlement.retry();
         settlementSupport.save(settlement);
+
+        settlementMetrics.incrementRetry();
 
         log.info("[정산 재처리 완료] settlementUuid={}, newStatus={}",
                 settlementUuid, settlement.getSettlementStatus());

--- a/settlement/src/main/java/dukku/settlement/boundedContext/settlement/app/SettlementMetrics.java
+++ b/settlement/src/main/java/dukku/settlement/boundedContext/settlement/app/SettlementMetrics.java
@@ -1,0 +1,43 @@
+package dukku.settlement.boundedContext.settlement.app;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SettlementMetrics {
+
+    private final MeterRegistry meterRegistry;
+
+    private Counter createdCounter;
+    private Counter amountCounter;
+    private Counter retryCounter;
+
+    @PostConstruct
+    void init() {
+        this.createdCounter = Counter.builder("business_settlement_created_total")
+                .description("정산 생성 건수")
+                .register(meterRegistry);
+        this.amountCounter = Counter.builder("business_settlement_amount_total")
+                .description("정산 금액 누적 합계")
+                .register(meterRegistry);
+        this.retryCounter = Counter.builder("business_settlement_retry_total")
+                .description("정산 재처리 요청 건수")
+                .register(meterRegistry);
+    }
+
+    public void incrementCreated() {
+        createdCounter.increment();
+    }
+
+    public void addAmount(double amount) {
+        amountCounter.increment(amount);
+    }
+
+    public void incrementRetry() {
+        retryCounter.increment();
+    }
+}

--- a/settlement/src/main/resources/logback-spring.xml
+++ b/settlement/src/main/resources/logback-spring.xml
@@ -52,6 +52,14 @@
     <!-- 3. Kafka Appender (중앙 로그 수집)              -->
     <!-- ============================================ -->
     <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
+        <!-- INFO 이상만 Kafka로 전송 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+
+        <!-- traceId가 있는 로그만 Kafka로 전송 (MDC 컨텍스트 필터) -->
+        <filter class="dukku.common.global.logging.MdcTraceFilter"/>
+
         <!-- Kafka Topic 이름 -->
         <topic>msa-logs</topic>
 
@@ -146,6 +154,19 @@
         <root level="WARN">
             <appender-ref ref="CONSOLE"/>
         </root>
+    </springProfile>
+
+    <!-- 프로파일 미지정 시 기본 설정: 콘솔 + Kafka -->
+    <springProfile name="default">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
+
+        <logger name="org.apache.kafka" level="WARN"/>
     </springProfile>
 
 </configuration>

--- a/settlement/src/main/resources/logback-spring.xml
+++ b/settlement/src/main/resources/logback-spring.xml
@@ -56,7 +56,9 @@
         <topic>msa-logs</topic>
 
         <!-- Key Partitioning: 같은 서비스 로그는 같은 파티션으로 -->
-        <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.ThreadNameKeyingStrategy"/>
+        <keyingStrategy class="dukku.common.global.logging.ServiceNameKeyingStrategy">
+            <serviceName>${SERVICE_NAME}</serviceName>
+        </keyingStrategy>
 
         <!-- 전송 실패 시 처리 (콘솔로 fallback) -->
         <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy"/>
@@ -104,8 +106,12 @@
     <springProfile name="dev">
         <root level="DEBUG">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>
@@ -121,8 +127,12 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>

--- a/user/src/main/resources/logback-spring.xml
+++ b/user/src/main/resources/logback-spring.xml
@@ -52,6 +52,14 @@
     <!-- 3. Kafka Appender (중앙 로그 수집)              -->
     <!-- ============================================ -->
     <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
+        <!-- INFO 이상만 Kafka로 전송 -->
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>INFO</level>
+        </filter>
+
+        <!-- traceId가 있는 로그만 Kafka로 전송 (MDC 컨텍스트 필터) -->
+        <filter class="dukku.common.global.logging.MdcTraceFilter"/>
+
         <!-- Kafka Topic 이름 -->
         <topic>msa-logs</topic>
 

--- a/user/src/main/resources/logback-spring.xml
+++ b/user/src/main/resources/logback-spring.xml
@@ -56,7 +56,9 @@
         <topic>msa-logs</topic>
 
         <!-- Key Partitioning: 같은 서비스 로그는 같은 파티션으로 -->
-        <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.ThreadNameKeyingStrategy"/>
+        <keyingStrategy class="dukku.common.global.logging.ServiceNameKeyingStrategy">
+            <serviceName>${SERVICE_NAME}</serviceName>
+        </keyingStrategy>
 
         <!-- 전송 실패 시 처리 (콘솔로 fallback) -->
         <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy"/>
@@ -104,8 +106,12 @@
     <springProfile name="dev">
         <root level="DEBUG">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>
@@ -121,8 +127,12 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
             <appender-ref ref="FILE"/>
-            <appender-ref ref="ASYNC_KAFKA"/>
         </root>
+
+        <!-- dukku 패키지 로그만 Kafka로 전송 -->
+        <logger name="dukku" level="INFO" additivity="true">
+            <appender-ref ref="ASYNC_KAFKA"/>
+        </logger>
 
         <!-- Kafka 클라이언트 내부 로그 억제 (피드백 루프 방지) -->
         <logger name="org.apache.kafka" level="WARN"/>


### PR DESCRIPTION
## 개요

- 오류 발생시, TraceId를 기준으로 추적할 수 있는 로그 시스템을 구축하였습니다.
- 해당 문서를 참고해주세요 
 - #198 
 - #205
- Close  #175 
- Close #198 
- Close  #205

<img width="1919" height="879" alt="스크린샷 2026-02-17 011508" src="https://github.com/user-attachments/assets/aa0163bd-59d8-446e-b8d1-2697ed8bb190" />
<img width="1895" height="852" alt="스크린샷 2026-02-17 175307" src="https://github.com/user-attachments/assets/ca430912-cf77-48f8-a614-5754ff5850a3" />
<img width="1897" height="850" alt="image" src="https://github.com/user-attachments/assets/bc5aa608-58a5-4c56-9399-c4d9d68bc434" />
<img width="1125" height="617" alt="image" src="https://github.com/user-attachments/assets/8e7e1d4d-b1b2-4e30-9ff5-1633695c11dc" />

---

## 상세 설명


- 로깅 에러 슬랙 알림 추가
- traceId log 추출되지 않는 현상 해결
- 로그 파이프라인 품질 개선 및 Grafana Log 대시보드 구현
- Kafka appender에 ThresholdFilter(INFO) + MdcTraceFilter 
추가하여 traceId가 있는 INFO 이상 로그만 전송
     - LogKafkaConsumer에 traceId null 필터 추가 (이중 방어)
     - log-consumer를 common 의존성 없이 자체 빌드로 분리
     - MongoDB log_service DB에 정확히 저장되도록 MongoConfig 구현
     - Grafana Infinity 데이터소스 + Log Overview 대시보드 (traceId 추적, 에러 조회, 로그 스트림)
     - Prometheus 스크래핑 대상에 전체 서비스 포트 추가
- 비지니스 매트릭 수집을 위한 meterRegistry 도입
- key 기반 partioning으로 리팩토링
    - 도메인 이름별로 msa-logs 토픽에 파티셔닝 들어감
    - 도메인 로그만 포함되어 들어감
- MongoDB에 저장된 로그를 조회할 수 있는 REST API 구현.
- Kafka msa-logs 토픽에서 로그 메시지를 수신하여 MongoDB에 저장하는 Consumer 구현.  
    - @KafkaListener(topics = "msa-logs", groupId = "log-consumer-group")
    - ConsumerRecord<String, String> 수신 → JSON 파싱 (ObjectMapper)
    - LogDoc 변환 → logRepository.save(doc)
    - 수동 ACK (ack.acknowledge())
    - 파싱 실패 시에도 ACK하여 무한 루프 방지
    - @timestamp ISO 8601 파싱 처리
- log respository 추가
- mogodb document 생성
- 로깅 모듈 인프라 세팅
    - 멀티 모듈에 맞게 리팩토링

---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [x] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [x] 커밋 메시지가 컨벤션에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [x] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [x] 메소드 역할과 책임이 적절하게 분리되었는가?
- [x] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [x] 기존 기능에 영향을 주지 않는가?
- [x] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

- 비지니스 로깅은 구축되지 않았습니다(API vs Metry 방식 고민중입니다..)\
- 로깅 구축 사항은 이슈 문서를 참조해주세요
- TraceId 추적 관련문의 궁금한 게 있다면 리뷰 남게주세요
- .env파일 추가하였습니다 @o-sein key값은 github action에 추가하였습니다.(SLACK_WEBHOOK_GRAFANA_ERROR)
 - 로그 데이터 수집하기 위해서 로그 서버도 동작시켜서 ci/cd에 추가해야할 거 같습니다 @o-sein 
<img width="395" height="237" alt="image" src="https://github.com/user-attachments/assets/313b7622-be4e-426b-b3ef-3f2adfd6caa3" />
