### PR TITLE
[Order] 반품 승인 및 반품 거절 단계 추가 #234

### DIFF
--- a/common/src/main/java/dukku/common/shared/order/dto/ReturnRejectDto.java
+++ b/common/src/main/java/dukku/common/shared/order/dto/ReturnRejectDto.java
@@ -1,0 +1,18 @@
+package dukku.common.shared.order.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 반품 거절 요청 DTO
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReturnRejectDto {
+    private String reason;
+}

--- a/common/src/main/java/dukku/common/shared/order/dto/ReturnResponse.java
+++ b/common/src/main/java/dukku/common/shared/order/dto/ReturnResponse.java
@@ -1,12 +1,19 @@
 package dukku.common.shared.order.dto;
 
 import dukku.common.shared.order.type.ReturnStatus;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * 반품 요청 응답 DTO
+ */
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,12 +23,16 @@ public class ReturnResponse {
     private UUID orderUuid;
     private ReturnStatus status;
     private String reason;
+    private String rejectionReason;
     private String carrierName;
     private String carrierCode;
     private String trackingNumber;
     private LocalDateTime createdAt;
     private List<ReturnItemResponse> returnItems;
 
+    /**
+     * 반품 아이템 응답 DTO
+     */
     @Getter
     @Builder
     @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/common/src/main/java/dukku/common/shared/order/exception/ReturnRequestStatusInvalidException.java
+++ b/common/src/main/java/dukku/common/shared/order/exception/ReturnRequestStatusInvalidException.java
@@ -1,0 +1,17 @@
+package dukku.common.shared.order.exception;
+
+import dukku.common.global.exception.ConflictException;
+import dukku.common.shared.order.type.ReturnStatus;
+
+/**
+ * 반품 상태 전이 불가 예외
+ */
+public class ReturnRequestStatusInvalidException extends ConflictException {
+
+    /**
+     * 현재 상태 기준 허용되지 않은 반품 처리 예외 생성
+     */
+    public ReturnRequestStatusInvalidException(ReturnStatus currentStatus, String requiredStateDescription) {
+        super("현재 반품 상태(" + currentStatus + ")에서는 요청을 처리할 수 없습니다. 필요 상태: " + requiredStateDescription);
+    }
+}

--- a/common/src/main/java/dukku/common/shared/order/type/ReturnStatus.java
+++ b/common/src/main/java/dukku/common/shared/order/type/ReturnStatus.java
@@ -1,9 +1,15 @@
 package dukku.common.shared.order.type;
 
+/**
+ * 반품 요청 상태 코드
+ */
 public enum ReturnStatus {
-    RETURN_REQUESTED, // 반품 신청됨
-    RETURN_SHIPPED, // 반품 발송됨 (운송장 등록 완료)
-    RETURN_APPROVED, // 판매자 반품 수락 (환불 트리거)
-    RETURN_COMPLETED, // 반품 완료 (부분환불 완료)
-    RETURN_REJECTED // 반품 거절
+    RETURN_REQUESTED,
+    RETURN_SELLER_APPROVED,
+    RETURN_SHIPPED,
+    RETURN_APPROVED,
+    RETURN_COMPLETED,
+    RETURN_REJECTED_BEFORE_SHIPMENT,
+    RETURN_REJECTED_AFTER_SHIPMENT,
+    RETURN_REJECTED
 }

--- a/common/src/main/java/dukku/common/shared/product/dto/product/ProductDetailResponse.java
+++ b/common/src/main/java/dukku/common/shared/product/dto/product/ProductDetailResponse.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 public class ProductDetailResponse {
 
     private UUID productUuid;
+    private UUID sellerUuid;
     private String title;
     private String description;
     private Long price;

--- a/order/src/main/java/dukku/order/boundedContext/order/app/FinalRejectReturnUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/FinalRejectReturnUseCase.java
@@ -1,8 +1,6 @@
 package dukku.order.boundedContext.order.app;
 
-import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.order.dto.ReturnResponse;
-import dukku.common.shared.order.event.PartialRefundRequestedEvent;
 import dukku.common.shared.order.exception.ReturnApprovalAccessDeniedException;
 import dukku.common.shared.order.exception.ReturnRequestNotFoundException;
 import dukku.common.shared.order.exception.ReturnRequestStatusInvalidException;
@@ -14,24 +12,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 /**
- * 판매자 반품 최종 승인 처리 유스케이스
+ * 판매자 반품 최종 거절 처리 유스케이스
  */
 @Service
 @RequiredArgsConstructor
-public class ApproveReturnUseCase {
+public class FinalRejectReturnUseCase {
 
     private final ReturnRequestRepository returnRequestRepository;
-    private final EventPublisher eventPublisher;
 
     /**
-     * 판매자 권한 및 상태 검증 후 반품 최종 승인 처리
+     * 판매자 권한 및 상태 검증 후 반품 최종 거절 처리
      */
     @Transactional
-    public ReturnResponse execute(UUID sellerUuid, UUID returnRequestUuid) {
+    public ReturnResponse execute(UUID sellerUuid, UUID returnRequestUuid, String rejectionReason) {
         ReturnRequest returnRequest = returnRequestRepository.findByUuid(returnRequestUuid)
                 .orElseThrow(ReturnRequestNotFoundException::new);
 
@@ -41,20 +37,14 @@ public class ApproveReturnUseCase {
             throw new ReturnRequestStatusInvalidException(returnRequest.getStatus(), ReturnStatus.RETURN_SHIPPED.name());
         }
 
-        returnRequest.approveFinal();
-        returnRequest.getReturnItems().forEach(item -> item.getOrderItem().updateOrderStatus(OrderItemStatus.REFUND_IN_PROGRESS));
+        returnRequest.rejectAfterShipment(rejectionReason);
 
-        List<PartialRefundRequestedEvent.RefundItemInfo> refundItems = returnRequest.getReturnItems().stream()
-                .map(item -> new PartialRefundRequestedEvent.RefundItemInfo(
-                        item.getOrderItem().getUuid(),
-                        item.getRefundAmount()))
-                .toList();
-
-        eventPublisher.publish(new PartialRefundRequestedEvent(
-                returnRequest.getUuid(),
-                returnRequest.getOrder().getUuid(),
-                returnRequest.getUserUuid(),
-                refundItems));
+        returnRequest.getReturnItems().forEach(item -> {
+            OrderItemStatus currentStatus = item.getOrderItem().getStatus();
+            if (currentStatus == OrderItemStatus.REFUND_REQUESTED || currentStatus == OrderItemStatus.REFUND_IN_PROGRESS) {
+                item.getOrderItem().updateOrderStatus(OrderItemStatus.DELIVERED);
+            }
+        });
 
         return returnRequest.toResponse();
     }

--- a/order/src/main/java/dukku/order/boundedContext/order/app/RegisterReturnTrackingUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/RegisterReturnTrackingUseCase.java
@@ -4,6 +4,8 @@ import dukku.common.shared.order.dto.ReturnResponse;
 import dukku.common.shared.order.dto.ReturnTrackingRegisterDto;
 import dukku.common.shared.order.exception.ReturnRequestAccessDeniedException;
 import dukku.common.shared.order.exception.ReturnRequestNotFoundException;
+import dukku.common.shared.order.exception.ReturnRequestStatusInvalidException;
+import dukku.common.shared.order.type.ReturnStatus;
 import dukku.order.boundedContext.order.entity.ReturnRequest;
 import dukku.order.boundedContext.order.out.ReturnRequestRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +14,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
+/**
+ * 반품 운송장 등록 처리 유스케이스
+ */
 @Service
 @RequiredArgsConstructor
 public class RegisterReturnTrackingUseCase {
 
     private final ReturnRequestRepository returnRequestRepository;
 
+    /**
+     * 구매자 권한 및 상태 검증 후 반품 운송장 등록 처리
+     */
     @Transactional
     public ReturnResponse execute(UUID userUuid, UUID returnRequestUuid, ReturnTrackingRegisterDto dto) {
         ReturnRequest returnRequest = returnRequestRepository.findByUuid(returnRequestUuid)
@@ -25,6 +33,10 @@ public class RegisterReturnTrackingUseCase {
 
         if (!returnRequest.getUserUuid().equals(userUuid)) {
             throw new ReturnRequestAccessDeniedException();
+        }
+
+        if (returnRequest.getStatus() != ReturnStatus.RETURN_SELLER_APPROVED) {
+            throw new ReturnRequestStatusInvalidException(returnRequest.getStatus(), ReturnStatus.RETURN_SELLER_APPROVED.name());
         }
 
         returnRequest.updateTrackingInfo(dto.getCarrierName(), dto.getCarrierCode(), dto.getTrackingNumber());

--- a/order/src/main/java/dukku/order/boundedContext/order/app/RequestReturnUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/RequestReturnUseCase.java
@@ -19,6 +19,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
+/**
+ * 구매자 반품 신청 처리 유스케이스
+ */
 @Service
 @RequiredArgsConstructor
 public class RequestReturnUseCase {
@@ -26,6 +29,9 @@ public class RequestReturnUseCase {
     private final OrderRepository orderRepository;
     private final ReturnRequestRepository returnRequestRepository;
 
+    /**
+     * 주문 소유권 검증 후 반품 신청 생성 처리
+     */
     @Transactional
     public ReturnResponse execute(UUID userUuid, UUID orderUuid, ReturnRequestCreateDto dto) {
         Order order = orderRepository.findByUuidWithItems(orderUuid)
@@ -47,11 +53,7 @@ public class RequestReturnUseCase {
                     .findFirst()
                     .orElseThrow(OrderItemNotFoundException::new);
 
-            // 반품 신청 가능 알맞은 상태로 전환 시도. 검증을 거침.
             orderItem.updateOrderStatus(OrderItemStatus.REFUND_REQUESTED);
-
-            // 반품 신청 단계에서는 주문 원가 기준으로 저장
-            // 실제 환불 집행 금액(쿠폰/기환불 반영)은 Payment BC에서 스냅샷 기준으로 재계산
             int refundAmount = orderItem.getProductPrice();
 
             ReturnItem returnItem = ReturnItem.create(orderItem, refundAmount);

--- a/order/src/main/java/dukku/order/boundedContext/order/app/SellerApproveReturnUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/SellerApproveReturnUseCase.java
@@ -1,12 +1,9 @@
 package dukku.order.boundedContext.order.app;
 
-import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.order.dto.ReturnResponse;
-import dukku.common.shared.order.event.PartialRefundRequestedEvent;
 import dukku.common.shared.order.exception.ReturnApprovalAccessDeniedException;
 import dukku.common.shared.order.exception.ReturnRequestNotFoundException;
 import dukku.common.shared.order.exception.ReturnRequestStatusInvalidException;
-import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.common.shared.order.type.ReturnStatus;
 import dukku.order.boundedContext.order.entity.ReturnRequest;
 import dukku.order.boundedContext.order.out.ReturnRequestRepository;
@@ -14,21 +11,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 /**
- * 판매자 반품 최종 승인 처리 유스케이스
+ * 판매자 반품 1차 승인 처리 유스케이스
  */
 @Service
 @RequiredArgsConstructor
-public class ApproveReturnUseCase {
+public class SellerApproveReturnUseCase {
 
     private final ReturnRequestRepository returnRequestRepository;
-    private final EventPublisher eventPublisher;
 
     /**
-     * 판매자 권한 및 상태 검증 후 반품 최종 승인 처리
+     * 판매자 권한 및 상태 검증 후 반품 1차 승인 처리
      */
     @Transactional
     public ReturnResponse execute(UUID sellerUuid, UUID returnRequestUuid) {
@@ -37,25 +32,11 @@ public class ApproveReturnUseCase {
 
         validateSellerOwnership(sellerUuid, returnRequest);
 
-        if (returnRequest.getStatus() != ReturnStatus.RETURN_SHIPPED) {
-            throw new ReturnRequestStatusInvalidException(returnRequest.getStatus(), ReturnStatus.RETURN_SHIPPED.name());
+        if (returnRequest.getStatus() != ReturnStatus.RETURN_REQUESTED) {
+            throw new ReturnRequestStatusInvalidException(returnRequest.getStatus(), ReturnStatus.RETURN_REQUESTED.name());
         }
 
-        returnRequest.approveFinal();
-        returnRequest.getReturnItems().forEach(item -> item.getOrderItem().updateOrderStatus(OrderItemStatus.REFUND_IN_PROGRESS));
-
-        List<PartialRefundRequestedEvent.RefundItemInfo> refundItems = returnRequest.getReturnItems().stream()
-                .map(item -> new PartialRefundRequestedEvent.RefundItemInfo(
-                        item.getOrderItem().getUuid(),
-                        item.getRefundAmount()))
-                .toList();
-
-        eventPublisher.publish(new PartialRefundRequestedEvent(
-                returnRequest.getUuid(),
-                returnRequest.getOrder().getUuid(),
-                returnRequest.getUserUuid(),
-                refundItems));
-
+        returnRequest.approveBySeller();
         return returnRequest.toResponse();
     }
 

--- a/order/src/main/java/dukku/order/boundedContext/order/app/SellerRejectReturnUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/SellerRejectReturnUseCase.java
@@ -1,8 +1,6 @@
 package dukku.order.boundedContext.order.app;
 
-import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.order.dto.ReturnResponse;
-import dukku.common.shared.order.event.PartialRefundRequestedEvent;
 import dukku.common.shared.order.exception.ReturnApprovalAccessDeniedException;
 import dukku.common.shared.order.exception.ReturnRequestNotFoundException;
 import dukku.common.shared.order.exception.ReturnRequestStatusInvalidException;
@@ -14,47 +12,42 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.UUID;
 
 /**
- * 판매자 반품 최종 승인 처리 유스케이스
+ * 판매자 반품 1차 거절 처리 유스케이스
  */
 @Service
 @RequiredArgsConstructor
-public class ApproveReturnUseCase {
+public class SellerRejectReturnUseCase {
 
     private final ReturnRequestRepository returnRequestRepository;
-    private final EventPublisher eventPublisher;
 
     /**
-     * 판매자 권한 및 상태 검증 후 반품 최종 승인 처리
+     * 판매자 권한 및 상태 검증 후 반품 1차 거절 처리
      */
     @Transactional
-    public ReturnResponse execute(UUID sellerUuid, UUID returnRequestUuid) {
+    public ReturnResponse execute(UUID sellerUuid, UUID returnRequestUuid, String rejectionReason) {
         ReturnRequest returnRequest = returnRequestRepository.findByUuid(returnRequestUuid)
                 .orElseThrow(ReturnRequestNotFoundException::new);
 
         validateSellerOwnership(sellerUuid, returnRequest);
 
-        if (returnRequest.getStatus() != ReturnStatus.RETURN_SHIPPED) {
-            throw new ReturnRequestStatusInvalidException(returnRequest.getStatus(), ReturnStatus.RETURN_SHIPPED.name());
+        ReturnStatus status = returnRequest.getStatus();
+        if (status != ReturnStatus.RETURN_REQUESTED && status != ReturnStatus.RETURN_SELLER_APPROVED) {
+            throw new ReturnRequestStatusInvalidException(
+                    status,
+                    ReturnStatus.RETURN_REQUESTED.name() + " 또는 " + ReturnStatus.RETURN_SELLER_APPROVED.name());
         }
 
-        returnRequest.approveFinal();
-        returnRequest.getReturnItems().forEach(item -> item.getOrderItem().updateOrderStatus(OrderItemStatus.REFUND_IN_PROGRESS));
+        returnRequest.rejectBeforeShipment(rejectionReason);
 
-        List<PartialRefundRequestedEvent.RefundItemInfo> refundItems = returnRequest.getReturnItems().stream()
-                .map(item -> new PartialRefundRequestedEvent.RefundItemInfo(
-                        item.getOrderItem().getUuid(),
-                        item.getRefundAmount()))
-                .toList();
-
-        eventPublisher.publish(new PartialRefundRequestedEvent(
-                returnRequest.getUuid(),
-                returnRequest.getOrder().getUuid(),
-                returnRequest.getUserUuid(),
-                refundItems));
+        returnRequest.getReturnItems().forEach(item -> {
+            OrderItemStatus currentStatus = item.getOrderItem().getStatus();
+            if (currentStatus == OrderItemStatus.REFUND_REQUESTED || currentStatus == OrderItemStatus.REFUND_IN_PROGRESS) {
+                item.getOrderItem().updateOrderStatus(OrderItemStatus.DELIVERED);
+            }
+        });
 
         return returnRequest.toResponse();
     }

--- a/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
@@ -2,7 +2,9 @@ package dukku.order.boundedContext.order.app;
 
 import dukku.common.shared.order.exception.OrderRefundAmountOutOfRangeException;
 import dukku.common.shared.order.exception.OrderRefundRequestInvalidException;
+import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.common.shared.order.type.OrderStatus;
+import dukku.common.shared.order.type.ReturnStatus;
 import dukku.order.boundedContext.order.entity.Order;
 import dukku.order.boundedContext.order.out.ReturnRequestRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,57 +14,48 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * 환불 이벤트 기준 주문 및 반품 상태 동기화 유스케이스
+ */
 @Component
 @RequiredArgsConstructor
 public class UpdateOrderRefundStatusUseCase {
+
     private final OrderSupport orderSupport;
     private final ReturnRequestRepository returnRequestRepository;
 
     /**
-     * 결제 환불 이벤트의 환불 금액을 주문에 반영하고 상태를 갱신
-     * 누적 환불 금액과 총 결제 금액을 비교해 상태를 분기
-     *
-     * @param refundUuid        환불 UUID
-     * @param orderUuid         주문 UUID
-     * @param refundAmount      누적 환불 금액
-     * @param refundedItemUuids 환불 처리된 아이템의 UUID 목록
+     * 환불 완료 이벤트 반영 처리
      */
     @Transactional
     public void updateRefund(UUID refundUuid, UUID orderUuid, Long refundAmount, List<UUID> refundedItemUuids) {
-        // 입력값이 없거나 0 이하이면 예외 처리
         if (refundUuid == null || orderUuid == null || refundAmount == null || refundAmount <= 0) {
             throw new OrderRefundRequestInvalidException();
         }
 
-        // 이미 처리된 환불 이벤트면 중복 적용 방지
         if (!orderSupport.tryMarkRefundCompleted(refundUuid, orderUuid, refundAmount)) {
             return;
         }
 
-        // 주문 조회 실패는 상위 트랜잭션에서 롤백 또는 재시도로 처리
         Order order = orderSupport.findOrderByUuid(orderUuid);
 
-        // 환불 금액 범위 방어
         if (refundAmount > Integer.MAX_VALUE) {
             throw new OrderRefundAmountOutOfRangeException();
         }
 
-        // 누적 환불 금액 반영
         order.updateRefundedAmount(refundAmount.intValue());
 
-        // 개별 상품 환불 상태 처리 및 반품 묶음(ReturnRequest) 상태 갱신
         if (refundedItemUuids != null && !refundedItemUuids.isEmpty()) {
             order.getOrderItems().forEach(item -> {
                 if (refundedItemUuids.contains(item.getUuid())) {
-                    item.updateOrderStatus(dukku.common.shared.order.type.OrderItemStatus.REFUND_COMPLETED);
+                    item.updateOrderStatus(OrderItemStatus.REFUND_COMPLETED);
                 }
             });
 
             returnRequestRepository.findByOrderUuid(orderUuid).forEach(req -> {
-                if (req.getStatus() == dukku.common.shared.order.type.ReturnStatus.RETURN_APPROVED) {
+                if (req.getStatus() == ReturnStatus.RETURN_APPROVED) {
                     boolean allRefunded = req.getReturnItems().stream()
-                            .allMatch(ri -> ri.getOrderItem()
-                                    .getStatus() == dukku.common.shared.order.type.OrderItemStatus.REFUND_COMPLETED);
+                            .allMatch(ri -> ri.getOrderItem().getStatus() == OrderItemStatus.REFUND_COMPLETED);
                     if (allRefunded) {
                         req.complete();
                     }
@@ -70,25 +63,20 @@ public class UpdateOrderRefundStatusUseCase {
             });
         }
 
-        // 이미 취소된 주문이면 추가 상태 변경 생략
         if (order.getStatus() == OrderStatus.CANCELED) {
             return;
         }
 
-        // 누적 환불 금액이 총액 이상이면 주문 취소
         if (order.getRefundedAmount() >= order.getTotalAmount()) {
             order.updateOrderStatus(OrderStatus.CANCELED);
             return;
         }
 
-        // 일부만 환불된 경우 부분 환불 상태 반영
         order.updateOrderStatus(OrderStatus.PARTIAL_REFUNDED);
     }
 
     /**
-     * PG 결제 취소 실패 등으로 인한 환불 실패 시 보상 트랜잭션 수행
-     *
-     * @param orderUuid 주문 UUID
+     * 환불 실패 이벤트 보상 처리
      */
     @Transactional
     public void failRefund(UUID orderUuid) {
@@ -96,17 +84,15 @@ public class UpdateOrderRefundStatusUseCase {
             return;
         }
 
-        // 환불 실패 시 반품 승인 대기 중이던 ReturnRequest를 거절(실패) 상태로 변경하고,
-        // 연관된 OrderItem 상태를 이전(DELIVERED) 상태로 변경
         returnRequestRepository.findByOrderUuid(orderUuid).forEach(req -> {
-            if (req.getStatus() == dukku.common.shared.order.type.ReturnStatus.RETURN_APPROVED) {
-                req.reject(); // RETURN_REJECTED 상태로 변경
+            if (req.getStatus() == ReturnStatus.RETURN_APPROVED) {
+                req.rejectAfterShipment("PG 환불 실패");
 
                 req.getReturnItems().forEach(ri -> {
-                    dukku.common.shared.order.type.OrderItemStatus currentStatus = ri.getOrderItem().getStatus();
-                    if (currentStatus == dukku.common.shared.order.type.OrderItemStatus.REFUND_REQUESTED
-                            || currentStatus == dukku.common.shared.order.type.OrderItemStatus.REFUND_IN_PROGRESS) {
-                        ri.getOrderItem().updateOrderStatus(dukku.common.shared.order.type.OrderItemStatus.DELIVERED);
+                    OrderItemStatus currentStatus = ri.getOrderItem().getStatus();
+                    if (currentStatus == OrderItemStatus.REFUND_REQUESTED
+                            || currentStatus == OrderItemStatus.REFUND_IN_PROGRESS) {
+                        ri.getOrderItem().updateOrderStatus(OrderItemStatus.DELIVERED);
                     }
                 });
             }

--- a/order/src/main/java/dukku/order/boundedContext/order/entity/ReturnRequest.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/entity/ReturnRequest.java
@@ -28,6 +28,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * 반품 요청 엔티티
+ */
 @Entity
 @Table(name = "return_requests")
 @Getter
@@ -57,21 +60,30 @@ public class ReturnRequest extends BaseIdAndUUIDAndTime {
     @Column(nullable = false)
     private ReturnStatus status;
 
-    @Column(length = 500, comment = "반품 사유")
+    @Column(length = 500, comment = "반품 요청 사유")
     private String reason;
 
-    @Column(comment = "판매자 수락 일시")
+    @Column(length = 500, comment = "반품 거절 사유")
+    private String rejectionReason;
+
+    @Column(comment = "최종 반품 승인 일시")
     private LocalDateTime approvedAt;
 
     @Builder.Default
     @OneToMany(mappedBy = "returnRequest", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReturnItem> returnItems = new ArrayList<>();
 
+    /**
+     * 반품 아이템 연관관계 설정
+     */
     public void addReturnItem(ReturnItem item) {
         this.returnItems.add(item);
         item.setReturnRequest(this);
     }
 
+    /**
+     * 반품 요청 엔티티 생성
+     */
     public static ReturnRequest create(Order order, UUID userUuid, String reason) {
         return ReturnRequest.builder()
                 .order(order)
@@ -81,6 +93,16 @@ public class ReturnRequest extends BaseIdAndUUIDAndTime {
                 .build();
     }
 
+    /**
+     * 판매자 1차 승인 상태 전이
+     */
+    public void approveBySeller() {
+        this.status = ReturnStatus.RETURN_SELLER_APPROVED;
+    }
+
+    /**
+     * 반품 운송장 정보 등록 및 발송 상태 전이
+     */
     public void updateTrackingInfo(String carrierName, String carrierCode, String trackingNumber) {
         this.carrierName = carrierName;
         this.carrierCode = carrierCode;
@@ -88,25 +110,47 @@ public class ReturnRequest extends BaseIdAndUUIDAndTime {
         this.status = ReturnStatus.RETURN_SHIPPED;
     }
 
-    public void approve() {
+    /**
+     * 판매자 최종 승인 상태 전이
+     */
+    public void approveFinal() {
         this.status = ReturnStatus.RETURN_APPROVED;
         this.approvedAt = LocalDateTime.now();
     }
 
+    /**
+     * 반품 완료 상태 전이
+     */
     public void complete() {
         this.status = ReturnStatus.RETURN_COMPLETED;
     }
 
-    public void reject() {
-        this.status = ReturnStatus.RETURN_REJECTED;
+    /**
+     * 반품 발송 전 거절 상태 전이
+     */
+    public void rejectBeforeShipment(String rejectionReason) {
+        this.status = ReturnStatus.RETURN_REJECTED_BEFORE_SHIPMENT;
+        this.rejectionReason = rejectionReason;
     }
 
+    /**
+     * 반품 발송 후 거절 상태 전이
+     */
+    public void rejectAfterShipment(String rejectionReason) {
+        this.status = ReturnStatus.RETURN_REJECTED_AFTER_SHIPMENT;
+        this.rejectionReason = rejectionReason;
+    }
+
+    /**
+     * 반품 응답 DTO 변환
+     */
     public ReturnResponse toResponse() {
         return ReturnResponse.builder()
                 .returnRequestUuid(this.getUuid())
                 .orderUuid(this.order.getUuid())
                 .status(this.status)
                 .reason(this.reason)
+                .rejectionReason(this.rejectionReason)
                 .carrierName(this.carrierName)
                 .carrierCode(this.carrierCode)
                 .trackingNumber(this.trackingNumber)

--- a/order/src/main/java/dukku/order/boundedContext/order/in/OrderController.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/in/OrderController.java
@@ -4,6 +4,7 @@ import dukku.common.shared.order.dto.*;
 import dukku.common.shared.order.docs.OrderApiDocs;
 import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.order.boundedContext.order.app.OrderFacade;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -23,7 +24,7 @@ public class OrderController {
 
     @PostMapping
     @OrderApiDocs.CreateOrder
-    public ResponseEntity<OrderResponse> createOrder(@RequestBody OrderCreateRequest req) {
+    public ResponseEntity<OrderResponse> createOrder(@RequestBody @Valid OrderCreateRequest req) {
         OrderResponse response = orderFacade.createOrder(req);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/order/src/main/java/dukku/order/boundedContext/order/in/ReturnController.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/in/ReturnController.java
@@ -1,18 +1,30 @@
 package dukku.order.boundedContext.order.in;
 
+import dukku.common.global.UserUtil;
+import dukku.common.shared.order.dto.ReturnRejectDto;
 import dukku.common.shared.order.dto.ReturnRequestCreateDto;
 import dukku.common.shared.order.dto.ReturnResponse;
 import dukku.common.shared.order.dto.ReturnTrackingRegisterDto;
-import dukku.common.global.UserUtil;
 import dukku.order.boundedContext.order.app.ApproveReturnUseCase;
+import dukku.order.boundedContext.order.app.FinalRejectReturnUseCase;
 import dukku.order.boundedContext.order.app.RegisterReturnTrackingUseCase;
 import dukku.order.boundedContext.order.app.RequestReturnUseCase;
+import dukku.order.boundedContext.order.app.SellerApproveReturnUseCase;
+import dukku.order.boundedContext.order.app.SellerRejectReturnUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
 
+/**
+ * 반품 요청/처리 API 컨트롤러
+ */
 @RestController
 @RequestMapping("/api/v1/returns")
 @RequiredArgsConstructor
@@ -20,8 +32,14 @@ public class ReturnController {
 
     private final RequestReturnUseCase requestReturnUseCase;
     private final RegisterReturnTrackingUseCase registerReturnTrackingUseCase;
+    private final SellerApproveReturnUseCase sellerApproveReturnUseCase;
+    private final SellerRejectReturnUseCase sellerRejectReturnUseCase;
     private final ApproveReturnUseCase approveReturnUseCase;
+    private final FinalRejectReturnUseCase finalRejectReturnUseCase;
 
+    /**
+     * 구매자 반품 신청 처리 API
+     */
     @PostMapping("/orders/{orderUuid}")
     public ResponseEntity<ReturnResponse> requestReturn(
             @PathVariable UUID orderUuid,
@@ -31,6 +49,32 @@ public class ReturnController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 판매자 1차 승인 처리 API
+     */
+    @PostMapping("/{returnRequestUuid}/seller-approve")
+    public ResponseEntity<ReturnResponse> approveBySeller(
+            @PathVariable UUID returnRequestUuid) {
+        UUID sellerUuid = UserUtil.getUserId();
+        ReturnResponse response = sellerApproveReturnUseCase.execute(sellerUuid, returnRequestUuid);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 판매자 1차 거절 처리 API
+     */
+    @PostMapping("/{returnRequestUuid}/seller-reject")
+    public ResponseEntity<ReturnResponse> rejectBySeller(
+            @PathVariable UUID returnRequestUuid,
+            @RequestBody ReturnRejectDto requestDto) {
+        UUID sellerUuid = UserUtil.getUserId();
+        ReturnResponse response = sellerRejectReturnUseCase.execute(sellerUuid, returnRequestUuid, requestDto.getReason());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 구매자 반품 운송장 등록 API
+     */
     @PutMapping("/{returnRequestUuid}/tracking")
     public ResponseEntity<ReturnResponse> registerTrackingInfo(
             @PathVariable UUID returnRequestUuid,
@@ -40,11 +84,26 @@ public class ReturnController {
         return ResponseEntity.ok(response);
     }
 
-    @PostMapping("/{returnRequestUuid}/approve")
+    /**
+     * 판매자 최종 승인 처리 API
+     */
+    @PostMapping("/{returnRequestUuid}/final-approve")
     public ResponseEntity<ReturnResponse> approveReturn(
             @PathVariable UUID returnRequestUuid) {
         UUID sellerUuid = UserUtil.getUserId();
         ReturnResponse response = approveReturnUseCase.execute(sellerUuid, returnRequestUuid);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 판매자 최종 거절 처리 API
+     */
+    @PostMapping("/{returnRequestUuid}/final-reject")
+    public ResponseEntity<ReturnResponse> rejectFinalReturn(
+            @PathVariable UUID returnRequestUuid,
+            @RequestBody ReturnRejectDto requestDto) {
+        UUID sellerUuid = UserUtil.getUserId();
+        ReturnResponse response = finalRejectReturnUseCase.execute(sellerUuid, returnRequestUuid, requestDto.getReason());
         return ResponseEntity.ok(response);
     }
 }

--- a/order/src/test/java/dukku/order/boundedContext/order/app/ApproveReturnUseCaseIntegrationTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/ApproveReturnUseCaseIntegrationTest.java
@@ -68,7 +68,7 @@ class ApproveReturnUseCaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("반품 요청의 모든 상품 판매자가 요청자와 일치하면 승인되고 이벤트가 발행된다")
+    @DisplayName("최종 승인 시 모든 반품 아이템의 판매자가 본인이면 승인되고 이벤트가 발행된다")
     void approvesWhenSellerOwnsAllItems() {
         UUID sellerUuid = UUID.randomUUID();
         ReturnRequest returnRequest = createReturnRequest(sellerUuid, sellerUuid);
@@ -82,10 +82,14 @@ class ApproveReturnUseCaseIntegrationTest {
                 ArgumentCaptor.forClass(PartialRefundRequestedEvent.class);
         verify(eventPublisher).publish(eventCaptor.capture());
         assertThat(eventCaptor.getValue().returnRequestUuid()).isEqualTo(returnRequest.getUuid());
+
+        assertThat(approved.getReturnItems())
+                .extracting(item -> item.getOrderItem().getStatus())
+                .containsOnly(OrderItemStatus.REFUND_IN_PROGRESS);
     }
 
     @Test
-    @DisplayName("반품 요청에 타 판매자 상품이 포함되면 승인할 수 없다")
+    @DisplayName("최종 승인 시 타 판매자 아이템이 포함되어 있으면 승인할 수 없다")
     void deniesWhenOtherSellerItemExists() {
         UUID sellerUuid = UUID.randomUUID();
         ReturnRequest returnRequest = createReturnRequest(sellerUuid, UUID.randomUUID());
@@ -94,7 +98,7 @@ class ApproveReturnUseCaseIntegrationTest {
                 .isInstanceOf(ReturnApprovalAccessDeniedException.class);
 
         ReturnRequest denied = returnRequestRepository.findByUuid(returnRequest.getUuid()).orElseThrow();
-        assertThat(denied.getStatus()).isEqualTo(ReturnStatus.RETURN_REQUESTED);
+        assertThat(denied.getStatus()).isEqualTo(ReturnStatus.RETURN_SHIPPED);
         verify(eventPublisher, never()).publish(any());
     }
 
@@ -131,6 +135,9 @@ class ApproveReturnUseCaseIntegrationTest {
         Order savedOrder = orderRepository.save(order);
 
         ReturnRequest returnRequest = ReturnRequest.create(savedOrder, buyerUuid, "단순 변심");
+        returnRequest.approveBySeller();
+        returnRequest.updateTrackingInfo("cj", "04", "1234567890");
+
         List<OrderItem> savedItems = savedOrder.getOrderItems();
         returnRequest.addReturnItem(ReturnItem.create(savedItems.get(0), 10_000));
         returnRequest.addReturnItem(ReturnItem.create(savedItems.get(1), 20_000));

--- a/order/src/test/java/dukku/order/boundedContext/order/app/ApproveReturnUseCaseTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/ApproveReturnUseCaseTest.java
@@ -42,19 +42,16 @@ class ApproveReturnUseCaseTest {
     private ApproveReturnUseCase useCase;
 
     @Test
-    @DisplayName("반품 요청의 모든 아이템 판매자가 본인이면 승인되고 부분환불 이벤트가 발행된다")
+    @DisplayName("최종 승인 시 모든 반품 아이템의 판매자가 본인이면 승인되고 환불 이벤트가 발행된다")
     void approveWhenSellerOwnsAllItems() {
-        // given
         UUID sellerUuid = UUID.randomUUID();
         UUID buyerUuid = UUID.randomUUID();
         ReturnRequest returnRequest = createReturnRequest(buyerUuid, sellerUuid, sellerUuid);
 
         when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
 
-        // when
         useCase.execute(sellerUuid, returnRequest.getUuid());
 
-        // then
         assertThat(returnRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_APPROVED);
 
         ArgumentCaptor<PartialRefundRequestedEvent> eventCaptor =
@@ -65,12 +62,14 @@ class ApproveReturnUseCaseTest {
         assertThat(event.orderUuid()).isEqualTo(returnRequest.getOrder().getUuid());
         assertThat(event.userUuid()).isEqualTo(returnRequest.getUserUuid());
         assertThat(event.refundItems()).hasSize(2);
+        assertThat(returnRequest.getReturnItems())
+                .extracting(item -> item.getOrderItem().getStatus())
+                .containsOnly(OrderItemStatus.REFUND_IN_PROGRESS);
     }
 
     @Test
-    @DisplayName("반품 요청 아이템에 본인 소유가 아닌 상품이 있으면 승인할 수 없다")
+    @DisplayName("최종 승인 시 타 판매자 아이템이 포함되어 있으면 승인할 수 없다")
     void denyWhenSellerDoesNotOwnAllItems() {
-        // given
         UUID buyerUuid = UUID.randomUUID();
         UUID sellerUuid = UUID.randomUUID();
         UUID otherSellerUuid = UUID.randomUUID();
@@ -78,11 +77,10 @@ class ApproveReturnUseCaseTest {
 
         when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
 
-        // when/then
         assertThatThrownBy(() -> useCase.execute(sellerUuid, returnRequest.getUuid()))
                 .isInstanceOf(ReturnApprovalAccessDeniedException.class);
 
-        assertThat(returnRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_REQUESTED);
+        assertThat(returnRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_SHIPPED);
         verify(eventPublisher, never()).publish(any());
     }
 
@@ -124,7 +122,7 @@ class ApproveReturnUseCaseTest {
                 .order(order)
                 .userUuid(buyerUuid)
                 .reason("단순 변심")
-                .status(ReturnStatus.RETURN_REQUESTED)
+                .status(ReturnStatus.RETURN_SHIPPED)
                 .build();
 
         returnRequest.addReturnItem(ReturnItem.create(firstItem, 10_000));

--- a/order/src/test/java/dukku/order/boundedContext/order/app/FinalRejectReturnUseCaseTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/FinalRejectReturnUseCaseTest.java
@@ -1,0 +1,120 @@
+package dukku.order.boundedContext.order.app;
+
+import dukku.common.shared.order.exception.ReturnApprovalAccessDeniedException;
+import dukku.common.shared.order.exception.ReturnRequestNotFoundException;
+import dukku.common.shared.order.exception.ReturnRequestStatusInvalidException;
+import dukku.common.shared.order.type.OrderItemStatus;
+import dukku.common.shared.order.type.OrderStatus;
+import dukku.common.shared.order.type.ReturnStatus;
+import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.entity.OrderItem;
+import dukku.order.boundedContext.order.entity.ReturnItem;
+import dukku.order.boundedContext.order.entity.ReturnRequest;
+import dukku.order.boundedContext.order.out.ReturnRequestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FinalRejectReturnUseCaseTest {
+
+    @Mock
+    private ReturnRequestRepository returnRequestRepository;
+
+    @InjectMocks
+    private FinalRejectReturnUseCase useCase;
+
+    @Test
+    @DisplayName("반품 발송 이후 판매자 최종 거절 시 거절 상태로 변경되고 아이템은 배송완료로 복구된다")
+    void finalRejectSuccess() {
+        UUID sellerUuid = UUID.randomUUID();
+        ReturnRequest returnRequest = createReturnRequest(sellerUuid, ReturnStatus.RETURN_SHIPPED, OrderItemStatus.REFUND_REQUESTED);
+
+        when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
+
+        useCase.execute(sellerUuid, returnRequest.getUuid(), "회수 상품 상태 불량");
+
+        assertThat(returnRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_REJECTED_AFTER_SHIPMENT);
+        assertThat(returnRequest.getRejectionReason()).isEqualTo("회수 상품 상태 불량");
+        assertThat(returnRequest.getReturnItems().get(0).getOrderItem().getStatus()).isEqualTo(OrderItemStatus.DELIVERED);
+    }
+
+    @Test
+    @DisplayName("반품 요청이 없으면 판매자 최종 거절에 실패한다")
+    void failWhenReturnRequestNotFound() {
+        UUID returnRequestUuid = UUID.randomUUID();
+        when(returnRequestRepository.findByUuid(returnRequestUuid)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(UUID.randomUUID(), returnRequestUuid, "사유"))
+                .isInstanceOf(ReturnRequestNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("반품 발송 완료 상태가 아니면 판매자 최종 거절을 할 수 없다")
+    void failWhenStatusInvalid() {
+        UUID sellerUuid = UUID.randomUUID();
+        ReturnRequest returnRequest = createReturnRequest(sellerUuid, ReturnStatus.RETURN_REQUESTED, OrderItemStatus.REFUND_REQUESTED);
+
+        when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
+
+        assertThatThrownBy(() -> useCase.execute(sellerUuid, returnRequest.getUuid(), "사유"))
+                .isInstanceOf(ReturnRequestStatusInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("타 판매자 요청은 판매자 최종 거절을 처리할 수 없다")
+    void failWhenSellerOwnershipInvalid() {
+        UUID sellerUuid = UUID.randomUUID();
+        ReturnRequest returnRequest = createReturnRequest(UUID.randomUUID(), ReturnStatus.RETURN_SHIPPED, OrderItemStatus.REFUND_REQUESTED);
+
+        when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
+
+        assertThatThrownBy(() -> useCase.execute(sellerUuid, returnRequest.getUuid(), "사유"))
+                .isInstanceOf(ReturnApprovalAccessDeniedException.class);
+    }
+
+    private ReturnRequest createReturnRequest(UUID itemSellerUuid, ReturnStatus status, OrderItemStatus itemStatus) {
+        UUID buyerUuid = UUID.randomUUID();
+
+        Order order = Order.builder()
+                .uuid(UUID.randomUUID())
+                .userUuid(buyerUuid)
+                .totalAmount(10_000)
+                .address("서울")
+                .recipient("구매자")
+                .contactNumber("010-0000-0000")
+                .status(OrderStatus.PAID)
+                .build();
+
+        OrderItem orderItem = OrderItem.builder()
+                .uuid(UUID.randomUUID())
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(itemSellerUuid)
+                .productName("상품")
+                .productPrice(10_000)
+                .status(itemStatus)
+                .build();
+        order.addOrderItem(orderItem);
+
+        ReturnRequest returnRequest = ReturnRequest.builder()
+                .uuid(UUID.randomUUID())
+                .order(order)
+                .userUuid(buyerUuid)
+                .reason("사유")
+                .status(status)
+                .build();
+        returnRequest.addReturnItem(ReturnItem.create(orderItem, 10_000));
+
+        return returnRequest;
+    }
+}

--- a/order/src/test/java/dukku/order/boundedContext/order/app/RegisterReturnTrackingUseCaseTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/RegisterReturnTrackingUseCaseTest.java
@@ -1,0 +1,107 @@
+package dukku.order.boundedContext.order.app;
+
+import dukku.common.shared.order.dto.ReturnResponse;
+import dukku.common.shared.order.dto.ReturnTrackingRegisterDto;
+import dukku.common.shared.order.exception.ReturnRequestAccessDeniedException;
+import dukku.common.shared.order.exception.ReturnRequestNotFoundException;
+import dukku.common.shared.order.exception.ReturnRequestStatusInvalidException;
+import dukku.common.shared.order.type.ReturnStatus;
+import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.entity.ReturnRequest;
+import dukku.order.boundedContext.order.out.ReturnRequestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterReturnTrackingUseCaseTest {
+
+    @Mock
+    private ReturnRequestRepository returnRequestRepository;
+
+    @InjectMocks
+    private RegisterReturnTrackingUseCase useCase;
+
+    @Test
+    @DisplayName("판매자 1차 승인 상태에서 구매자가 운송장을 등록하면 반품 발송 상태로 전환된다")
+    void registerTrackingSuccess() {
+        UUID userUuid = UUID.randomUUID();
+        UUID returnRequestUuid = UUID.randomUUID();
+
+        ReturnRequest returnRequest = createReturnRequest(returnRequestUuid, userUuid, ReturnStatus.RETURN_SELLER_APPROVED);
+        when(returnRequestRepository.findByUuid(returnRequestUuid)).thenReturn(Optional.of(returnRequest));
+
+        ReturnResponse response = useCase.execute(userUuid, returnRequestUuid,
+                ReturnTrackingRegisterDto.builder()
+                        .carrierName("CJ대한통운")
+                        .carrierCode("04")
+                        .trackingNumber("1234567890")
+                        .build());
+
+        assertThat(response.getStatus()).isEqualTo(ReturnStatus.RETURN_SHIPPED);
+        assertThat(response.getTrackingNumber()).isEqualTo("1234567890");
+    }
+
+    @Test
+    @DisplayName("반품 요청이 없으면 운송장 등록에 실패한다")
+    void failWhenReturnRequestNotFound() {
+        UUID returnRequestUuid = UUID.randomUUID();
+        when(returnRequestRepository.findByUuid(returnRequestUuid)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(UUID.randomUUID(), returnRequestUuid,
+                ReturnTrackingRegisterDto.builder().carrierName("CJ").carrierCode("04").trackingNumber("1").build()))
+                .isInstanceOf(ReturnRequestNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("구매자 본인이 아니면 운송장 등록에 실패한다")
+    void failWhenUserMismatch() {
+        UUID ownerUuid = UUID.randomUUID();
+        UUID returnRequestUuid = UUID.randomUUID();
+
+        ReturnRequest returnRequest = createReturnRequest(returnRequestUuid, ownerUuid, ReturnStatus.RETURN_SELLER_APPROVED);
+        when(returnRequestRepository.findByUuid(returnRequestUuid)).thenReturn(Optional.of(returnRequest));
+
+        assertThatThrownBy(() -> useCase.execute(UUID.randomUUID(), returnRequestUuid,
+                ReturnTrackingRegisterDto.builder().carrierName("CJ").carrierCode("04").trackingNumber("1").build()))
+                .isInstanceOf(ReturnRequestAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("판매자 1차 승인이 아니면 운송장 등록에 실패한다")
+    void failWhenStatusInvalid() {
+        UUID userUuid = UUID.randomUUID();
+        UUID returnRequestUuid = UUID.randomUUID();
+
+        ReturnRequest returnRequest = createReturnRequest(returnRequestUuid, userUuid, ReturnStatus.RETURN_REQUESTED);
+        when(returnRequestRepository.findByUuid(returnRequestUuid)).thenReturn(Optional.of(returnRequest));
+
+        assertThatThrownBy(() -> useCase.execute(userUuid, returnRequestUuid,
+                ReturnTrackingRegisterDto.builder().carrierName("CJ").carrierCode("04").trackingNumber("1").build()))
+                .isInstanceOf(ReturnRequestStatusInvalidException.class);
+    }
+
+    private ReturnRequest createReturnRequest(UUID returnRequestUuid, UUID userUuid, ReturnStatus status) {
+        Order order = Order.builder()
+                .uuid(UUID.randomUUID())
+                .build();
+
+        return ReturnRequest.builder()
+                .uuid(returnRequestUuid)
+                .order(order)
+                .userUuid(userUuid)
+                .status(status)
+                .reason("사유")
+                .build();
+    }
+}

--- a/order/src/test/java/dukku/order/boundedContext/order/app/RequestReturnUseCaseTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/RequestReturnUseCaseTest.java
@@ -1,0 +1,164 @@
+package dukku.order.boundedContext.order.app;
+
+import dukku.common.shared.order.dto.ReturnRequestCreateDto;
+import dukku.common.shared.order.dto.ReturnResponse;
+import dukku.common.shared.order.exception.OrderAccessDeniedException;
+import dukku.common.shared.order.exception.OrderItemNotFoundException;
+import dukku.common.shared.order.exception.OrderNotFoundException;
+import dukku.common.shared.order.exception.ReturnItemSelectionRequiredException;
+import dukku.common.shared.order.type.OrderItemStatus;
+import dukku.common.shared.order.type.OrderStatus;
+import dukku.common.shared.order.type.ReturnStatus;
+import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.entity.OrderItem;
+import dukku.order.boundedContext.order.entity.ReturnRequest;
+import dukku.order.boundedContext.order.out.OrderRepository;
+import dukku.order.boundedContext.order.out.ReturnRequestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RequestReturnUseCaseTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private ReturnRequestRepository returnRequestRepository;
+
+    @InjectMocks
+    private RequestReturnUseCase useCase;
+
+    @Test
+    @DisplayName("반품 신청이 정상 접수되면 요청 상태가 생성되고 아이템은 환불요청 상태가 된다")
+    void requestReturnSuccess() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+
+        Order order = createOrder(orderUuid, userUuid);
+        UUID firstItemUuid = order.getOrderItems().get(0).getUuid();
+        UUID secondItemUuid = order.getOrderItems().get(1).getUuid();
+
+        ReturnRequestCreateDto dto = ReturnRequestCreateDto.builder()
+                .reason("상품 하자")
+                .orderItemUuids(List.of(firstItemUuid, secondItemUuid))
+                .build();
+
+        when(orderRepository.findByUuidWithItems(orderUuid)).thenReturn(Optional.of(order));
+        when(returnRequestRepository.save(any(ReturnRequest.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ReturnResponse response = useCase.execute(userUuid, orderUuid, dto);
+
+        assertThat(response.getStatus()).isEqualTo(ReturnStatus.RETURN_REQUESTED);
+        assertThat(response.getReturnItems()).hasSize(2);
+        assertThat(order.getOrderItems())
+                .extracting(OrderItem::getStatus)
+                .containsOnly(OrderItemStatus.REFUND_REQUESTED);
+        verify(returnRequestRepository).save(any(ReturnRequest.class));
+    }
+
+    @Test
+    @DisplayName("주문이 없으면 반품 신청에 실패한다")
+    void failWhenOrderNotFound() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+
+        when(orderRepository.findByUuidWithItems(orderUuid)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(userUuid, orderUuid,
+                ReturnRequestCreateDto.builder().reason("사유").orderItemUuids(List.of(UUID.randomUUID())).build()))
+                .isInstanceOf(OrderNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("구매자 본인 주문이 아니면 반품 신청에 실패한다")
+    void failWhenOrderOwnerMismatch() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderOwnerUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+
+        Order order = createOrder(orderUuid, orderOwnerUuid);
+        when(orderRepository.findByUuidWithItems(orderUuid)).thenReturn(Optional.of(order));
+
+        assertThatThrownBy(() -> useCase.execute(userUuid, orderUuid,
+                ReturnRequestCreateDto.builder().reason("사유").orderItemUuids(List.of(order.getOrderItems().get(0).getUuid())).build()))
+                .isInstanceOf(OrderAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("반품 아이템을 선택하지 않으면 반품 신청에 실패한다")
+    void failWhenReturnItemsEmpty() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+
+        Order order = createOrder(orderUuid, userUuid);
+        when(orderRepository.findByUuidWithItems(orderUuid)).thenReturn(Optional.of(order));
+
+        assertThatThrownBy(() -> useCase.execute(userUuid, orderUuid,
+                ReturnRequestCreateDto.builder().reason("사유").orderItemUuids(List.of()).build()))
+                .isInstanceOf(ReturnItemSelectionRequiredException.class);
+    }
+
+    @Test
+    @DisplayName("주문에 없는 아이템을 반품 신청하면 실패한다")
+    void failWhenOrderItemNotFound() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderUuid = UUID.randomUUID();
+
+        Order order = createOrder(orderUuid, userUuid);
+        when(orderRepository.findByUuidWithItems(orderUuid)).thenReturn(Optional.of(order));
+
+        assertThatThrownBy(() -> useCase.execute(userUuid, orderUuid,
+                ReturnRequestCreateDto.builder().reason("사유").orderItemUuids(List.of(UUID.randomUUID())).build()))
+                .isInstanceOf(OrderItemNotFoundException.class);
+    }
+
+    private Order createOrder(UUID orderUuid, UUID userUuid) {
+        Order order = Order.builder()
+                .uuid(orderUuid)
+                .userUuid(userUuid)
+                .totalAmount(30_000)
+                .address("서울")
+                .recipient("구매자")
+                .contactNumber("010-0000-0000")
+                .refundedAmount(0)
+                .status(OrderStatus.PAID)
+                .build();
+
+        OrderItem firstItem = OrderItem.builder()
+                .uuid(UUID.randomUUID())
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(UUID.randomUUID())
+                .productName("상품1")
+                .productPrice(10_000)
+                .status(OrderItemStatus.DELIVERED)
+                .build();
+
+        OrderItem secondItem = OrderItem.builder()
+                .uuid(UUID.randomUUID())
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(UUID.randomUUID())
+                .productName("상품2")
+                .productPrice(20_000)
+                .status(OrderItemStatus.DELIVERED)
+                .build();
+
+        order.addOrderItem(firstItem);
+        order.addOrderItem(secondItem);
+        return order;
+    }
+}

--- a/order/src/test/java/dukku/order/boundedContext/order/app/ReturnProcessIntegrationTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/ReturnProcessIntegrationTest.java
@@ -1,0 +1,358 @@
+package dukku.order.boundedContext.order.app;
+
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.order.dto.ReturnRequestCreateDto;
+import dukku.common.shared.order.dto.ReturnResponse;
+import dukku.common.shared.order.dto.ReturnTrackingRegisterDto;
+import dukku.common.shared.order.exception.ReturnApprovalAccessDeniedException;
+import dukku.common.shared.order.exception.ReturnRequestStatusInvalidException;
+import dukku.common.shared.order.type.OrderItemStatus;
+import dukku.common.shared.order.type.OrderStatus;
+import dukku.common.shared.order.type.ReturnStatus;
+import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.entity.OrderItem;
+import dukku.order.boundedContext.order.entity.ReturnRequest;
+import dukku.order.boundedContext.order.out.OrderRepository;
+import dukku.order.boundedContext.order.out.ReturnRequestRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.reset;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {
+        "spring.datasource.url=jdbc:h2:mem:return_process_it;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.properties.hibernate.hbm2ddl.auto=create-drop",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect",
+        "spring.kafka.listener.auto-startup=false",
+        "spring.kafka.bootstrap-servers=localhost:9092",
+        "spring.data.redis.host=localhost",
+        "spring.data.redis.port=6379",
+        "spring.elasticsearch.uris=http://localhost:9200",
+        "jwt.access.secret.key=dGhpcy1rZXktaXMtdGVzdC1rZXktYWNjZXNzLTAxMjM=",
+        "jwt.refresh.secret.key=dGhpcy1rZXktaXMtdGVzdC1rZXktcmVmcmVzaC0wMTI=",
+        "crypto.key=dGhpcy1rZXktaXMtdGVzdC1rZXktY3J5cHRvLTAxMjM="
+})
+@Transactional
+class ReturnProcessIntegrationTest {
+
+    @Autowired
+    private RequestReturnUseCase requestReturnUseCase;
+
+    @Autowired
+    private SellerApproveReturnUseCase sellerApproveReturnUseCase;
+
+    @Autowired
+    private SellerRejectReturnUseCase sellerRejectReturnUseCase;
+
+    @Autowired
+    private RegisterReturnTrackingUseCase registerReturnTrackingUseCase;
+
+    @Autowired
+    private ApproveReturnUseCase approveReturnUseCase;
+
+    @Autowired
+    private FinalRejectReturnUseCase finalRejectReturnUseCase;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private ReturnRequestRepository returnRequestRepository;
+
+    @MockitoBean
+    private EventPublisher eventPublisher;
+
+    @BeforeEach
+    void cleanUp() {
+        returnRequestRepository.deleteAll();
+        orderRepository.deleteAll();
+        reset(eventPublisher);
+    }
+
+    @Test
+    @DisplayName("반품 신청부터 최종 승인까지 전체 플로우가 순서대로 진행된다")
+    void fullFlowToFinalApprove() {
+        ReturnFixture fixture = createSingleSellerDeliveredOrderFixture();
+
+        ReturnResponse requested = requestReturnUseCase.execute(
+                fixture.buyerUuid(),
+                fixture.orderUuid(),
+                ReturnRequestCreateDto.builder()
+                        .reason("상품 하자")
+                        .orderItemUuids(List.of(fixture.firstItemUuid()))
+                        .build());
+        assertThat(requested.getStatus()).isEqualTo(ReturnStatus.RETURN_REQUESTED);
+
+        ReturnResponse sellerApproved = sellerApproveReturnUseCase.execute(fixture.firstSellerUuid(), requested.getReturnRequestUuid());
+        assertThat(sellerApproved.getStatus()).isEqualTo(ReturnStatus.RETURN_SELLER_APPROVED);
+
+        ReturnResponse shipped = registerReturnTrackingUseCase.execute(
+                fixture.buyerUuid(),
+                requested.getReturnRequestUuid(),
+                ReturnTrackingRegisterDto.builder()
+                        .carrierName("CJ대한통운")
+                        .carrierCode("04")
+                        .trackingNumber("1234567890")
+                        .build());
+        assertThat(shipped.getStatus()).isEqualTo(ReturnStatus.RETURN_SHIPPED);
+        assertThat(shipped.getTrackingNumber()).isEqualTo("1234567890");
+
+        ReturnResponse finalApproved = approveReturnUseCase.execute(fixture.firstSellerUuid(), requested.getReturnRequestUuid());
+        assertThat(finalApproved.getStatus()).isEqualTo(ReturnStatus.RETURN_APPROVED);
+
+        Order order = orderRepository.findByUuidWithItems(fixture.orderUuid()).orElseThrow();
+        assertThat(order.getOrderItems().get(0).getStatus()).isEqualTo(OrderItemStatus.REFUND_IN_PROGRESS);
+    }
+
+    @Test
+    @DisplayName("판매자가 반품 발송 전에 거절하면 반품 상태와 아이템 상태가 복구된다")
+    void sellerRejectBeforeShipment() {
+        ReturnFixture fixture = createSingleSellerDeliveredOrderFixture();
+
+        ReturnResponse requested = requestReturnUseCase.execute(
+                fixture.buyerUuid(),
+                fixture.orderUuid(),
+                ReturnRequestCreateDto.builder()
+                        .reason("단순 변심")
+                        .orderItemUuids(List.of(fixture.firstItemUuid()))
+                        .build());
+
+        ReturnResponse rejected = sellerRejectReturnUseCase.execute(
+                fixture.firstSellerUuid(),
+                requested.getReturnRequestUuid(),
+                "반품 사유 불충분");
+
+        assertThat(rejected.getStatus()).isEqualTo(ReturnStatus.RETURN_REJECTED_BEFORE_SHIPMENT);
+        assertThat(rejected.getRejectionReason()).isEqualTo("반품 사유 불충분");
+
+        Order order = orderRepository.findByUuidWithItems(fixture.orderUuid()).orElseThrow();
+        assertThat(order.getOrderItems().get(0).getStatus()).isEqualTo(OrderItemStatus.DELIVERED);
+    }
+
+    @Test
+    @DisplayName("판매자 1차 승인 이후에도 발송 전이면 판매자는 1차 거절할 수 있다")
+    void sellerRejectAfterSellerApproveBeforeShipment() {
+        ReturnFixture fixture = createSingleSellerDeliveredOrderFixture();
+
+        ReturnResponse requested = requestReturnUseCase.execute(
+                fixture.buyerUuid(),
+                fixture.orderUuid(),
+                ReturnRequestCreateDto.builder()
+                        .reason("사이즈 불만")
+                        .orderItemUuids(List.of(fixture.firstItemUuid()))
+                        .build());
+
+        sellerApproveReturnUseCase.execute(fixture.firstSellerUuid(), requested.getReturnRequestUuid());
+        ReturnResponse rejected = sellerRejectReturnUseCase.execute(
+                fixture.firstSellerUuid(),
+                requested.getReturnRequestUuid(),
+                "검수 결과 반품 불가");
+
+        assertThat(rejected.getStatus()).isEqualTo(ReturnStatus.RETURN_REJECTED_BEFORE_SHIPMENT);
+        assertThat(rejected.getRejectionReason()).isEqualTo("검수 결과 반품 불가");
+    }
+
+    @Test
+    @DisplayName("판매자가 최종 거절하면 발송 후 거절 상태로 전환되고 아이템은 배송완료로 복구된다")
+    void sellerFinalRejectAfterShipment() {
+        ReturnFixture fixture = createSingleSellerDeliveredOrderFixture();
+
+        ReturnResponse requested = requestReturnUseCase.execute(
+                fixture.buyerUuid(),
+                fixture.orderUuid(),
+                ReturnRequestCreateDto.builder()
+                        .reason("상품 하자")
+                        .orderItemUuids(List.of(fixture.firstItemUuid()))
+                        .build());
+
+        sellerApproveReturnUseCase.execute(fixture.firstSellerUuid(), requested.getReturnRequestUuid());
+        registerReturnTrackingUseCase.execute(
+                fixture.buyerUuid(),
+                requested.getReturnRequestUuid(),
+                ReturnTrackingRegisterDto.builder()
+                        .carrierName("CJ대한통운")
+                        .carrierCode("04")
+                        .trackingNumber("9999999999")
+                        .build());
+
+        ReturnResponse rejected = finalRejectReturnUseCase.execute(
+                fixture.firstSellerUuid(),
+                requested.getReturnRequestUuid(),
+                "회수 상품 상태 불량");
+
+        assertThat(rejected.getStatus()).isEqualTo(ReturnStatus.RETURN_REJECTED_AFTER_SHIPMENT);
+        assertThat(rejected.getRejectionReason()).isEqualTo("회수 상품 상태 불량");
+
+        Order order = orderRepository.findByUuidWithItems(fixture.orderUuid()).orElseThrow();
+        assertThat(order.getOrderItems().get(0).getStatus()).isEqualTo(OrderItemStatus.DELIVERED);
+    }
+
+    @Test
+    @DisplayName("판매자 1차 승인 전에는 구매자가 운송장을 등록할 수 없다")
+    void denyTrackingRegistrationBeforeSellerApprove() {
+        ReturnFixture fixture = createSingleSellerDeliveredOrderFixture();
+
+        ReturnResponse requested = requestReturnUseCase.execute(
+                fixture.buyerUuid(),
+                fixture.orderUuid(),
+                ReturnRequestCreateDto.builder()
+                        .reason("상품 하자")
+                        .orderItemUuids(List.of(fixture.firstItemUuid()))
+                        .build());
+
+        assertThatThrownBy(() -> registerReturnTrackingUseCase.execute(
+                fixture.buyerUuid(),
+                requested.getReturnRequestUuid(),
+                ReturnTrackingRegisterDto.builder()
+                        .carrierName("CJ대한통운")
+                        .carrierCode("04")
+                        .trackingNumber("1111111111")
+                        .build()))
+                .isInstanceOf(ReturnRequestStatusInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("타 판매자는 반품 승인이나 거절을 처리할 수 없다")
+    void denyOtherSellerApprovalOrRejection() {
+        ReturnFixture fixture = createSingleSellerDeliveredOrderFixture();
+
+        ReturnResponse requested = requestReturnUseCase.execute(
+                fixture.buyerUuid(),
+                fixture.orderUuid(),
+                ReturnRequestCreateDto.builder()
+                        .reason("상품 하자")
+                        .orderItemUuids(List.of(fixture.firstItemUuid()))
+                        .build());
+
+        UUID otherSellerUuid = UUID.randomUUID();
+        assertThatThrownBy(() -> sellerApproveReturnUseCase.execute(otherSellerUuid, requested.getReturnRequestUuid()))
+                .isInstanceOf(ReturnApprovalAccessDeniedException.class);
+
+        assertThatThrownBy(() -> sellerRejectReturnUseCase.execute(otherSellerUuid, requested.getReturnRequestUuid(), "권한 없음"))
+                .isInstanceOf(ReturnApprovalAccessDeniedException.class);
+    }
+
+    @Test
+    @DisplayName("서로 다른 판매자 아이템을 한 번에 반품 신청하면 단일 판매자는 승인할 수 없다")
+    void denySellerApproveWhenRequestContainsOtherSellerItems() {
+        ReturnFixture fixture = createMultiSellerDeliveredOrderFixture();
+
+        ReturnResponse requested = requestReturnUseCase.execute(
+                fixture.buyerUuid(),
+                fixture.orderUuid(),
+                ReturnRequestCreateDto.builder()
+                        .reason("복수 상품 반품")
+                        .orderItemUuids(List.of(fixture.firstItemUuid(), fixture.secondItemUuid()))
+                        .build());
+
+        assertThatThrownBy(() -> sellerApproveReturnUseCase.execute(fixture.firstSellerUuid(), requested.getReturnRequestUuid()))
+                .isInstanceOf(ReturnApprovalAccessDeniedException.class);
+
+        ReturnRequest found = returnRequestRepository.findByUuid(requested.getReturnRequestUuid()).orElseThrow();
+        assertThat(found.getStatus()).isEqualTo(ReturnStatus.RETURN_REQUESTED);
+    }
+
+    private ReturnFixture createSingleSellerDeliveredOrderFixture() {
+        UUID buyerUuid = UUID.randomUUID();
+        UUID sellerUuid = UUID.randomUUID();
+
+        Order order = Order.builder()
+                .userUuid(buyerUuid)
+                .totalAmount(15_000)
+                .address("서울")
+                .recipient("구매자")
+                .contactNumber("010-1111-2222")
+                .refundedAmount(0)
+                .status(OrderStatus.PAID)
+                .build();
+
+        OrderItem item = OrderItem.builder()
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(sellerUuid)
+                .productName("테스트 상품")
+                .productPrice(15_000)
+                .imageUrl("https://example.com/item.png")
+                .status(OrderItemStatus.DELIVERED)
+                .build();
+
+        order.addOrderItem(item);
+        Order savedOrder = orderRepository.save(order);
+
+        return new ReturnFixture(
+                buyerUuid,
+                sellerUuid,
+                null,
+                savedOrder.getUuid(),
+                savedOrder.getOrderItems().get(0).getUuid(),
+                null
+        );
+    }
+
+    private ReturnFixture createMultiSellerDeliveredOrderFixture() {
+        UUID buyerUuid = UUID.randomUUID();
+        UUID firstSellerUuid = UUID.randomUUID();
+        UUID secondSellerUuid = UUID.randomUUID();
+
+        Order order = Order.builder()
+                .userUuid(buyerUuid)
+                .totalAmount(30_000)
+                .address("서울")
+                .recipient("구매자")
+                .contactNumber("010-3333-4444")
+                .refundedAmount(0)
+                .status(OrderStatus.PAID)
+                .build();
+
+        OrderItem firstItem = OrderItem.builder()
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(firstSellerUuid)
+                .productName("첫 번째 상품")
+                .productPrice(10_000)
+                .status(OrderItemStatus.DELIVERED)
+                .build();
+
+        OrderItem secondItem = OrderItem.builder()
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(secondSellerUuid)
+                .productName("두 번째 상품")
+                .productPrice(20_000)
+                .status(OrderItemStatus.DELIVERED)
+                .build();
+
+        order.addOrderItem(firstItem);
+        order.addOrderItem(secondItem);
+        Order savedOrder = orderRepository.save(order);
+
+        return new ReturnFixture(
+                buyerUuid,
+                firstSellerUuid,
+                secondSellerUuid,
+                savedOrder.getUuid(),
+                savedOrder.getOrderItems().get(0).getUuid(),
+                savedOrder.getOrderItems().get(1).getUuid()
+        );
+    }
+
+    private record ReturnFixture(
+            UUID buyerUuid,
+            UUID firstSellerUuid,
+            UUID secondSellerUuid,
+            UUID orderUuid,
+            UUID firstItemUuid,
+            UUID secondItemUuid
+    ) {
+    }
+}

--- a/order/src/test/java/dukku/order/boundedContext/order/app/ReturnRefundFlowIntegrationTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/ReturnRefundFlowIntegrationTest.java
@@ -3,6 +3,7 @@ package dukku.order.boundedContext.order.app;
 import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.order.dto.ReturnRequestCreateDto;
 import dukku.common.shared.order.dto.ReturnResponse;
+import dukku.common.shared.order.dto.ReturnTrackingRegisterDto;
 import dukku.common.shared.order.event.PartialRefundRequestedEvent;
 import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.common.shared.order.type.OrderStatus;
@@ -57,6 +58,12 @@ class ReturnRefundFlowIntegrationTest {
     private RequestReturnUseCase requestReturnUseCase;
 
     @Autowired
+    private SellerApproveReturnUseCase sellerApproveReturnUseCase;
+
+    @Autowired
+    private RegisterReturnTrackingUseCase registerReturnTrackingUseCase;
+
+    @Autowired
     private ApproveReturnUseCase approveReturnUseCase;
 
     @Autowired
@@ -83,7 +90,7 @@ class ReturnRefundFlowIntegrationTest {
     }
 
     @Test
-    @DisplayName("Return request -> approve -> refund completed updates order item and ignores duplicated retry event")
+    @DisplayName("반품 플로우 완료 후 중복 환불 완료 이벤트는 무시된다")
     void completesReturnFlowAndIgnoresDuplicateRefundEvent() {
         ReturnFlowFixture fixture = createDeliveredOrderFixture();
 
@@ -91,10 +98,23 @@ class ReturnRefundFlowIntegrationTest {
                 fixture.buyerUuid(),
                 fixture.orderUuid(),
                 ReturnRequestCreateDto.builder()
-                        .reason("buyer change of mind")
+                        .reason("단순 변심")
                         .orderItemUuids(List.of(fixture.orderItemUuid()))
                         .build());
         assertThat(requested.getStatus()).isEqualTo(ReturnStatus.RETURN_REQUESTED);
+
+        ReturnResponse sellerApproved = sellerApproveReturnUseCase.execute(fixture.sellerUuid(), requested.getReturnRequestUuid());
+        assertThat(sellerApproved.getStatus()).isEqualTo(ReturnStatus.RETURN_SELLER_APPROVED);
+
+        ReturnResponse shipped = registerReturnTrackingUseCase.execute(
+                fixture.buyerUuid(),
+                requested.getReturnRequestUuid(),
+                ReturnTrackingRegisterDto.builder()
+                        .carrierName("CJ")
+                        .carrierCode("04")
+                        .trackingNumber("1234567890")
+                        .build());
+        assertThat(shipped.getStatus()).isEqualTo(ReturnStatus.RETURN_SHIPPED);
 
         Order requestedOrder = orderRepository.findByUuidWithItems(fixture.orderUuid()).orElseThrow();
         assertThat(requestedOrder.getOrderItems()).hasSize(1);
@@ -102,6 +122,9 @@ class ReturnRefundFlowIntegrationTest {
 
         ReturnResponse approved = approveReturnUseCase.execute(fixture.sellerUuid(), requested.getReturnRequestUuid());
         assertThat(approved.getStatus()).isEqualTo(ReturnStatus.RETURN_APPROVED);
+
+        Order inProgressOrder = orderRepository.findByUuidWithItems(fixture.orderUuid()).orElseThrow();
+        assertThat(inProgressOrder.getOrderItems().get(0).getStatus()).isEqualTo(OrderItemStatus.REFUND_IN_PROGRESS);
 
         ArgumentCaptor<PartialRefundRequestedEvent> eventCaptor =
                 ArgumentCaptor.forClass(PartialRefundRequestedEvent.class);
@@ -141,7 +164,7 @@ class ReturnRefundFlowIntegrationTest {
     }
 
     @Test
-    @DisplayName("Refund failed event reverts approved return back to rejected and order item to delivered")
+    @DisplayName("환불 실패 이벤트 수신 시 최종 승인된 반품은 발송 후 거절 상태로 전환된다")
     void revertsApprovedReturnWhenRefundFails() {
         ReturnFlowFixture fixture = createDeliveredOrderFixture();
 
@@ -151,6 +174,16 @@ class ReturnRefundFlowIntegrationTest {
                 ReturnRequestCreateDto.builder()
                         .reason("defect")
                         .orderItemUuids(List.of(fixture.orderItemUuid()))
+                        .build());
+
+        sellerApproveReturnUseCase.execute(fixture.sellerUuid(), requested.getReturnRequestUuid());
+        registerReturnTrackingUseCase.execute(
+                fixture.buyerUuid(),
+                requested.getReturnRequestUuid(),
+                ReturnTrackingRegisterDto.builder()
+                        .carrierName("CJ")
+                        .carrierCode("04")
+                        .trackingNumber("1234567890")
                         .build());
 
         ReturnResponse approved = approveReturnUseCase.execute(fixture.sellerUuid(), requested.getReturnRequestUuid());
@@ -175,7 +208,7 @@ class ReturnRefundFlowIntegrationTest {
         assertThat(restoredOrder.getOrderItems().get(0).getStatus()).isEqualTo(OrderItemStatus.DELIVERED);
 
         ReturnRequest rejectedRequest = returnRequestRepository.findByUuid(approved.getReturnRequestUuid()).orElseThrow();
-        assertThat(rejectedRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_REJECTED);
+        assertThat(rejectedRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_REJECTED_AFTER_SHIPMENT);
     }
 
     private ReturnFlowFixture createDeliveredOrderFixture() {

--- a/order/src/test/java/dukku/order/boundedContext/order/app/SellerApproveReturnUseCaseTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/SellerApproveReturnUseCaseTest.java
@@ -1,0 +1,119 @@
+package dukku.order.boundedContext.order.app;
+
+import dukku.common.shared.order.exception.ReturnApprovalAccessDeniedException;
+import dukku.common.shared.order.exception.ReturnRequestNotFoundException;
+import dukku.common.shared.order.exception.ReturnRequestStatusInvalidException;
+import dukku.common.shared.order.type.OrderItemStatus;
+import dukku.common.shared.order.type.OrderStatus;
+import dukku.common.shared.order.type.ReturnStatus;
+import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.entity.OrderItem;
+import dukku.order.boundedContext.order.entity.ReturnItem;
+import dukku.order.boundedContext.order.entity.ReturnRequest;
+import dukku.order.boundedContext.order.out.ReturnRequestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SellerApproveReturnUseCaseTest {
+
+    @Mock
+    private ReturnRequestRepository returnRequestRepository;
+
+    @InjectMocks
+    private SellerApproveReturnUseCase useCase;
+
+    @Test
+    @DisplayName("반품 신청 상태에서 판매자가 1차 승인하면 상태가 변경된다")
+    void approveBySellerSuccess() {
+        UUID sellerUuid = UUID.randomUUID();
+        ReturnRequest returnRequest = createReturnRequest(sellerUuid, ReturnStatus.RETURN_REQUESTED);
+
+        when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
+
+        useCase.execute(sellerUuid, returnRequest.getUuid());
+
+        assertThat(returnRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_SELLER_APPROVED);
+    }
+
+    @Test
+    @DisplayName("반품 요청이 없으면 판매자 1차 승인에 실패한다")
+    void failWhenReturnRequestNotFound() {
+        UUID returnRequestUuid = UUID.randomUUID();
+        when(returnRequestRepository.findByUuid(returnRequestUuid)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(UUID.randomUUID(), returnRequestUuid))
+                .isInstanceOf(ReturnRequestNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("반품 신청 상태가 아니면 판매자 1차 승인에 실패한다")
+    void failWhenStatusInvalid() {
+        UUID sellerUuid = UUID.randomUUID();
+        ReturnRequest returnRequest = createReturnRequest(sellerUuid, ReturnStatus.RETURN_SHIPPED);
+
+        when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
+
+        assertThatThrownBy(() -> useCase.execute(sellerUuid, returnRequest.getUuid()))
+                .isInstanceOf(ReturnRequestStatusInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("타 판매자 요청은 판매자 1차 승인할 수 없다")
+    void failWhenSellerOwnershipInvalid() {
+        UUID sellerUuid = UUID.randomUUID();
+        UUID otherSellerUuid = UUID.randomUUID();
+        ReturnRequest returnRequest = createReturnRequest(otherSellerUuid, ReturnStatus.RETURN_REQUESTED);
+
+        when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
+
+        assertThatThrownBy(() -> useCase.execute(sellerUuid, returnRequest.getUuid()))
+                .isInstanceOf(ReturnApprovalAccessDeniedException.class);
+    }
+
+    private ReturnRequest createReturnRequest(UUID itemSellerUuid, ReturnStatus status) {
+        UUID buyerUuid = UUID.randomUUID();
+
+        Order order = Order.builder()
+                .uuid(UUID.randomUUID())
+                .userUuid(buyerUuid)
+                .totalAmount(10_000)
+                .address("서울")
+                .recipient("구매자")
+                .contactNumber("010-0000-0000")
+                .status(OrderStatus.PAID)
+                .build();
+
+        OrderItem orderItem = OrderItem.builder()
+                .uuid(UUID.randomUUID())
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(itemSellerUuid)
+                .productName("상품")
+                .productPrice(10_000)
+                .status(OrderItemStatus.REFUND_REQUESTED)
+                .build();
+        order.addOrderItem(orderItem);
+
+        ReturnRequest returnRequest = ReturnRequest.builder()
+                .uuid(UUID.randomUUID())
+                .order(order)
+                .userUuid(buyerUuid)
+                .reason("사유")
+                .status(status)
+                .build();
+        returnRequest.addReturnItem(ReturnItem.create(orderItem, 10_000));
+
+        return returnRequest;
+    }
+}

--- a/order/src/test/java/dukku/order/boundedContext/order/app/SellerRejectReturnUseCaseTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/SellerRejectReturnUseCaseTest.java
@@ -1,0 +1,133 @@
+package dukku.order.boundedContext.order.app;
+
+import dukku.common.shared.order.exception.ReturnApprovalAccessDeniedException;
+import dukku.common.shared.order.exception.ReturnRequestNotFoundException;
+import dukku.common.shared.order.exception.ReturnRequestStatusInvalidException;
+import dukku.common.shared.order.type.OrderItemStatus;
+import dukku.common.shared.order.type.OrderStatus;
+import dukku.common.shared.order.type.ReturnStatus;
+import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.entity.OrderItem;
+import dukku.order.boundedContext.order.entity.ReturnItem;
+import dukku.order.boundedContext.order.entity.ReturnRequest;
+import dukku.order.boundedContext.order.out.ReturnRequestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SellerRejectReturnUseCaseTest {
+
+    @Mock
+    private ReturnRequestRepository returnRequestRepository;
+
+    @InjectMocks
+    private SellerRejectReturnUseCase useCase;
+
+    @Test
+    @DisplayName("반품 발송 전 판매자 거절 시 거절 상태로 변경되고 아이템은 배송완료로 복구된다")
+    void rejectBeforeShipmentSuccess() {
+        UUID sellerUuid = UUID.randomUUID();
+        ReturnRequest returnRequest = createReturnRequest(sellerUuid, ReturnStatus.RETURN_REQUESTED, OrderItemStatus.REFUND_REQUESTED);
+
+        when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
+
+        useCase.execute(sellerUuid, returnRequest.getUuid(), "사유 불충분");
+
+        assertThat(returnRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_REJECTED_BEFORE_SHIPMENT);
+        assertThat(returnRequest.getRejectionReason()).isEqualTo("사유 불충분");
+        assertThat(returnRequest.getReturnItems().get(0).getOrderItem().getStatus()).isEqualTo(OrderItemStatus.DELIVERED);
+    }
+
+    @Test
+    @DisplayName("판매자 1차 승인 상태에서도 발송 전 거절이 가능하다")
+    void rejectFromSellerApprovedSuccess() {
+        UUID sellerUuid = UUID.randomUUID();
+        ReturnRequest returnRequest = createReturnRequest(sellerUuid, ReturnStatus.RETURN_SELLER_APPROVED, OrderItemStatus.REFUND_REQUESTED);
+
+        when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
+
+        useCase.execute(sellerUuid, returnRequest.getUuid(), "검수 결과 반품 불가");
+
+        assertThat(returnRequest.getStatus()).isEqualTo(ReturnStatus.RETURN_REJECTED_BEFORE_SHIPMENT);
+    }
+
+    @Test
+    @DisplayName("반품 요청이 없으면 판매자 거절에 실패한다")
+    void failWhenReturnRequestNotFound() {
+        UUID returnRequestUuid = UUID.randomUUID();
+        when(returnRequestRepository.findByUuid(returnRequestUuid)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(UUID.randomUUID(), returnRequestUuid, "사유"))
+                .isInstanceOf(ReturnRequestNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("반품 발송 이후 상태에서는 판매자 1차 거절을 할 수 없다")
+    void failWhenStatusInvalid() {
+        UUID sellerUuid = UUID.randomUUID();
+        ReturnRequest returnRequest = createReturnRequest(sellerUuid, ReturnStatus.RETURN_SHIPPED, OrderItemStatus.REFUND_REQUESTED);
+
+        when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
+
+        assertThatThrownBy(() -> useCase.execute(sellerUuid, returnRequest.getUuid(), "사유"))
+                .isInstanceOf(ReturnRequestStatusInvalidException.class);
+    }
+
+    @Test
+    @DisplayName("타 판매자 요청은 판매자 거절을 처리할 수 없다")
+    void failWhenSellerOwnershipInvalid() {
+        UUID sellerUuid = UUID.randomUUID();
+        ReturnRequest returnRequest = createReturnRequest(UUID.randomUUID(), ReturnStatus.RETURN_REQUESTED, OrderItemStatus.REFUND_REQUESTED);
+
+        when(returnRequestRepository.findByUuid(returnRequest.getUuid())).thenReturn(Optional.of(returnRequest));
+
+        assertThatThrownBy(() -> useCase.execute(sellerUuid, returnRequest.getUuid(), "사유"))
+                .isInstanceOf(ReturnApprovalAccessDeniedException.class);
+    }
+
+    private ReturnRequest createReturnRequest(UUID itemSellerUuid, ReturnStatus status, OrderItemStatus itemStatus) {
+        UUID buyerUuid = UUID.randomUUID();
+
+        Order order = Order.builder()
+                .uuid(UUID.randomUUID())
+                .userUuid(buyerUuid)
+                .totalAmount(10_000)
+                .address("서울")
+                .recipient("구매자")
+                .contactNumber("010-0000-0000")
+                .status(OrderStatus.PAID)
+                .build();
+
+        OrderItem orderItem = OrderItem.builder()
+                .uuid(UUID.randomUUID())
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(itemSellerUuid)
+                .productName("상품")
+                .productPrice(10_000)
+                .status(itemStatus)
+                .build();
+        order.addOrderItem(orderItem);
+
+        ReturnRequest returnRequest = ReturnRequest.builder()
+                .uuid(UUID.randomUUID())
+                .order(order)
+                .userUuid(buyerUuid)
+                .reason("사유")
+                .status(status)
+                .build();
+        returnRequest.addReturnItem(ReturnItem.create(orderItem, 10_000));
+
+        return returnRequest;
+    }
+}

--- a/order/src/test/java/dukku/order/boundedContext/order/in/OrderControllerWebMvcTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/in/OrderControllerWebMvcTest.java
@@ -1,0 +1,70 @@
+package dukku.order.boundedContext.order.in;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dukku.common.global.handler.GlobalExceptionHandler;
+import dukku.order.boundedContext.order.app.OrderFacade;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class OrderControllerWebMvcTest {
+
+    @Mock
+    private OrderFacade orderFacade;
+
+    @InjectMocks
+    private OrderController orderController;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(orderController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("주문 생성 시 sellerUuid 누락이면 400을 반환하고 유스케이스를 호출하지 않는다")
+    void createOrder_withoutSellerUuid_returnsBadRequest() throws Exception {
+        String payload = """
+                {
+                  "address": "서울 강북구 4.19로12길 8 1",
+                  "recipient": "테스터",
+                  "contactNumber": "010-1234-5678",
+                  "items": [
+                    {
+                      "productUuid": "%s",
+                      "productName": "맥북 프로 14인치 M3 Pro 18GB",
+                      "productPrice": 2800000,
+                      "imageUrl": "https://images.unsplash.com/photo-1517336714731-489689fd1ca8"
+                    }
+                  ]
+                }
+                """.formatted(UUID.randomUUID());
+
+        mockMvc.perform(post("/api/v1/orders")
+                        .contentType("application/json")
+                        .content(payload))
+                .andExpect(status().isBadRequest());
+
+        verify(orderFacade, never()).createOrder(any());
+    }
+}

--- a/order/src/test/java/dukku/order/boundedContext/order/in/ReturnControllerWebMvcTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/in/ReturnControllerWebMvcTest.java
@@ -1,0 +1,202 @@
+package dukku.order.boundedContext.order.in;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dukku.common.global.auth.detail.CustomUserDetails;
+import dukku.common.shared.order.dto.ReturnRejectDto;
+import dukku.common.shared.order.dto.ReturnRequestCreateDto;
+import dukku.common.shared.order.dto.ReturnResponse;
+import dukku.common.shared.order.dto.ReturnTrackingRegisterDto;
+import dukku.common.shared.order.type.ReturnStatus;
+import dukku.order.boundedContext.order.app.ApproveReturnUseCase;
+import dukku.order.boundedContext.order.app.FinalRejectReturnUseCase;
+import dukku.order.boundedContext.order.app.RegisterReturnTrackingUseCase;
+import dukku.order.boundedContext.order.app.RequestReturnUseCase;
+import dukku.order.boundedContext.order.app.SellerApproveReturnUseCase;
+import dukku.order.boundedContext.order.app.SellerRejectReturnUseCase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class ReturnControllerWebMvcTest {
+
+    @Mock
+    private RequestReturnUseCase requestReturnUseCase;
+
+    @Mock
+    private RegisterReturnTrackingUseCase registerReturnTrackingUseCase;
+
+    @Mock
+    private SellerApproveReturnUseCase sellerApproveReturnUseCase;
+
+    @Mock
+    private SellerRejectReturnUseCase sellerRejectReturnUseCase;
+
+    @Mock
+    private ApproveReturnUseCase approveReturnUseCase;
+
+    @Mock
+    private FinalRejectReturnUseCase finalRejectReturnUseCase;
+
+    @InjectMocks
+    private ReturnController returnController;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+    private UUID userUuid;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(returnController).build();
+
+        userUuid = UUID.randomUUID();
+        CustomUserDetails userDetails = new CustomUserDetails(userUuid, "USER");
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @AfterEach
+    void clearAuthentication() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("반품 신청 API는 구매자 UUID와 요청 바디를 유스케이스로 전달한다")
+    void requestReturnApi() throws Exception {
+        UUID orderUuid = UUID.randomUUID();
+        UUID returnRequestUuid = UUID.randomUUID();
+
+        when(requestReturnUseCase.execute(eq(userUuid), eq(orderUuid), any(ReturnRequestCreateDto.class)))
+                .thenReturn(response(returnRequestUuid, orderUuid, ReturnStatus.RETURN_REQUESTED));
+
+        mockMvc.perform(post("/api/v1/returns/orders/{orderUuid}", orderUuid)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(ReturnRequestCreateDto.builder()
+                                .reason("상품 하자")
+                                .orderItemUuids(List.of(UUID.randomUUID()))
+                                .build())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.returnRequestUuid").value(returnRequestUuid.toString()))
+                .andExpect(jsonPath("$.status").value(ReturnStatus.RETURN_REQUESTED.name()));
+
+        verify(requestReturnUseCase).execute(eq(userUuid), eq(orderUuid), any(ReturnRequestCreateDto.class));
+    }
+
+    @Test
+    @DisplayName("판매자 1차 승인 API는 판매자 UUID를 유스케이스로 전달한다")
+    void sellerApproveApi() throws Exception {
+        UUID returnRequestUuid = UUID.randomUUID();
+
+        when(sellerApproveReturnUseCase.execute(eq(userUuid), eq(returnRequestUuid)))
+                .thenReturn(response(returnRequestUuid, UUID.randomUUID(), ReturnStatus.RETURN_SELLER_APPROVED));
+
+        mockMvc.perform(post("/api/v1/returns/{returnRequestUuid}/seller-approve", returnRequestUuid))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(ReturnStatus.RETURN_SELLER_APPROVED.name()));
+
+        verify(sellerApproveReturnUseCase).execute(eq(userUuid), eq(returnRequestUuid));
+    }
+
+    @Test
+    @DisplayName("판매자 1차 거절 API는 거절 사유를 포함해 유스케이스로 전달한다")
+    void sellerRejectApi() throws Exception {
+        UUID returnRequestUuid = UUID.randomUUID();
+        String rejectReason = "사유 불충분";
+
+        when(sellerRejectReturnUseCase.execute(eq(userUuid), eq(returnRequestUuid), eq(rejectReason)))
+                .thenReturn(response(returnRequestUuid, UUID.randomUUID(), ReturnStatus.RETURN_REJECTED_BEFORE_SHIPMENT));
+
+        mockMvc.perform(post("/api/v1/returns/{returnRequestUuid}/seller-reject", returnRequestUuid)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(ReturnRejectDto.builder().reason(rejectReason).build())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(ReturnStatus.RETURN_REJECTED_BEFORE_SHIPMENT.name()));
+
+        verify(sellerRejectReturnUseCase).execute(eq(userUuid), eq(returnRequestUuid), eq(rejectReason));
+    }
+
+    @Test
+    @DisplayName("운송장 등록 API는 구매자 UUID와 운송장 정보를 유스케이스로 전달한다")
+    void registerTrackingApi() throws Exception {
+        UUID returnRequestUuid = UUID.randomUUID();
+
+        when(registerReturnTrackingUseCase.execute(eq(userUuid), eq(returnRequestUuid), any(ReturnTrackingRegisterDto.class)))
+                .thenReturn(response(returnRequestUuid, UUID.randomUUID(), ReturnStatus.RETURN_SHIPPED));
+
+        mockMvc.perform(put("/api/v1/returns/{returnRequestUuid}/tracking", returnRequestUuid)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(ReturnTrackingRegisterDto.builder()
+                                .carrierName("CJ대한통운")
+                                .carrierCode("04")
+                                .trackingNumber("1234567890")
+                                .build())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(ReturnStatus.RETURN_SHIPPED.name()));
+
+        verify(registerReturnTrackingUseCase).execute(eq(userUuid), eq(returnRequestUuid), any(ReturnTrackingRegisterDto.class));
+    }
+
+    @Test
+    @DisplayName("최종 승인 API는 판매자 UUID를 유스케이스로 전달한다")
+    void finalApproveApi() throws Exception {
+        UUID returnRequestUuid = UUID.randomUUID();
+
+        when(approveReturnUseCase.execute(eq(userUuid), eq(returnRequestUuid)))
+                .thenReturn(response(returnRequestUuid, UUID.randomUUID(), ReturnStatus.RETURN_APPROVED));
+
+        mockMvc.perform(post("/api/v1/returns/{returnRequestUuid}/final-approve", returnRequestUuid))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(ReturnStatus.RETURN_APPROVED.name()));
+
+        verify(approveReturnUseCase).execute(eq(userUuid), eq(returnRequestUuid));
+    }
+
+    @Test
+    @DisplayName("최종 거절 API는 거절 사유를 포함해 유스케이스로 전달한다")
+    void finalRejectApi() throws Exception {
+        UUID returnRequestUuid = UUID.randomUUID();
+        String rejectReason = "회수 상품 상태 불량";
+
+        when(finalRejectReturnUseCase.execute(eq(userUuid), eq(returnRequestUuid), eq(rejectReason)))
+                .thenReturn(response(returnRequestUuid, UUID.randomUUID(), ReturnStatus.RETURN_REJECTED_AFTER_SHIPMENT));
+
+        mockMvc.perform(post("/api/v1/returns/{returnRequestUuid}/final-reject", returnRequestUuid)
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(ReturnRejectDto.builder().reason(rejectReason).build())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(ReturnStatus.RETURN_REJECTED_AFTER_SHIPMENT.name()));
+
+        verify(finalRejectReturnUseCase).execute(eq(userUuid), eq(returnRequestUuid), eq(rejectReason));
+    }
+
+    private ReturnResponse response(UUID returnRequestUuid, UUID orderUuid, ReturnStatus status) {
+        return ReturnResponse.builder()
+                .returnRequestUuid(returnRequestUuid)
+                .orderUuid(orderUuid)
+                .status(status)
+                .build();
+    }
+}

--- a/product/src/main/java/dukku/product/boundedContext/product/app/support/ProductMapper.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/support/ProductMapper.java
@@ -32,6 +32,7 @@ public class ProductMapper {
 
         return ProductDetailResponse.builder()
                 .productUuid(p.getUuid())
+                .sellerUuid(p.getSellerUuid())
                 .title(p.getTitle())
                 .description(p.getDescription())
                 .price(p.getPrice())


### PR DESCRIPTION
## PR 제목

[Order] 반품 승인 및 반품 거절 단계 추가 #234

---

## 개요

반품 신청 -> 판매자 반품 승인 -> 반품 과정으로 확장은 반영되었으나 추가 단계가 필요
- 지금 구조대로면 구매자가 반품을 보내면 판매자가 무조건 반품을 받아줘야 하고, 판매자가 반품을 취소할 수 없으며, 반송이나 일부환불과 관계된 기능도 준비되어 있지 않음
- 없어도 MVP로 동작은 가능하지만 만들어놓고 나중에 새 단계를 끼워넣는거보다 단계의 뼈대를 만들어넣고 기능을 덧붙이는게 구조수정의 영향이 적을 것으로 생각됨
- 추가적인 중간 단계 구현 (해당 단계 내에서 입력하는 세부 정보 같은 비즈니스 로직은 추후 보완하고, 일단 각 단계를 위한 상태전환과 API 뼈대만 구현)

---

## 상세 내용

**반품 단계 분리 및 판매자 거절 플로우 추가**
SHA : 348ef8f345daa55d4f58737f6cff3cb79fef72bc
- 반품 상태 enum을 1차 승인/최종 승인/발송 전 거절/발송 후 거절 단계로 세분화
- 판매자 1차 승인/거절, 최종 거절 유스케이스와 API 엔드포인트를 분리
- 반품 상태 전이 검증용 CustomException과 거절 사유 DTO/응답 필드를 추가
- 반품 관련 클래스와 메소드 Javadoc을 간결한 명사형 스타일로 정리


**반품 단계 분리 시나리오 테스트 보강**
SHA : 5da036e20c8aa259e666624fb8ddf2331a9fc381
- 판매자 1차 승인/거절, 최종 승인/거절 유스케이스 단위 테스트 추가
- 반품 상태 전이와 권한 검증을 포함한 통합 테스트 시나리오 확장
- ReturnController WebMvc 테스트를 추가해 요청/응답 및 위임 동작 검증


---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [x] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [x] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
