### PR TITLE
[Product] Cart가 SellerUuid 전달하도록 수정 #230

### DIFF
--- a/common/src/main/java/dukku/common/shared/product/dto/cart/CartDto.java
+++ b/common/src/main/java/dukku/common/shared/product/dto/cart/CartDto.java
@@ -6,12 +6,13 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record CartDto(
-        int cartId,            // 장바구니 PK (삭제 시 사용)
-        UUID productUuid,       // 상품 UUID (상세 페이지 이동용)
-        String title,           // 상품 제목
-        long price,             // 현재 상품 가격 (실시간 반영)
-        SaleStatus saleStatus,  // 판매 상태 (ON_SALE, SOLD_OUT 등)
-        String thumbnailUrl,    // 썸네일 이미지 URL
-        LocalDateTime createdAt // 장바구니에 담은 날짜
+        int cartId,
+        UUID productUuid,
+        UUID sellerUuid,
+        String title,
+        long price,
+        SaleStatus saleStatus,
+        String thumbnailUrl,
+        LocalDateTime createdAt
 ) {
 }

--- a/order/src/test/java/dukku/order/boundedContext/order/app/ReturnRefundFlowIntegrationTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/ReturnRefundFlowIntegrationTest.java
@@ -1,0 +1,221 @@
+package dukku.order.boundedContext.order.app;
+
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.order.dto.ReturnRequestCreateDto;
+import dukku.common.shared.order.dto.ReturnResponse;
+import dukku.common.shared.order.event.PartialRefundRequestedEvent;
+import dukku.common.shared.order.type.OrderItemStatus;
+import dukku.common.shared.order.type.OrderStatus;
+import dukku.common.shared.order.type.ReturnStatus;
+import dukku.common.shared.payment.event.RefundCompletedEvent;
+import dukku.common.shared.payment.event.RefundFailedEvent;
+import dukku.common.shared.payment.type.PaymentFailureCode;
+import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.entity.OrderItem;
+import dukku.order.boundedContext.order.entity.ReturnRequest;
+import dukku.order.boundedContext.order.in.OrderEventListener;
+import dukku.order.boundedContext.order.out.OrderRepository;
+import dukku.order.boundedContext.order.out.ProcessedRefundEventRepository;
+import dukku.order.boundedContext.order.out.ReturnRequestRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+        "spring.datasource.url=jdbc:h2:mem:return_refund_flow_it;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.kafka.listener.auto-startup=false",
+        "spring.kafka.bootstrap-servers=localhost:9092",
+        "spring.data.redis.host=localhost",
+        "spring.data.redis.port=6379",
+        "spring.elasticsearch.uris=http://localhost:9200",
+        "jwt.access.secret.key=dGhpcy1rZXktaXMtdGVzdC1rZXktYWNjZXNzLTAxMjM=",
+        "jwt.refresh.secret.key=dGhpcy1rZXktaXMtdGVzdC1rZXktcmVmcmVzaC0wMTI=",
+        "crypto.key=dGhpcy1rZXktaXMtdGVzdC1rZXktY3J5cHRvLTAxMjM="
+})
+@Transactional
+class ReturnRefundFlowIntegrationTest {
+
+    @Autowired
+    private RequestReturnUseCase requestReturnUseCase;
+
+    @Autowired
+    private ApproveReturnUseCase approveReturnUseCase;
+
+    @Autowired
+    private OrderEventListener orderEventListener;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private ReturnRequestRepository returnRequestRepository;
+
+    @Autowired
+    private ProcessedRefundEventRepository processedRefundEventRepository;
+
+    @MockitoBean
+    private EventPublisher eventPublisher;
+
+    @BeforeEach
+    void cleanUp() {
+        processedRefundEventRepository.deleteAll();
+        returnRequestRepository.deleteAll();
+        orderRepository.deleteAll();
+        reset(eventPublisher);
+    }
+
+    @Test
+    @DisplayName("Return request -> approve -> refund completed updates order item and ignores duplicated retry event")
+    void completesReturnFlowAndIgnoresDuplicateRefundEvent() {
+        ReturnFlowFixture fixture = createDeliveredOrderFixture();
+
+        ReturnResponse requested = requestReturnUseCase.execute(
+                fixture.buyerUuid(),
+                fixture.orderUuid(),
+                ReturnRequestCreateDto.builder()
+                        .reason("buyer change of mind")
+                        .orderItemUuids(List.of(fixture.orderItemUuid()))
+                        .build());
+        assertThat(requested.getStatus()).isEqualTo(ReturnStatus.RETURN_REQUESTED);
+
+        Order requestedOrder = orderRepository.findByUuidWithItems(fixture.orderUuid()).orElseThrow();
+        assertThat(requestedOrder.getOrderItems()).hasSize(1);
+        assertThat(requestedOrder.getOrderItems().get(0).getStatus()).isEqualTo(OrderItemStatus.REFUND_REQUESTED);
+
+        ReturnResponse approved = approveReturnUseCase.execute(fixture.sellerUuid(), requested.getReturnRequestUuid());
+        assertThat(approved.getStatus()).isEqualTo(ReturnStatus.RETURN_APPROVED);
+
+        ArgumentCaptor<PartialRefundRequestedEvent> eventCaptor =
+                ArgumentCaptor.forClass(PartialRefundRequestedEvent.class);
+        verify(eventPublisher).publish(eventCaptor.capture());
+        PartialRefundRequestedEvent partialRefundRequestedEvent = eventCaptor.getValue();
+        long refundAmount = partialRefundRequestedEvent.refundItems().stream()
+                .mapToLong(PartialRefundRequestedEvent.RefundItemInfo::refundAmount)
+                .sum();
+
+        UUID refundUuid = UUID.randomUUID();
+        RefundCompletedEvent completedEvent = new RefundCompletedEvent(
+                refundUuid,
+                UUID.randomUUID(),
+                fixture.orderUuid(),
+                refundAmount,
+                0L,
+                fixture.buyerUuid(),
+                LocalDateTime.now(),
+                List.of(fixture.orderItemUuid()));
+
+        orderEventListener.handle(completedEvent);
+
+        Order refundedOrder = orderRepository.findByUuidWithItems(fixture.orderUuid()).orElseThrow();
+        assertThat(refundedOrder.getRefundedAmount()).isEqualTo((int) refundAmount);
+        assertThat(refundedOrder.getStatus()).isEqualTo(OrderStatus.CANCELED);
+        assertThat(refundedOrder.getOrderItems().get(0).getStatus()).isEqualTo(OrderItemStatus.REFUND_COMPLETED);
+
+        ReturnRequest completedRequest = returnRequestRepository.findByUuid(approved.getReturnRequestUuid()).orElseThrow();
+        assertThat(completedRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_COMPLETED);
+
+        orderEventListener.handle(completedEvent);
+
+        Order retriedOrder = orderRepository.findByUuidWithItems(fixture.orderUuid()).orElseThrow();
+        assertThat(retriedOrder.getRefundedAmount()).isEqualTo((int) refundAmount);
+        assertThat(retriedOrder.getOrderItems().get(0).getStatus()).isEqualTo(OrderItemStatus.REFUND_COMPLETED);
+        assertThat(processedRefundEventRepository.existsByRefundUuid(refundUuid)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Refund failed event reverts approved return back to rejected and order item to delivered")
+    void revertsApprovedReturnWhenRefundFails() {
+        ReturnFlowFixture fixture = createDeliveredOrderFixture();
+
+        ReturnResponse requested = requestReturnUseCase.execute(
+                fixture.buyerUuid(),
+                fixture.orderUuid(),
+                ReturnRequestCreateDto.builder()
+                        .reason("defect")
+                        .orderItemUuids(List.of(fixture.orderItemUuid()))
+                        .build());
+
+        ReturnResponse approved = approveReturnUseCase.execute(fixture.sellerUuid(), requested.getReturnRequestUuid());
+        assertThat(approved.getStatus()).isEqualTo(ReturnStatus.RETURN_APPROVED);
+
+        RefundFailedEvent failedEvent = new RefundFailedEvent(
+                fixture.orderUuid(),
+                UUID.randomUUID(),
+                fixture.buyerUuid(),
+                fixture.itemPrice().longValue(),
+                fixture.itemPrice().longValue(),
+                0L,
+                PaymentFailureCode.REFUND_PG_CANCEL_FAILED,
+                true,
+                "simulated pg failure",
+                LocalDateTime.now());
+
+        orderEventListener.handle(failedEvent);
+
+        Order restoredOrder = orderRepository.findByUuidWithItems(fixture.orderUuid()).orElseThrow();
+        assertThat(restoredOrder.getRefundedAmount()).isZero();
+        assertThat(restoredOrder.getOrderItems().get(0).getStatus()).isEqualTo(OrderItemStatus.DELIVERED);
+
+        ReturnRequest rejectedRequest = returnRequestRepository.findByUuid(approved.getReturnRequestUuid()).orElseThrow();
+        assertThat(rejectedRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_REJECTED);
+    }
+
+    private ReturnFlowFixture createDeliveredOrderFixture() {
+        UUID buyerUuid = UUID.randomUUID();
+        UUID sellerUuid = UUID.randomUUID();
+
+        Order order = Order.builder()
+                .userUuid(buyerUuid)
+                .totalAmount(15_000)
+                .address("seoul")
+                .recipient("buyer")
+                .contactNumber("010-1111-2222")
+                .refundedAmount(0)
+                .status(OrderStatus.PAID)
+                .build();
+
+        OrderItem orderItem = OrderItem.builder()
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(sellerUuid)
+                .productName("test-item")
+                .productPrice(15_000)
+                .imageUrl("https://example.com/item.png")
+                .status(OrderItemStatus.DELIVERED)
+                .build();
+
+        order.addOrderItem(orderItem);
+        Order savedOrder = orderRepository.save(order);
+
+        UUID orderUuid = savedOrder.getUuid();
+        UUID orderItemUuid = savedOrder.getOrderItems().get(0).getUuid();
+
+        return new ReturnFlowFixture(buyerUuid, sellerUuid, orderUuid, orderItemUuid, 15_000);
+    }
+
+    private record ReturnFlowFixture(
+            UUID buyerUuid,
+            UUID sellerUuid,
+            UUID orderUuid,
+            UUID orderItemUuid,
+            Integer itemPrice
+    ) {
+    }
+}

--- a/product/src/main/java/dukku/product/boundedContext/product/entity/Cart.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/entity/Cart.java
@@ -69,6 +69,7 @@ public class Cart extends BaseIdAndTime {
         return new CartDto(
                 cart.getId(),
                 product.getUuid(),
+                product.getSellerUuid(),
                 product.getTitle(),
                 product.getPrice(),
                 product.getSaleStatus(),


### PR DESCRIPTION
## PR 제목

[Product] Cart가 SellerUuid 전달하도록 수정 #230

---

## 개요

프론트가 받는 장바구니 아이템 데이터에 실제 sellerUuid가 있어야 Order에 SellerUuid를 정상적으로 전달할 수 있습니다.
기존에는 Cart 응답에 그 값이 없어서 하드코딩된 UUID를 쓰고 있었습니다.
Cart 엔티티에는 sellerUuid 필드가 없습니다. user, product만 가집니다. Product에 대해서 프론트는 Uuid만 받아서 하위 정보를 들고 있지 않습니다. Order로 요청을 보낼 때 SellerUuid를 전달할 수 없는 구조입니다.

---

## 상세 내용


**Feat(common,product): CartDto sellerUuid 연동 반영**
SHA : 1e309de033d7df625cc2d5bf23be8aeabb0a0aa1
- CartDto 응답 필드에 sellerUuid를 추가해 주문 생성에 필요한 판매자 정보를 제공
- Cart.toDto에서 Product.sellerUuid를 매핑하도록 변경


**Test(order): 반품-환불 통합 시나리오 테스트 추가**
SHA : 8f6c69b0160a6c76e2153fb7bf22eabeaa66a280
- 반품 요청 -> 판매자 승인 -> 환불 완료 이벤트 흐름의 상태 전이를 통합 테스트로 고정
- 동일 refundUuid 재수신 시 중복 반영이 되지 않는 멱등 처리 동작을 검증
- 환불 실패 이벤트 수신 시 ReturnRequest/OrderItem 상태 복구를 검증



---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [x] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [x] 커밋 메시지가 컨벤션에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?

### 안정성 체크
- [x] 기존 기능에 영향을 주지 않는가?
- [x] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
