### PR TITLE
[Auth] RateLimiter가 활성화 되지 않는 현상 해결 #191

### DIFF
--- a/common/src/main/java/dukku/common/global/ratelimit/RateLimitInterceptor.java
+++ b/common/src/main/java/dukku/common/global/ratelimit/RateLimitInterceptor.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -24,7 +24,7 @@ import java.util.Optional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@ConditionalOnBean(StringRedisTemplate.class)
+@ConditionalOnBean(RedisTemplate.class)
 @ConditionalOnProperty(prefix = "custom.rate-limit", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class RateLimitInterceptor implements HandlerInterceptor {
     private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();

--- a/common/src/main/java/dukku/common/global/ratelimit/RateLimitWebConfig.java
+++ b/common/src/main/java/dukku/common/global/ratelimit/RateLimitWebConfig.java
@@ -5,14 +5,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableConfigurationProperties(RateLimitProperties.class)
-@ConditionalOnBean(StringRedisTemplate.class)
+@ConditionalOnBean(RedisTemplate.class)
 @ConditionalOnProperty(prefix = "custom.rate-limit", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class RateLimitWebConfig implements WebMvcConfigurer {
     private final RateLimitInterceptor rateLimitInterceptor;

--- a/common/src/main/java/dukku/common/global/ratelimit/RedisFixedWindowRateLimiter.java
+++ b/common/src/main/java/dukku/common/global/ratelimit/RedisFixedWindowRateLimiter.java
@@ -3,7 +3,7 @@ package dukku.common.global.ratelimit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
@@ -11,12 +11,12 @@ import java.time.Instant;
 
 @Component
 @RequiredArgsConstructor
-@ConditionalOnBean(StringRedisTemplate.class)
+@ConditionalOnBean(RedisTemplate.class)
 @ConditionalOnProperty(prefix = "custom.rate-limit", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class RedisFixedWindowRateLimiter {
     private static final String KEY_PREFIX = "rate_limit";
 
-    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     public RateLimitDecision tryConsume(String policyName, String identifier, long limit, long windowSeconds) {
         long safeLimit = Math.max(limit, 1L);
@@ -26,9 +26,9 @@ public class RedisFixedWindowRateLimiter {
         long windowStart = (nowEpochSeconds / safeWindow) * safeWindow;
         String redisKey = KEY_PREFIX + ":" + policyName + ":" + identifier + ":" + windowStart;
 
-        Long current = stringRedisTemplate.opsForValue().increment(redisKey);
+        Long current = redisTemplate.opsForValue().increment(redisKey);
         if (current != null && current == 1L) {
-            stringRedisTemplate.expire(redisKey, Duration.ofSeconds(safeWindow + 1L));
+            redisTemplate.expire(redisKey, Duration.ofSeconds(safeWindow + 1L));
         }
 
         long used = current == null ? safeLimit : current;


### PR DESCRIPTION
## 개요

- RateLimiter가 활성화 되지 않음
- #191 추가 수정

---

## 상세 내용

- 로그인 요청을 보내면 header에 X-RateLimit관련 내용 누락
- 10번 요청을 보내면 10번 다 요청이 보내지는 현상 수정
<img width="1861" height="1397" alt="image" src="https://github.com/user-attachments/assets/276f227a-e3ac-4141-9b72-8a97acf03203" />

- Iterations: 10
- Delay: 100ms
- postman runner로 테스트 진행하였습니다.
- 요청 10번을 보내면 5번까지는 정상적으로 200 ok가 나오다가 6번째부터 429error가 나오면서 로그인에 fail하는 걸 확인할 수 있습니다.

---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
