### PR TITLE
[Product] 상품 상세 페이지에서 판매자 정보 나오지 않는 이슈 수정 #261

### DIFF
--- a/common/src/main/java/dukku/common/shared/product/docs/ProductApiDocs.java
+++ b/common/src/main/java/dukku/common/shared/product/docs/ProductApiDocs.java
@@ -97,9 +97,11 @@ public final class ProductApiDocs {
               "price": 1500000,
               "stock": 10,
               "images": ["https://example.com/image1.jpg", "https://example.com/image2.jpg"],
-              "sellerInfo": {
-                "shopUuid": "s1h2o3p4-e5f6-7890-1234-567890abcdef",
-                "shopName": "최고의 상점"
+              "seller": {
+                "sellerUuid": "s1h2o3p4-e5f6-7890-1234-567890abcdef",
+                "nickname": "최고의 상점",
+                "averageRating": 4.90,
+                "reviewCount": 18
               }
             }
             """)))

--- a/common/src/main/java/dukku/common/shared/product/docs/SellerProductApiDocs.java
+++ b/common/src/main/java/dukku/common/shared/product/docs/SellerProductApiDocs.java
@@ -48,9 +48,11 @@ public final class SellerProductApiDocs {
               "price": 25000,
               "stock": 50,
               "images": [],
-              "sellerInfo": {
-                "shopUuid": "s1h2o3p4-e5f6-7890-1234-567890abcdef",
-                "shopName": "판매자의 상점"
+              "seller": {
+                "sellerUuid": "s1h2o3p4-e5f6-7890-1234-567890abcdef",
+                "nickname": "판매자의 상점",
+                "averageRating": 4.90,
+                "reviewCount": 18
               }
             }
             """)))
@@ -79,9 +81,11 @@ public final class SellerProductApiDocs {
               "price": 30000,
               "stock": 40,
               "images": [],
-              "sellerInfo": {
-                "shopUuid": "s1h2o3p4-e5f6-7890-1234-567890abcdef",
-                "shopName": "판매자의 상점"
+              "seller": {
+                "sellerUuid": "s1h2o3p4-e5f6-7890-1234-567890abcdef",
+                "nickname": "판매자의 상점",
+                "averageRating": 4.90,
+                "reviewCount": 18
               }
             }
             """)))

--- a/common/src/main/java/dukku/common/shared/product/docs/ShopApiDocs.java
+++ b/common/src/main/java/dukku/common/shared/product/docs/ShopApiDocs.java
@@ -34,8 +34,12 @@ public final class ShopApiDocs {
     @ApiResponse(responseCode = "200", description = "내 상점 정보 조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
             {
               "shopUuid": "s1h2o3p4-e5f6-7890-1234-567890abcdef",
-              "shopName": "내 상점",
-              "description": "내 상점입니다. 많이 이용해주세요."
+              "nickname": "내 상점",
+              "intro": "내 상점입니다. 많이 이용해주세요.",
+              "salesCount": 12,
+              "activeListingCount": 3,
+              "averageRating": 4.75,
+              "reviewCount": 24
             }
             """)))
     @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"message\": \"인증이 필요합니다.\"}")))
@@ -49,14 +53,18 @@ public final class ShopApiDocs {
     @Operation(summary = "내 상점 소개 수정", description = "로그인한 사용자의 상점 소개를 수정합니다.")
     @RequestBody(required = true, content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
             {
-              "description": "새로운 상점 소개입니다."
+              "intro": "새로운 상점 소개입니다."
             }
             """)))
     @ApiResponse(responseCode = "200", description = "내 상점 소개 수정 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
             {
               "shopUuid": "s1h2o3p4-e5f6-7890-1234-567890abcdef",
-              "shopName": "내 상점",
-              "description": "새로운 상점 소개입니다."
+              "nickname": "내 상점",
+              "intro": "새로운 상점 소개입니다.",
+              "salesCount": 12,
+              "activeListingCount": 3,
+              "averageRating": 4.75,
+              "reviewCount": 24
             }
             """)))
     @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"message\": \"인증이 필요합니다.\"}")))
@@ -93,8 +101,12 @@ public final class ShopApiDocs {
     @ApiResponse(responseCode = "200", description = "판매자 상점 정보 조회 성공", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
             {
               "shopUuid": "s1h2o3p4-e5f6-7890-1234-abcdefghij",
-              "shopName": "다른 사람의 상점",
-              "description": "구경하고 가세요."
+              "nickname": "다른 사람의 상점",
+              "intro": "구경하고 가세요.",
+              "salesCount": 4,
+              "activeListingCount": 1,
+              "averageRating": 5.00,
+              "reviewCount": 2
             }
             """)))
     @ApiResponse(responseCode = "404", description = "상점을 찾을 수 없음", content = @Content(mediaType = "application/json", examples = @ExampleObject(value = "{\"message\": \"상점을 찾을 수 없습니다.\"}")))

--- a/common/src/main/java/dukku/common/shared/product/dto/product/ProductDetailResponse.java
+++ b/common/src/main/java/dukku/common/shared/product/dto/product/ProductDetailResponse.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,6 +32,7 @@ public class ProductDetailResponse {
     private int viewCount;
     private List<String> imageUrls;
     private CategorySummary category;
+    private Seller seller;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
     private List<String> tagNames;
@@ -41,5 +43,14 @@ public class ProductDetailResponse {
         private Integer id;
         private String name;
         private int depth;
+    }
+
+    @Getter
+    @Builder
+    public static class Seller {
+        private UUID sellerUuid;
+        private String nickname;
+        private BigDecimal averageRating;
+        private int reviewCount;
     }
 }

--- a/common/src/main/java/dukku/common/shared/product/dto/shop/ShopResponse.java
+++ b/common/src/main/java/dukku/common/shared/product/dto/shop/ShopResponse.java
@@ -3,13 +3,17 @@ package dukku.common.shared.product.dto.shop;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
 @Builder
 public class ShopResponse {
     private UUID shopUuid;              // ProductSeller.uuid
+    private String nickname;
     private String intro;
     private int salesCount;
     private int activeListingCount;
+    private BigDecimal averageRating;
+    private int reviewCount;
 }

--- a/common/src/main/java/dukku/common/shared/product/exception/ProductUserNotFoundException.java
+++ b/common/src/main/java/dukku/common/shared/product/exception/ProductUserNotFoundException.java
@@ -1,0 +1,9 @@
+package dukku.common.shared.product.exception;
+
+import dukku.common.global.exception.NotFoundException;
+
+public class ProductUserNotFoundException extends NotFoundException {
+    public ProductUserNotFoundException() {
+        super("판매자 사용자 정보를 찾을 수 없습니다.");
+    }
+}

--- a/product/src/main/java/dukku/product/boundedContext/product/app/support/ProductMapper.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/support/ProductMapper.java
@@ -2,6 +2,7 @@ package dukku.product.boundedContext.product.app.support;
 
 import dukku.product.boundedContext.product.entity.Product;
 import dukku.product.boundedContext.product.entity.ProductImage;
+import dukku.product.boundedContext.product.entity.ProductSeller;
 import dukku.common.shared.product.dto.product.ProductDetailResponse;
 import dukku.common.shared.product.dto.product.ProductListItemResponse;
 
@@ -25,6 +26,10 @@ public class ProductMapper {
     }
 
     public static ProductDetailResponse toDetail(Product p) {
+        return toDetail(p, null, null);
+    }
+
+    public static ProductDetailResponse toDetail(Product p, ProductSeller seller, String nickname) {
         List<String> imageUrls = p.getImages().stream()
                 .sorted(Comparator.comparingInt(ProductImage::getSortOrder))
                 .map(ProductImage::getImageUrl)
@@ -48,6 +53,12 @@ public class ProductMapper {
                         .id(p.getCategory().getId())
                         .name(p.getCategory().getCategoryName())
                         .depth(p.getCategory().getDepth())
+                        .build())
+                .seller(seller == null ? null : ProductDetailResponse.Seller.builder()
+                        .sellerUuid(seller.getUserUuid())
+                        .nickname(nickname)
+                        .averageRating(seller.getAverageRating())
+                        .reviewCount(seller.getReviewCount())
                         .build())
                 .createdAt(p.getCreatedAt())
                 .tagNames(p.getTagNames())

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
@@ -3,12 +3,18 @@ package dukku.product.boundedContext.product.app.usecase.product;
 import dukku.product.boundedContext.product.app.support.ProductMapper;
 import dukku.product.boundedContext.product.app.cqrs.ProductStatsRedisSupport;
 import dukku.product.boundedContext.product.entity.Product;
+import dukku.product.boundedContext.product.entity.ProductSeller;
 import dukku.product.boundedContext.product.out.ProductRepository;
+import dukku.product.boundedContext.product.out.ProductSellerRepository;
+import dukku.product.boundedContext.product.out.ProductUserRepository;
 import dukku.common.shared.product.dto.product.ProductDetailResponse;
 import dukku.common.shared.product.exception.ProductNotFoundException;
+import dukku.common.shared.product.exception.ProductSellerNotFoundException;
+import dukku.common.shared.product.exception.ProductUserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
@@ -18,6 +24,8 @@ import java.util.UUID;
 public class FindProductDetailUseCase {
     private final ProductRepository productRepository;
     private final ProductStatsRedisSupport productStatsRedisSupport;
+    private final ProductSellerRepository productSellerRepository;
+    private final ProductUserRepository productUserRepository;
 
     public ProductDetailResponse execute(UUID productUuid) {
         Product product = productRepository.findByUuidWithImagesAndCategory(productUuid)
@@ -25,6 +33,14 @@ public class FindProductDetailUseCase {
 
         productStatsRedisSupport.incrementView(product.getId());
 
-        return ProductMapper.toDetail(product);
+        ProductSeller seller = productSellerRepository.findByUserUuid(product.getSellerUuid())
+                .orElseThrow(ProductSellerNotFoundException::new);
+
+        String nickname = productUserRepository.findById(seller.getUserUuid())
+                .map(user -> user.getNickname())
+                .filter(StringUtils::hasText)
+                .orElseThrow(ProductUserNotFoundException::new);
+
+        return ProductMapper.toDetail(product, seller, nickname);
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopUseCase.java
@@ -2,11 +2,14 @@ package dukku.product.boundedContext.product.app.usecase.shop;
 
 import dukku.common.shared.product.dto.shop.ShopResponse;
 import dukku.common.shared.product.exception.ProductSellerNotFoundException;
+import dukku.common.shared.product.exception.ProductUserNotFoundException;
 import dukku.product.boundedContext.product.entity.ProductSeller;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
+import dukku.product.boundedContext.product.out.ProductUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
@@ -15,12 +18,18 @@ import java.util.UUID;
 public class FindMyShopUseCase {
 
     private final ProductSellerRepository productSellerRepository;
+    private final ProductUserRepository productUserRepository;
 
     @Transactional(readOnly = true)
     public ShopResponse execute(UUID userUuid) {
         ProductSeller seller = productSellerRepository.findByUserUuid(userUuid)
                 .orElseThrow(ProductSellerNotFoundException::new);
 
-        return ProductSeller.from(seller);
+        String nickname = productUserRepository.findById(seller.getUserUuid())
+                .map(user -> user.getNickname())
+                .filter(StringUtils::hasText)
+                .orElseThrow(ProductUserNotFoundException::new);
+
+        return ProductSeller.from(seller, nickname);
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindShopUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindShopUseCase.java
@@ -2,11 +2,14 @@ package dukku.product.boundedContext.product.app.usecase.shop;
 
 import dukku.common.shared.product.dto.shop.ShopResponse;
 import dukku.common.shared.product.exception.ProductSellerNotFoundException;
+import dukku.common.shared.product.exception.ProductUserNotFoundException;
 import dukku.product.boundedContext.product.entity.ProductSeller;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
+import dukku.product.boundedContext.product.out.ProductUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
@@ -15,12 +18,18 @@ import java.util.UUID;
 public class FindShopUseCase {
 
     private final ProductSellerRepository productSellerRepository;
+    private final ProductUserRepository productUserRepository;
 
     @Transactional(readOnly = true)
     public ShopResponse execute(UUID shopUuid) {
         ProductSeller seller = productSellerRepository.findByUuid(shopUuid)
                 .orElseThrow(ProductSellerNotFoundException::new);
 
-        return ProductSeller.from(seller);
+        String nickname = productUserRepository.findById(seller.getUserUuid())
+                .map(user -> user.getNickname())
+                .filter(StringUtils::hasText)
+                .orElseThrow(ProductUserNotFoundException::new);
+
+        return ProductSeller.from(seller, nickname);
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/UpdateMyShopUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/UpdateMyShopUseCase.java
@@ -3,11 +3,14 @@ package dukku.product.boundedContext.product.app.usecase.shop;
 import dukku.common.shared.product.dto.shop.ShopResponse;
 import dukku.common.shared.product.dto.shop.UpdateShopRequest;
 import dukku.common.shared.product.exception.ProductSellerNotFoundException;
+import dukku.common.shared.product.exception.ProductUserNotFoundException;
 import dukku.product.boundedContext.product.entity.ProductSeller;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
+import dukku.product.boundedContext.product.out.ProductUserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
@@ -16,6 +19,7 @@ import java.util.UUID;
 public class UpdateMyShopUseCase {
 
     private final ProductSellerRepository productSellerRepository;
+    private final ProductUserRepository productUserRepository;
 
     @Transactional
     public ShopResponse execute(UUID userUuid, UpdateShopRequest request) {
@@ -27,6 +31,11 @@ public class UpdateMyShopUseCase {
             seller.changeIntro(request.getIntro());
         }
 
-        return ProductSeller.from(seller);
+        String nickname = productUserRepository.findById(seller.getUserUuid())
+                .map(user -> user.getNickname())
+                .filter(StringUtils::hasText)
+                .orElseThrow(ProductUserNotFoundException::new);
+
+        return ProductSeller.from(seller, nickname);
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/entity/ProductSeller.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/entity/ProductSeller.java
@@ -74,12 +74,15 @@ public class ProductSeller extends BaseIdAndUUIDAndTime {
         this.intro = intro;
     }
 
-    public static ShopResponse from(ProductSeller seller) {
+    public static ShopResponse from(ProductSeller seller, String nickname) {
         return ShopResponse.builder()
                 .shopUuid(seller.getUuid())
+                .nickname(nickname)
                 .intro(seller.getIntro())
                 .salesCount(seller.getSalesCount())
                 .activeListingCount(seller.getActiveListingCount())
+                .averageRating(seller.getAverageRating())
+                .reviewCount(seller.getReviewCount())
                 .build();
     }
 }


### PR DESCRIPTION
## PR 제목

[Product] 상품 상세 페이지에서 판매자 정보 나오지 않는 이슈 수정 #261


---

## 개요

#261 

- 프론트에서 상품 상세정보 보기 시 판매자 정보가 알수없음으로 표시
- 원인은 백엔드에서 보내는 응답에 판매자 관련 정보가 누락되어있기 때문
- 정상적으로 표시되도록 수정

---

## 상세 내용

**상품/상점 조회: 판매자 표시 정보 응답 보강**
SHA : c73c44ef3b5fa81be3c619c3aa6113260d4508be
- ShopResponse와 ProductDetailResponse에 판매자 표시 필드(닉네임/평점/리뷰수) 추가
- 상품 상세 응답의 판매자 객체 키를 seller로 통일하고 매퍼/문서 예시 동기화
- ProductUser 닉네임 누락 시 404 예외를 반환해 프론트 fallback 없이 실패 처리


---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [x] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
