### PR TITLE
[User] user 생성시 ai 모듈 saga패턴으로 연결

### DIFF
--- a/ai/src/main/java/dukku/ai/app/usecase/InitializeAiUserUseCase.java
+++ b/ai/src/main/java/dukku/ai/app/usecase/InitializeAiUserUseCase.java
@@ -1,0 +1,38 @@
+package dukku.ai.app.usecase;
+
+import dukku.ai.entity.AiMemory;
+import dukku.ai.out.AiMemoryRepository;
+import dukku.common.shared.ai.type.MemorySubType;
+import dukku.common.shared.ai.type.MemoryType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+public class InitializeAiUserUseCase {
+
+    private final AiMemoryRepository aiMemoryRepository;
+
+    public InitializeAiUserUseCase(AiMemoryRepository aiMemoryRepository) {
+        this.aiMemoryRepository = aiMemoryRepository;
+    }
+
+    @Transactional
+    public void execute(UUID userUuid, String nickname) {
+        if (aiMemoryRepository.existsByUserUuidAndMemoryType(userUuid, MemoryType.PROFILE)) {
+            return;
+        }
+
+        AiMemory profileMemory = AiMemory.builder()
+                .userUuid(userUuid)
+                .memoryType(MemoryType.PROFILE)
+                .subType(MemorySubType.GENERAL)
+                .content("Profile initialized for user: " + nickname)
+                .importanceScore(1.0)
+                .confidenceScore(1.0)
+                .build();
+
+        aiMemoryRepository.save(profileMemory);
+    }
+}

--- a/ai/src/main/java/dukku/ai/in/AiUserEventListener.java
+++ b/ai/src/main/java/dukku/ai/in/AiUserEventListener.java
@@ -1,0 +1,35 @@
+package dukku.ai.in;
+
+import dukku.ai.app.usecase.InitializeAiUserUseCase;
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.user.event.UserAiInitializationFailedEvent;
+import dukku.common.shared.user.event.UserProductInitializedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiUserEventListener {
+
+    private final InitializeAiUserUseCase initializeAiUserUseCase;
+    private final EventPublisher eventPublisher;
+
+    @KafkaListener(topics = "user.product-initialized", groupId = "${spring.application.name}-group")
+    public void handleProductInitialized(UserProductInitializedEvent event) {
+        try {
+            initializeAiUserUseCase.execute(event.userUuid(), event.nickname());
+            log.info("[UserProductInitializedEvent] AI user initialization completed. userUuid={}", event.userUuid());
+        } catch (Exception e) {
+            publishAiInitFailed(event, e);
+        }
+    }
+
+    private void publishAiInitFailed(UserProductInitializedEvent event, Exception cause) {
+        String reason = cause.getMessage() == null ? "AI user initialization exception" : cause.getMessage();
+        eventPublisher.publish(new UserAiInitializationFailedEvent(event.userUuid(), reason));
+        log.error("[UserProductInitializedEvent] AI user initialization failed. userUuid={}", event.userUuid(), cause);
+    }
+}

--- a/ai/src/main/java/dukku/ai/out/AiMemoryRepository.java
+++ b/ai/src/main/java/dukku/ai/out/AiMemoryRepository.java
@@ -8,8 +8,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import dukku.ai.entity.AiMemory;
+import dukku.common.shared.ai.type.MemoryType;
 
 public interface AiMemoryRepository extends JpaRepository<AiMemory, Integer> {
+    boolean existsByUserUuidAndMemoryType(UUID userUuid, MemoryType memoryType);
 
     @Query(value = """
             SELECT * FROM ai_memory

--- a/common/src/main/java/dukku/common/shared/user/event/UserAiInitializationFailedEvent.java
+++ b/common/src/main/java/dukku/common/shared/user/event/UserAiInitializationFailedEvent.java
@@ -1,0 +1,17 @@
+package dukku.common.shared.user.event;
+
+import dukku.common.global.event.DomainEvent;
+
+import java.util.UUID;
+
+public record UserAiInitializationFailedEvent(UUID userUuid, String reason) implements DomainEvent {
+    @Override
+    public String getTopic() {
+        return "user.ai-initialization-failed";
+    }
+
+    @Override
+    public String getKey() {
+        return userUuid.toString();
+    }
+}

--- a/common/src/main/java/dukku/common/shared/user/event/UserProductInitializedEvent.java
+++ b/common/src/main/java/dukku/common/shared/user/event/UserProductInitializedEvent.java
@@ -1,0 +1,17 @@
+package dukku.common.shared.user.event;
+
+import dukku.common.global.event.DomainEvent;
+
+import java.util.UUID;
+
+public record UserProductInitializedEvent(UUID userUuid, String nickname) implements DomainEvent {
+    @Override
+    public String getTopic() {
+        return "user.product-initialized";
+    }
+
+    @Override
+    public String getKey() {
+        return userUuid.toString();
+    }
+}

--- a/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductUserEventListener.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductUserEventListener.java
@@ -1,8 +1,10 @@
-package dukku.product.boundedContext.product.in.listener;
+﻿package dukku.product.boundedContext.product.in.listener;
 
 import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.user.event.UserAiInitializationFailedEvent;
 import dukku.common.shared.user.event.UserDepositInitializedEvent;
 import dukku.common.shared.user.event.UserProductInitializationFailedEvent;
+import dukku.common.shared.user.event.UserProductInitializedEvent;
 import dukku.product.boundedContext.product.entity.ProductUser;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,21 +27,32 @@ public class ProductUserEventListener {
         try {
             UUID userUuid = event.userUuid();
 
-            if (productUserRepository.existsById(userUuid)) {
-                return;
+            if (!productUserRepository.existsById(userUuid)) {
+                productUserRepository.save(ProductUser.create(userUuid, event.nickname()));
             }
 
-            productUserRepository.save(ProductUser.create(userUuid, event.nickname()));
-            log.info("[UserDepositInitializedEvent] 상품 도메인 유저 초기화 완료. userUuid={}", userUuid);
+            eventPublisher.publish(new UserProductInitializedEvent(userUuid, event.nickname()));
+            log.info("[UserDepositInitializedEvent] Product user initialization completed. userUuid={}", userUuid);
         } catch (Exception e) {
             publishProductInitFailed(event, e);
         }
     }
 
-    private void publishProductInitFailed(UserDepositInitializedEvent event, Exception cause) {
-        String reason = cause.getMessage() == null ? "상품 도메인 유저 초기화 중 예외 발생" : cause.getMessage();
-        eventPublisher.publish(new UserProductInitializationFailedEvent(event.userUuid(), reason));
-        log.error("[UserDepositInitializedEvent] 상품 도메인 유저 초기화 실패. userUuid={}", event.userUuid(), cause);
+    @KafkaListener(topics = "user.ai-initialization-failed", groupId = "${spring.application.name}-group")
+    public void handleAiInitializationFailed(UserAiInitializationFailedEvent event) {
+        try {
+            UUID userUuid = event.userUuid();
+            productUserRepository.findById(userUuid).ifPresent(productUserRepository::delete);
+            eventPublisher.publish(new UserProductInitializationFailedEvent(userUuid, event.reason()));
+            log.warn("[UserAiInitializationFailedEvent] Product user compensation completed. userUuid={}", userUuid);
+        } catch (Exception e) {
+            log.error("[UserAiInitializationFailedEvent] Product user compensation failed. userUuid={}", event.userUuid(), e);
+        }
     }
 
+    private void publishProductInitFailed(UserDepositInitializedEvent event, Exception cause) {
+        String reason = cause.getMessage() == null ? "Product user initialization exception" : cause.getMessage();
+        eventPublisher.publish(new UserProductInitializationFailedEvent(event.userUuid(), reason));
+        log.error("[UserDepositInitializedEvent] Product user initialization failed. userUuid={}", event.userUuid(), cause);
+    }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductUserEventListener.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductUserEventListener.java
@@ -1,4 +1,4 @@
-﻿package dukku.product.boundedContext.product.in.listener;
+package dukku.product.boundedContext.product.in.listener;
 
 import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.user.event.UserAiInitializationFailedEvent;


### PR DESCRIPTION
## 개요

- 회원가입 초기화 플로우에 ai 모듈을 Saga 체인으로 연결
- 기존 deposit → product까지만 이어지던 분산 초기화 흐름을 ai까지 확장

---

## 상세 내용

• ai 모듈에 사용자 초기화 이벤트 리스너를 추가
• product 초기화 완료 이벤트(user.product-initialized)를 수신해 AI 기본 메모리(PROFILE)를 생성하도록 구성
• AI 초기화 실패 시 실패 이벤트(user.ai-initialization-failed)를 발행하도록 추가
• product 모듈에서 AI 실패 이벤트를 수신해 product user 데이터를 보상 삭제하고, 기존 보상 흐름(user.product-initialization-failed)으로 연결

---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
