### PR TITLE
[Coupon] 쿠폰 발급 이슈 해결 #272

### DIFF
--- a/coupon/src/main/java/dukku/coupon/boundedContext/coupon/entity/Coupon.java
+++ b/coupon/src/main/java/dukku/coupon/boundedContext/coupon/entity/Coupon.java
@@ -61,6 +61,7 @@ public class Coupon {
     // 쿠폰 생성 시 초기 상태는 DRAFT
     public static Coupon createCoupon(CouponCreateRequest request) {
         return Coupon.builder()
+                .uuid(UUID.randomUUID())
                 .couponName(request.couponName())
                 .discountAmount(request.discountAmount())
                 .minimumOrderAmount(request.minimumOrderAmount())
@@ -69,6 +70,13 @@ public class Coupon {
                 .issuedQuantity(0)
                 .totalQuantity(request.totalQuantity())
                 .build();
+    }
+
+    @PrePersist
+    void prePersist() {
+        if (this.uuid == null) {
+            this.uuid = UUID.randomUUID();
+        }
     }
 
     // 발급 전(Active로 전환 전) 수정 허용

--- a/coupon/src/test/java/dukku/coupon/boundedContext/coupon/entity/CouponTest.java
+++ b/coupon/src/test/java/dukku/coupon/boundedContext/coupon/entity/CouponTest.java
@@ -1,0 +1,30 @@
+package dukku.coupon.boundedContext.coupon.entity;
+
+import dukku.common.shared.coupon.dto.CouponCreateRequest;
+import dukku.common.shared.coupon.type.CouponStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CouponTest {
+
+    @Test
+    @DisplayName("createCoupon 호출 시 UUID가 자동 생성된다")
+    void createCouponGeneratesUuid() {
+        CouponCreateRequest request = new CouponCreateRequest(
+                "신규 쿠폰",
+                5000,
+                10000,
+                LocalDateTime.now().plusDays(1),
+                100
+        );
+
+        Coupon coupon = Coupon.createCoupon(request);
+
+        assertThat(coupon.getUuid()).isNotNull();
+        assertThat(coupon.getStatus()).isEqualTo(CouponStatus.DRAFT);
+    }
+}


### PR DESCRIPTION

## PR 제목

[Coupon] 쿠폰 발급 진행 안됨 #272

---

## 개요

쿠폰 발급 시 발급 진행 안되고 500 에러 발생
null 발생으로 interal error 발생
원인 : coupon 도메인 엔티티에서 빌더에 uuid를 넣지 않고 있었음

---

## 상세 내용


**엔티티 uuid 초기화 누락 수정**
SHA : 1f5f808e4117d38f4897634d6d67018a7510789f1f5f808e4117d38f4897634d6d67018a7510789f
- uuid 초기화 누락 수정


---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
