### PR TITLE
[Auth] 회원가입 이메일 인증 페이지 연결 수정 #258

### DIFF
--- a/auth/src/main/resources/application.yml
+++ b/auth/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
               - openid
               - profile
               - email
-            redirect-uri: ${GOOGLE_OAUTH_REDIRECT_URI:http://localhost:8081/login/oauth2/code/google}
+            redirect-uri: ${GOOGLE_OAUTH_REDIRECT_URI:https://localhost:8081/login/oauth2/code/google}
 
 management:
   endpoints:
@@ -46,4 +46,4 @@ management:
 custom:
   auth:
     oauth2:
-      success-redirect-url: ${GOOGLE_OAUTH_SUCCESS_REDIRECT_URL:http://localhost:3000/oauth/google/callback}
+      success-redirect-url: ${GOOGLE_OAUTH_SUCCESS_REDIRECT_URL:${GOOGLE_OAUTH_SUCCESS_REDIRECT_URI:https://localhost:3000/oauth/google/callback}}

--- a/common/src/main/java/dukku/common/global/handler/GlobalExceptionHandler.java
+++ b/common/src/main/java/dukku/common/global/handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -33,6 +34,29 @@ public class GlobalExceptionHandler {
         log.error("ValidationException: {}", ex.getMessage());
 
         ErrorResponse errorResponse = new ErrorResponse(HttpStatus.BAD_REQUEST.getReasonPhrase(), "입력 데이터에 오류가 있습니다.", HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(errorResponse);
+    }
+
+    /**
+     * 필수 헤더 누락 예외 처리.
+     *
+     * @param ex MissingRequestHeaderException 인스턴스
+     * @return HTTP 400 상태와 누락 헤더 정보가 포함된 에러 응답
+     */
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestHeaderException(
+            MissingRequestHeaderException ex
+    ) {
+        log.error("MissingRequestHeaderException: {}", ex.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "필수 요청 헤더가 누락되었습니다.",
+                HttpStatus.BAD_REQUEST.value(),
+                ex.getMessage()
+        );
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(errorResponse);

--- a/common/src/main/resources/application-common.yml
+++ b/common/src/main/resources/application-common.yml
@@ -76,4 +76,4 @@ custom:
     internalBackUrl: ${INTERNAL_BACK_URL:http://localhost}
   security:
     cors:
-      allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,https://localhost:3000}
+      allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost,https://localhost,http://localhost:3000,https://localhost:3000}

--- a/user/src/main/java/dukku/user/boundedContext/user/app/email/EmailVerificationService.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/app/email/EmailVerificationService.java
@@ -18,6 +18,7 @@ public class EmailVerificationService {
 
     private static final String TOKEN_KEY_PREFIX = "email:verify:token:";
     private static final String VERIFIED_KEY_PREFIX = "email:verify:ok:";
+    private static final String RESULT_TOKEN_KEY_PREFIX = "email:verify:result:";
 
     private final JavaMailSender mailSender;
     private final RedisTemplate<String, Object> redisTemplate;
@@ -33,6 +34,9 @@ public class EmailVerificationService {
 
     @Value("${custom.email.verification.verified-ttl-seconds:1800}")
     private long verifiedTtlSeconds;
+
+    @Value("${custom.email.verification.result-token-ttl-seconds:300}")
+    private long resultTokenTtlSeconds;
 
     @Value("${custom.email.verification.required:true}")
     private boolean verificationRequired;
@@ -69,6 +73,32 @@ public class EmailVerificationService {
             throw new UserEmailVerificationRequiredException();
         }
         redisTemplate.delete(verifiedKey(normalizedEmail));
+    }
+
+    public String issueVerificationResultToken(boolean verified, String email) {
+        // 프론트 인증 결과 페이지 진입용 1회성 결과 토큰 저장
+        String token = generateToken();
+        String normalizedEmail = normalizeEmail(email);
+        String payload = (verified ? "1" : "0") + "|" + normalizedEmail;
+        redisTemplate.opsForValue()
+                .set(resultTokenKey(token), payload, Duration.ofSeconds(resultTokenTtlSeconds));
+        return token;
+    }
+
+    public VerificationResult consumeVerificationResultToken(String token) {
+        String normalizedToken = token == null ? "" : token.trim();
+        Object stored = redisTemplate.opsForValue().get(resultTokenKey(normalizedToken));
+        if (stored == null) {
+            return VerificationResult.invalid();
+        }
+
+        // 토큰 재사용 방지를 위해 조회 즉시 삭제
+        redisTemplate.delete(resultTokenKey(normalizedToken));
+        String payload = stored.toString();
+        String[] parts = payload.split("\\|", 2);
+        boolean verified = parts.length > 0 && "1".equals(parts[0]);
+        String email = parts.length > 1 ? parts[1] : "";
+        return new VerificationResult(verified, email);
     }
 
     private void saveToken(String email, String token) {
@@ -114,11 +144,21 @@ public class EmailVerificationService {
         return TOKEN_KEY_PREFIX + token;
     }
 
+    private String resultTokenKey(String token) {
+        return RESULT_TOKEN_KEY_PREFIX + token;
+    }
+
     private String verifiedKey(String email) {
         return VERIFIED_KEY_PREFIX + email;
     }
 
     private String normalizeEmail(String email) {
         return email == null ? "" : email.trim().toLowerCase();
+    }
+
+    public record VerificationResult(boolean verified, String email) {
+        public static VerificationResult invalid() {
+            return new VerificationResult(false, "");
+        }
     }
 }

--- a/user/src/main/java/dukku/user/boundedContext/user/in/EmailVerificationController.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/in/EmailVerificationController.java
@@ -1,21 +1,21 @@
 package dukku.user.boundedContext.user.in;
 
+import dukku.common.shared.user.exception.UserEmailVerificationTokenInvalidException;
 import dukku.user.boundedContext.user.app.email.EmailVerificationService;
 import dukku.user.boundedContext.user.in.dto.EmailSendRequest;
-import dukku.common.shared.user.exception.UserEmailVerificationTokenInvalidException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @RestController
 @RequestMapping("/api/v1/users/email")
@@ -24,7 +24,7 @@ public class EmailVerificationController {
 
     private final EmailVerificationService emailVerificationService;
 
-    @Value("${custom.email.verification.success-redirect-url:https://dukku.shop}")
+    @Value("${custom.email.verification.success-redirect-url:https://localhost/email/verify}")
     private String successRedirectUrl;
 
     @PostMapping("/send")
@@ -40,15 +40,22 @@ public class EmailVerificationController {
             @RequestParam("token") String token
     ) {
         try {
-            emailVerificationService.verifyByToken(token);
+            String verifiedEmail = emailVerificationService.verifyByToken(token);
+            String verifiedRedirectUrl = UriComponentsBuilder.fromUriString(successRedirectUrl)
+                    .queryParam("verified", true)
+                    .queryParam("email", verifiedEmail)
+                    .build()
+                    .toUriString();
+
             return ResponseEntity.status(HttpStatus.FOUND)
-                    .header(HttpHeaders.LOCATION, successRedirectUrl)
+                    .header(HttpHeaders.LOCATION, verifiedRedirectUrl)
                     .build();
         } catch (UserEmailVerificationTokenInvalidException e) {
             String failureRedirectUrl = UriComponentsBuilder.fromUriString(successRedirectUrl)
-                    .queryParam("error", "이메일_인증_실패")
+                    .queryParam("verified", false)
                     .build()
                     .toUriString();
+
             return ResponseEntity.status(HttpStatus.FOUND)
                     .header(HttpHeaders.LOCATION, failureRedirectUrl)
                     .build();

--- a/user/src/main/java/dukku/user/boundedContext/user/in/EmailVerificationController.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/in/EmailVerificationController.java
@@ -3,6 +3,8 @@ package dukku.user.boundedContext.user.in;
 import dukku.common.shared.user.exception.UserEmailVerificationTokenInvalidException;
 import dukku.user.boundedContext.user.app.email.EmailVerificationService;
 import dukku.user.boundedContext.user.in.dto.EmailSendRequest;
+import dukku.user.boundedContext.user.in.dto.EmailVerifyResponse;
+import dukku.user.boundedContext.user.in.dto.EmailVerifyResultRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -40,10 +42,11 @@ public class EmailVerificationController {
             @RequestParam("token") String token
     ) {
         try {
+            // 메일 링크 토큰 검증이 성공하면, 프론트에서 1회 확인 가능한 결과 토큰을 발급한다.
             String verifiedEmail = emailVerificationService.verifyByToken(token);
+            String resultToken = emailVerificationService.issueVerificationResultToken(true, verifiedEmail);
             String verifiedRedirectUrl = UriComponentsBuilder.fromUriString(successRedirectUrl)
-                    .queryParam("verified", true)
-                    .queryParam("email", verifiedEmail)
+                    .queryParam("resultToken", resultToken)
                     .build()
                     .toUriString();
 
@@ -51,8 +54,10 @@ public class EmailVerificationController {
                     .header(HttpHeaders.LOCATION, verifiedRedirectUrl)
                     .build();
         } catch (UserEmailVerificationTokenInvalidException e) {
+            // 검증 실패도 동일하게 결과 토큰을 발급해, 프론트가 직접 상태를 단정하지 못하게 한다.
+            String resultToken = emailVerificationService.issueVerificationResultToken(false, null);
             String failureRedirectUrl = UriComponentsBuilder.fromUriString(successRedirectUrl)
-                    .queryParam("verified", false)
+                    .queryParam("resultToken", resultToken)
                     .build()
                     .toUriString();
 
@@ -60,5 +65,15 @@ public class EmailVerificationController {
                     .header(HttpHeaders.LOCATION, failureRedirectUrl)
                     .build();
         }
+    }
+
+    @PostMapping("/verify/result")
+    public ResponseEntity<EmailVerifyResponse> verifyResult(
+            @RequestBody @Validated EmailVerifyResultRequest request
+    ) {
+        // 결과 토큰은 1회 소모된다. 재사용이나 직접 URL 진입은 유효 토큰이 없으면 실패 처리된다.
+        EmailVerificationService.VerificationResult result =
+                emailVerificationService.consumeVerificationResultToken(request.getResultToken());
+        return ResponseEntity.ok(new EmailVerifyResponse(result.verified(), result.email()));
     }
 }

--- a/user/src/main/java/dukku/user/boundedContext/user/in/dto/EmailVerifyResultRequest.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/in/dto/EmailVerifyResultRequest.java
@@ -1,0 +1,13 @@
+package dukku.user.boundedContext.user.in.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EmailVerifyResultRequest {
+
+    @NotBlank(message = "인증 결과 토큰은 필수입니다.")
+    private String resultToken;
+}

--- a/user/src/main/resources/application-release.yml
+++ b/user/src/main/resources/application-release.yml
@@ -14,6 +14,9 @@ crypto:
 custom:
   global:
     internalBackUrl: http://localhost:${server.port:8080}
+  email:
+    verification:
+      success-redirect-url: ${EMAIL_VERIFICATION_SUCCESS_REDIRECT_URL:https://localhost/email/verify}
   security:
     cors:
-      allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000,https://localhost:3000}
+      allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost,https://localhost,http://localhost:3000,https://localhost:3000}

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -46,7 +46,7 @@ custom:
     verification:
       required: true
       base-url: ${EMAIL_VERIFICATION_BASE_URL:http://localhost:8082}
-      success-redirect-url: ${EMAIL_VERIFICATION_SUCCESS_REDIRECT_URL:https://localhost:3000/login}
+      success-redirect-url: ${EMAIL_VERIFICATION_SUCCESS_REDIRECT_URL:https://localhost/email/verify}
       token-ttl-seconds: ${EMAIL_VERIFICATION_TOKEN_TTL_SECONDS:1800}
       verified-ttl-seconds: ${EMAIL_VERIFICATION_VERIFIED_TTL_SECONDS:1800}
   signup:
@@ -54,3 +54,4 @@ custom:
     idempotency:
       in-progress-ttl-seconds: 30
       completed-ttl-seconds: 1800
+

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -49,6 +49,7 @@ custom:
       success-redirect-url: ${EMAIL_VERIFICATION_SUCCESS_REDIRECT_URL:https://localhost/email/verify}
       token-ttl-seconds: ${EMAIL_VERIFICATION_TOKEN_TTL_SECONDS:1800}
       verified-ttl-seconds: ${EMAIL_VERIFICATION_VERIFIED_TTL_SECONDS:1800}
+      result-token-ttl-seconds: ${EMAIL_VERIFICATION_RESULT_TOKEN_TTL_SECONDS:300}
   signup:
     request-lock-ttl-seconds: 10
     idempotency:


### PR DESCRIPTION
## PR 제목

[Auth] 회원가입 이메일 인증 페이지 연결 수정 #258

---

## 개요

- 회원가입 시 이메일인증 완료 후 그냥 로그인 페이지로 보내지 않고 이메일 인증 성공/실패 결과를 보여주는 화면으로 이동
- 로그인 성공/실패 화면은 회원가입 상황이 아니면 진입할 수 없도록 일회용 토큰 추가

---

## 상세 내용

회원가입 이메일 인증 시 리다이렉트 경로 수정
SHA : 19ccdd559cb4aab6a88604c947e4b07464538cb2

회원가입 중이 아니면 verify 페이지 진입 못하도록 하는 토큰 추가
SHA : c5d32b9beeb3f6d3dca203dd5b59a8900db7a8a2


---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
