### PR TITLE
[Product] 상품 판매 등록 시 발생하는 500 에러 수정 및 기동 이슈 수정 #251 #280

### DIFF
--- a/common/src/main/java/dukku/common/shared/user/dto/UserRegisterRequest.java
+++ b/common/src/main/java/dukku/common/shared/user/dto/UserRegisterRequest.java
@@ -1,7 +1,11 @@
 package dukku.common.shared.user.dto;
 
-import jakarta.validation.constraints.*;
-import lombok.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 @Data
 @AllArgsConstructor
@@ -14,9 +18,11 @@ public class UserRegisterRequest {
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Pattern(
             regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+]{8,20}$",
-            message = "비밀번호는 8~20자, 영문과 숫자를 포함해야 합니다."
+            message = "비밀번호는 8~20자 영문과 숫자를 포함해야 합니다."
     )
     private String password;
 
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")
     private String nickname;
 }

--- a/common/src/main/resources/application-common.yml
+++ b/common/src/main/resources/application-common.yml
@@ -5,11 +5,11 @@ spring:
   datasource:
     driver-class-name: org.postgresql.Driver
     hikari:
-      minimum-idle: 5
-      maximum-pool-size: 30
-      idle-timeout: 30000
-      connection-timeout: 30000
-      max-lifetime: 1800000
+      minimum-idle: ${DB_HIKARI_MINIMUM_IDLE:1}
+      maximum-pool-size: ${DB_HIKARI_MAXIMUM_POOL_SIZE:10}
+      idle-timeout: ${DB_HIKARI_IDLE_TIMEOUT:30000}
+      connection-timeout: ${DB_HIKARI_CONNECTION_TIMEOUT:30000}
+      max-lifetime: ${DB_HIKARI_MAX_LIFETIME:1800000}
 
   jpa:
     open-in-view: false
@@ -20,7 +20,7 @@ spring:
         use_sql_comments: false
 
         hbm2ddl:
-          auto: create
+          auto: ${HIBERNATE_DDL_AUTO:update}
 
         dialect: org.hibernate.dialect.PostgreSQLDialect
         default_batch_fetch_size: 100

--- a/common/src/test/java/dukku/common/shared/user/dto/UserRegisterRequestValidationTest.java
+++ b/common/src/test/java/dukku/common/shared/user/dto/UserRegisterRequestValidationTest.java
@@ -1,0 +1,50 @@
+package dukku.common.shared.user.dto;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserRegisterRequestValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    @DisplayName("닉네임이 비어있으면 검증에 실패한다")
+    void failsWhenNicknameBlank() {
+        UserRegisterRequest request = new UserRegisterRequest("test@example.com", "abc12345", " ");
+
+        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("닉네임은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("닉네임이 50자를 초과하면 검증에 실패한다")
+    void failsWhenNicknameTooLong() {
+        UserRegisterRequest request = new UserRegisterRequest(
+                "test@example.com",
+                "abc12345",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        Set<ConstraintViolation<UserRegisterRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("닉네임은 50자 이하여야 합니다.");
+    }
+}
+

--- a/coupon/src/main/java/dukku/coupon/boundedContext/coupon/app/command/CreateCouponUseCase.java
+++ b/coupon/src/main/java/dukku/coupon/boundedContext/coupon/app/command/CreateCouponUseCase.java
@@ -17,7 +17,7 @@ public class CreateCouponUseCase {
 
     public CouponResponse execute(CouponCreateRequest request) {
         Coupon coupon = Coupon.createCoupon(request);
-        couponRepository.save(coupon);
+        coupon = couponRepository.save(coupon);
 
         return Coupon.from(coupon);
     }

--- a/coupon/src/test/java/dukku/coupon/boundedContext/coupon/app/command/CreateCouponUseCaseTest.java
+++ b/coupon/src/test/java/dukku/coupon/boundedContext/coupon/app/command/CreateCouponUseCaseTest.java
@@ -1,0 +1,82 @@
+package dukku.coupon.boundedContext.coupon.app.command;
+
+import dukku.common.shared.coupon.dto.CouponCreateRequest;
+import dukku.common.shared.coupon.dto.CouponResponse;
+import dukku.common.shared.coupon.type.CouponStatus;
+import dukku.coupon.boundedContext.coupon.entity.Coupon;
+import dukku.coupon.boundedContext.coupon.out.CouponRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CreateCouponUseCaseTest {
+
+    @Mock
+    private CouponRepository couponRepository;
+
+    @InjectMocks
+    private CreateCouponUseCase useCase;
+
+    @Test
+    @DisplayName("쿠폰 생성 요청을 저장하고 CouponResponse를 반환한다")
+    void executeSavesCouponAndReturnsResponse() {
+        LocalDateTime validFrom = LocalDateTime.now().plusDays(1);
+        CouponCreateRequest request = new CouponCreateRequest(
+                "오픈 기념 쿠폰",
+                2000,
+                10000,
+                validFrom,
+                30
+        );
+
+        UUID couponUuid = UUID.randomUUID();
+        when(couponRepository.save(org.mockito.ArgumentMatchers.any(Coupon.class)))
+                .thenAnswer(invocation -> {
+                    Coupon saved = invocation.getArgument(0);
+                    return Coupon.builder()
+                            .id(1)
+                            .uuid(couponUuid)
+                            .couponName(saved.getCouponName())
+                            .discountAmount(saved.getDiscountAmount())
+                            .minimumOrderAmount(saved.getMinimumOrderAmount())
+                            .validFrom(saved.getValidFrom())
+                            .createdAt(LocalDateTime.now())
+                            .status(saved.getStatus())
+                            .totalQuantity(saved.getTotalQuantity())
+                            .issuedQuantity(saved.getIssuedQuantity())
+                            .build();
+                });
+
+        CouponResponse response = useCase.execute(request);
+
+        ArgumentCaptor<Coupon> captor = ArgumentCaptor.forClass(Coupon.class);
+        verify(couponRepository).save(captor.capture());
+        Coupon persisted = captor.getValue();
+        assertThat(persisted.getCouponName()).isEqualTo("오픈 기념 쿠폰");
+        assertThat(persisted.getDiscountAmount()).isEqualTo(2000);
+        assertThat(persisted.getMinimumOrderAmount()).isEqualTo(10000);
+        assertThat(persisted.getValidFrom()).isEqualTo(validFrom);
+        assertThat(persisted.getStatus()).isEqualTo(CouponStatus.DRAFT);
+        assertThat(persisted.getIssuedQuantity()).isZero();
+        assertThat(persisted.getTotalQuantity()).isEqualTo(30);
+
+        assertThat(response.uuid()).isEqualTo(couponUuid);
+        assertThat(response.couponName()).isEqualTo("오픈 기념 쿠폰");
+        assertThat(response.status()).isEqualTo(CouponStatus.DRAFT);
+        assertThat(response.issuedQuantity()).isZero();
+        assertThat(response.totalQuantity()).isEqualTo(30);
+    }
+}
+

--- a/coupon/src/test/java/dukku/coupon/boundedContext/coupon/entity/CouponLifecycleTest.java
+++ b/coupon/src/test/java/dukku/coupon/boundedContext/coupon/entity/CouponLifecycleTest.java
@@ -1,0 +1,157 @@
+package dukku.coupon.boundedContext.coupon.entity;
+
+import dukku.common.shared.coupon.dto.CouponCreateRequest;
+import dukku.common.shared.coupon.dto.CouponUpdateRequest;
+import dukku.common.shared.coupon.exception.CouponActivationNotAllowedException;
+import dukku.common.shared.coupon.exception.CouponDeactivationNotAllowedException;
+import dukku.common.shared.coupon.exception.CouponIssueNotAllowedException;
+import dukku.common.shared.coupon.exception.CouponSoldOutException;
+import dukku.common.shared.coupon.exception.CouponUpdateNotAllowedException;
+import dukku.common.shared.coupon.type.CouponStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CouponLifecycleTest {
+
+    @Test
+    @DisplayName("createCoupon은 DRAFT 상태와 issuedQuantity 0으로 초기화한다")
+    void createCouponInitializesDraftAndIssuedZero() {
+        CouponCreateRequest request = new CouponCreateRequest(
+                "신규 쿠폰",
+                3000,
+                10000,
+                LocalDateTime.now().plusDays(1),
+                50
+        );
+
+        Coupon coupon = Coupon.createCoupon(request);
+
+        assertThat(coupon.getCouponName()).isEqualTo("신규 쿠폰");
+        assertThat(coupon.getDiscountAmount()).isEqualTo(3000);
+        assertThat(coupon.getMinimumOrderAmount()).isEqualTo(10000);
+        assertThat(coupon.getValidFrom()).isEqualTo(request.validFrom());
+        assertThat(coupon.getStatus()).isEqualTo(CouponStatus.DRAFT);
+        assertThat(coupon.getIssuedQuantity()).isEqualTo(0);
+        assertThat(coupon.getTotalQuantity()).isEqualTo(50);
+    }
+
+    @Test
+    @DisplayName("DRAFT 상태에서 updateDraft가 필드를 갱신한다")
+    void updateDraftUpdatesFields() {
+        Coupon coupon = draftCoupon();
+        CouponUpdateRequest request = new CouponUpdateRequest(
+                "수정 쿠폰",
+                5000,
+                15000,
+                LocalDateTime.now().plusDays(2)
+        );
+
+        coupon.updateDraft(request);
+
+        assertThat(coupon.getCouponName()).isEqualTo("수정 쿠폰");
+        assertThat(coupon.getDiscountAmount()).isEqualTo(5000);
+        assertThat(coupon.getMinimumOrderAmount()).isEqualTo(15000);
+        assertThat(coupon.getValidFrom()).isEqualTo(request.validFrom());
+    }
+
+    @Test
+    @DisplayName("DRAFT가 아닌 상태에서 updateDraft를 호출하면 예외가 발생한다")
+    void updateDraftThrowsWhenNotDraft() {
+        Coupon coupon = activeCoupon(10, 0);
+
+        assertThatThrownBy(() -> coupon.updateDraft(
+                new CouponUpdateRequest("x", 1000, 0, LocalDateTime.now())
+        )).isInstanceOf(CouponUpdateNotAllowedException.class);
+    }
+
+    @Test
+    @DisplayName("activate/deactivate 상태 전이가 정상 동작한다")
+    void activateAndDeactivateWork() {
+        Coupon coupon = draftCoupon();
+
+        coupon.activate();
+        assertThat(coupon.getStatus()).isEqualTo(CouponStatus.ACTIVE);
+
+        coupon.deactivate();
+        assertThat(coupon.getStatus()).isEqualTo(CouponStatus.INACTIVE);
+    }
+
+    @Test
+    @DisplayName("잘못된 activate/deactivate 호출 시 예외가 발생한다")
+    void activateDeactivateThrowWhenInvalid() {
+        Coupon active = activeCoupon(10, 0);
+        Coupon draft = draftCoupon();
+
+        assertThatThrownBy(active::activate).isInstanceOf(CouponActivationNotAllowedException.class);
+        assertThatThrownBy(draft::deactivate).isInstanceOf(CouponDeactivationNotAllowedException.class);
+    }
+
+    @Test
+    @DisplayName("ACTIVE 상태에서 issue는 발급 수량을 증가시킨다")
+    void issueIncrementsIssuedQuantity() {
+        Coupon coupon = activeCoupon(3, 1);
+
+        coupon.issue();
+
+        assertThat(coupon.getIssuedQuantity()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("ACTIVE가 아니면 issue는 예외가 발생한다")
+    void issueThrowsWhenNotActive() {
+        Coupon coupon = draftCoupon();
+
+        assertThatThrownBy(coupon::issue).isInstanceOf(CouponIssueNotAllowedException.class);
+    }
+
+    @Test
+    @DisplayName("발급 수량이 총 수량에 도달하면 issue는 품절 예외가 발생한다")
+    void issueThrowsWhenSoldOut() {
+        Coupon coupon = activeCoupon(2, 2);
+
+        assertThatThrownBy(coupon::issue).isInstanceOf(CouponSoldOutException.class);
+    }
+
+    @Test
+    @DisplayName("syncIssuedQuantity는 실제 발급량으로 덮어쓴다")
+    void syncIssuedQuantitySetsRealValue() {
+        Coupon coupon = activeCoupon(100, 10);
+
+        coupon.syncIssuedQuantity(42);
+
+        assertThat(coupon.getIssuedQuantity()).isEqualTo(42);
+    }
+
+    private Coupon draftCoupon() {
+        return Coupon.builder()
+                .uuid(UUID.randomUUID())
+                .couponName("초안 쿠폰")
+                .discountAmount(1000)
+                .minimumOrderAmount(5000)
+                .validFrom(LocalDateTime.now().plusDays(1))
+                .status(CouponStatus.DRAFT)
+                .totalQuantity(100)
+                .issuedQuantity(0)
+                .build();
+    }
+
+    private Coupon activeCoupon(int totalQuantity, int issuedQuantity) {
+        return Coupon.builder()
+                .uuid(UUID.randomUUID())
+                .couponName("활성 쿠폰")
+                .discountAmount(2000)
+                .minimumOrderAmount(7000)
+                .validFrom(LocalDateTime.now().minusDays(1))
+                .status(CouponStatus.ACTIVE)
+                .totalQuantity(totalQuantity)
+                .issuedQuantity(issuedQuantity)
+                .build();
+    }
+}
+

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/CreateProductUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/CreateProductUseCase.java
@@ -18,6 +18,7 @@ import dukku.product.boundedContext.product.out.ProductRepository;
 import dukku.product.global.event.ProductCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -35,12 +36,11 @@ public class CreateProductUseCase {
     private final ProductRepository productRepository;
     private final EventPublisher eventPublisher;
 
+    @Transactional
     public ProductDetailResponse execute(UUID sellerUuid, ProductCreateRequest request) {
-        if (!productSupport.existsByCategoryId(request.getCategoryId())) {
-            throw new ProductCategoryNotFoundException();
-        }
-
-        Category category = categoryRepository.getReferenceById(request.getCategoryId());
+        // payload 매핑에서 categoryName 접근 시 LazyInitializationException이 나지 않도록 즉시 로딩한다.
+        Category category = categoryRepository.findById(request.getCategoryId())
+                .orElseThrow(ProductCategoryNotFoundException::new);
         Product product = Product.create(
                 sellerUuid,
                 category,

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
@@ -1,14 +1,17 @@
 package dukku.product.boundedContext.product.app.usecase.product;
 
-import dukku.product.boundedContext.product.app.support.ProductMapper;
+import dukku.common.shared.product.dto.product.ProductDetailResponse;
+import dukku.common.shared.product.exception.ProductNotFoundException;
+import dukku.common.shared.user.dto.UserProfileResponse;
+import dukku.common.shared.user.out.UserApiClient;
 import dukku.product.boundedContext.product.app.cqrs.ProductStatsRedisSupport;
+import dukku.product.boundedContext.product.app.support.ProductMapper;
 import dukku.product.boundedContext.product.entity.Product;
 import dukku.product.boundedContext.product.entity.ProductSeller;
+import dukku.product.boundedContext.product.entity.ProductUser;
 import dukku.product.boundedContext.product.out.ProductRepository;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
-import dukku.common.shared.product.dto.product.ProductDetailResponse;
-import dukku.common.shared.product.exception.ProductNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -22,56 +25,76 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FindProductDetailUseCase {
-        private final ProductRepository productRepository;
-        private final ProductStatsRedisSupport productStatsRedisSupport;
-        private final ProductSellerRepository productSellerRepository;
-        private final ProductUserRepository productUserRepository;
+    private final ProductRepository productRepository;
+    private final ProductStatsRedisSupport productStatsRedisSupport;
+    private final ProductSellerRepository productSellerRepository;
+    private final ProductUserRepository productUserRepository;
+    private final UserApiClient userApiClient;
 
-        @Transactional
-        public ProductDetailResponse execute(UUID productUuid) {
-                log.info("[FindProductDetailUseCase] 상품 상세 조회 시작. productUuid={}", productUuid);
+    @Transactional
+    public ProductDetailResponse execute(UUID productUuid) {
+        log.info("[FindProductDetailUseCase] 상품 상세 조회 시작. productUuid={}", productUuid);
 
-                Product product = productRepository.findByUuidWithImagesAndCategory(productUuid)
-                                .or(() -> {
-                                        log.warn("[FindProductDetailUseCase] 페치 조인 쿼리로 상품 조회 실패. 기본 조회(findByUuid)를 시도합니다. productUuid={}",
-                                                        productUuid);
-                                        return productRepository.findByUuid(productUuid);
-                                })
-                                .orElseThrow(() -> {
-                                        log.error("[FindProductDetailUseCase] 어떤 방식으로도 상품을 찾을 수 없습니다. productUuid={}",
-                                                        productUuid);
-                                        return new ProductNotFoundException();
-                                });
+        Product product = productRepository.findByUuidWithImagesAndCategory(productUuid)
+                .or(() -> {
+                    log.warn("[FindProductDetailUseCase] 패치 조인 쿼리로 상품 조회 실패. 기본 조회(findByUuid)를 시도합니다. productUuid={}",
+                            productUuid);
+                    return productRepository.findByUuid(productUuid);
+                })
+                .orElseThrow(() -> {
+                    log.error("[FindProductDetailUseCase] 어떤 방식으로도 상품을 찾을 수 없습니다. productUuid={}", productUuid);
+                    return new ProductNotFoundException();
+                });
 
-                log.info("[FindProductDetailUseCase] 상품 조회 성공. title={}, sellerUuid={}", product.getTitle(),
-                                product.getSellerUuid());
+        log.info("[FindProductDetailUseCase] 상품 조회 성공. title={}, sellerUuid={}", product.getTitle(),
+                product.getSellerUuid());
 
-                productStatsRedisSupport.incrementView(product.getId());
+        productStatsRedisSupport.incrementView(product.getId());
 
-                // 상점 정보 조회: 만약 이벤트 유실이나 레거시 유저 등으로 인해 ProductSeller가 없다면 즉시 생성한다 (데이터 정합성 복구 /
-                // Fallback)
-                ProductSeller seller = productSellerRepository.findByUserUuid(product.getSellerUuid())
-                                .orElseGet(() -> {
-                                        log.warn("[FindProductDetailUseCase] 상점 정보(ProductSeller)가 존재하지 않아 자동 생성합니다. userUuid={}, productUuid={}",
-                                                        product.getSellerUuid(), productUuid);
-                                        return productSellerRepository.save(ProductSeller
-                                                        .create(product.getSellerUuid(), "반가워요! 내 상점입니다."));
-                                });
+        // 상점 정보 조회: 이벤트 지연/누락으로 ProductSeller가 없으면 즉시 생성
+        ProductSeller seller = productSellerRepository.findByUserUuid(product.getSellerUuid())
+                .orElseGet(() -> {
+                    log.warn("[FindProductDetailUseCase] 상점 정보(ProductSeller)가 없어 자동 생성합니다. userUuid={}, productUuid={}",
+                            product.getSellerUuid(), productUuid);
+                    return productSellerRepository.save(ProductSeller.create(product.getSellerUuid(), "반가워요! 내 상점입니다."));
+                });
 
-                log.info("[FindProductDetailUseCase] 상점 정보 확보 성공. sellerUuid={}", seller.getUserUuid());
+        log.info("[FindProductDetailUseCase] 상점 정보 조회 성공. sellerUserUuid={}", seller.getUserUuid());
 
-                String nickname = productUserRepository.findById(seller.getUserUuid())
-                                .map(user -> user.getNickname())
-                                .filter(StringUtils::hasText)
-                                .orElseGet(() -> {
-                                        log.warn("[FindProductDetailUseCase] 유저 정보(ProductUser)가 존재하지 않아 폴백 닉네임을 사용합니다. userUuid={}",
-                                                        seller.getUserUuid());
-                                        // 유저 정보가 없더라도 상세 페이지는 보여주기 위해 임시 닉네임 반환 (필요시 DB에 저장할수도 있음)
-                                        return "이름없음";
-                                });
+        String nickname = resolveNicknameWithBackfill(seller.getUserUuid());
 
-                log.info("[FindProductDetailUseCase] 최종 조회 완료. nickname={}", nickname);
+        log.info("[FindProductDetailUseCase] 최종 조회 완료. nickname={}", nickname);
 
-                return ProductMapper.toDetail(product, seller, nickname);
+        return ProductMapper.toDetail(product, seller, nickname);
+    }
+
+    private String resolveNicknameWithBackfill(UUID userUuid) {
+        return productUserRepository.findById(userUuid)
+                .map(ProductUser::getNickname)
+                .filter(StringUtils::hasText)
+                .orElseGet(() -> fetchAndBackfillNickname(userUuid));
+    }
+
+    private String fetchAndBackfillNickname(UUID userUuid) {
+        try {
+            UserProfileResponse profile = userApiClient.getUserProfile(userUuid);
+            String nickname = profile == null ? null : profile.getNickname();
+            if (!StringUtils.hasText(nickname)) {
+                return "이름없음";
+            }
+
+            if (!productUserRepository.existsById(userUuid)) {
+                try {
+                    productUserRepository.save(ProductUser.create(userUuid, nickname));
+                } catch (Exception e) {
+                    log.warn("[FindProductDetailUseCase] ProductUser 보정 저장 실패. userUuid={}", userUuid, e);
+                }
+            }
+
+            return nickname;
+        } catch (Exception e) {
+            log.warn("[FindProductDetailUseCase] 유저 프로필 조회 실패로 기본 닉네임 사용. userUuid={}", userUuid, e);
+            return "이름없음";
         }
+    }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
@@ -9,38 +9,69 @@ import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
 import dukku.common.shared.product.dto.product.ProductDetailResponse;
 import dukku.common.shared.product.exception.ProductNotFoundException;
-import dukku.common.shared.product.exception.ProductSellerNotFoundException;
-import dukku.common.shared.product.exception.ProductUserNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FindProductDetailUseCase {
-    private final ProductRepository productRepository;
-    private final ProductStatsRedisSupport productStatsRedisSupport;
-    private final ProductSellerRepository productSellerRepository;
-    private final ProductUserRepository productUserRepository;
+        private final ProductRepository productRepository;
+        private final ProductStatsRedisSupport productStatsRedisSupport;
+        private final ProductSellerRepository productSellerRepository;
+        private final ProductUserRepository productUserRepository;
 
-    public ProductDetailResponse execute(UUID productUuid) {
-        Product product = productRepository.findByUuidWithImagesAndCategory(productUuid)
-                .orElseThrow(ProductNotFoundException::new);
+        @Transactional
+        public ProductDetailResponse execute(UUID productUuid) {
+                log.info("[FindProductDetailUseCase] 상품 상세 조회 시작. productUuid={}", productUuid);
 
-        productStatsRedisSupport.incrementView(product.getId());
+                Product product = productRepository.findByUuidWithImagesAndCategory(productUuid)
+                                .or(() -> {
+                                        log.warn("[FindProductDetailUseCase] 페치 조인 쿼리로 상품 조회 실패. 기본 조회(findByUuid)를 시도합니다. productUuid={}",
+                                                        productUuid);
+                                        return productRepository.findByUuid(productUuid);
+                                })
+                                .orElseThrow(() -> {
+                                        log.error("[FindProductDetailUseCase] 어떤 방식으로도 상품을 찾을 수 없습니다. productUuid={}",
+                                                        productUuid);
+                                        return new ProductNotFoundException();
+                                });
 
-        ProductSeller seller = productSellerRepository.findByUserUuid(product.getSellerUuid())
-                .orElseThrow(ProductSellerNotFoundException::new);
+                log.info("[FindProductDetailUseCase] 상품 조회 성공. title={}, sellerUuid={}", product.getTitle(),
+                                product.getSellerUuid());
 
-        String nickname = productUserRepository.findById(seller.getUserUuid())
-                .map(user -> user.getNickname())
-                .filter(StringUtils::hasText)
-                .orElseThrow(ProductUserNotFoundException::new);
+                productStatsRedisSupport.incrementView(product.getId());
 
-        return ProductMapper.toDetail(product, seller, nickname);
-    }
+                // 상점 정보 조회: 만약 이벤트 유실이나 레거시 유저 등으로 인해 ProductSeller가 없다면 즉시 생성한다 (데이터 정합성 복구 /
+                // Fallback)
+                ProductSeller seller = productSellerRepository.findByUserUuid(product.getSellerUuid())
+                                .orElseGet(() -> {
+                                        log.warn("[FindProductDetailUseCase] 상점 정보(ProductSeller)가 존재하지 않아 자동 생성합니다. userUuid={}, productUuid={}",
+                                                        product.getSellerUuid(), productUuid);
+                                        return productSellerRepository.save(ProductSeller
+                                                        .create(product.getSellerUuid(), "반가워요! 내 상점입니다."));
+                                });
+
+                log.info("[FindProductDetailUseCase] 상점 정보 확보 성공. sellerUuid={}", seller.getUserUuid());
+
+                String nickname = productUserRepository.findById(seller.getUserUuid())
+                                .map(user -> user.getNickname())
+                                .filter(StringUtils::hasText)
+                                .orElseGet(() -> {
+                                        log.warn("[FindProductDetailUseCase] 유저 정보(ProductUser)가 존재하지 않아 폴백 닉네임을 사용합니다. userUuid={}",
+                                                        seller.getUserUuid());
+                                        // 유저 정보가 없더라도 상세 페이지는 보여주기 위해 임시 닉네임 반환 (필요시 DB에 저장할수도 있음)
+                                        return "이름없음";
+                                });
+
+                log.info("[FindProductDetailUseCase] 최종 조회 완료. nickname={}", nickname);
+
+                return ProductMapper.toDetail(product, seller, nickname);
+        }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/UpdateProductUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/UpdateProductUseCase.java
@@ -42,10 +42,8 @@ public class UpdateProductUseCase {
         Category category = null;
 
         if (!product.getCategory().getId().equals(request.categoryId())) {
-            if (!categoryRepository.existsById(request.categoryId())) {
-                throw new ProductCategoryNotFoundException();
-            }
-            category = categoryRepository.getReferenceById(request.categoryId());
+            category = categoryRepository.findById(request.categoryId())
+                    .orElseThrow(ProductCategoryNotFoundException::new);
             isCategoryChanged = true;
         }
 

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopProductsUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopProductsUseCase.java
@@ -8,7 +8,6 @@ import dukku.product.boundedContext.product.out.ProductRepository;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.common.shared.product.dto.shop.ShopProductListResponse;
 import dukku.common.shared.product.dto.product.ProductListItemResponse;
-import dukku.common.shared.product.exception.ProductSellerNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Component;
@@ -21,33 +20,35 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class FindMyShopProductsUseCase {
 
-    private final ProductSellerRepository productSellerRepository;
-    private final ProductRepository productRepository;
+        private final ProductSellerRepository productSellerRepository;
+        private final ProductRepository productRepository;
 
-    @Transactional(readOnly = true)
-    public ShopProductListResponse execute(UUID userUuid, SaleStatus saleStatus, int page, int size) {
+        @Transactional
+        public ShopProductListResponse execute(UUID userUuid, SaleStatus saleStatus, int page, int size) {
 
-        Pageable pageable = PageRequest.of(
-                Math.max(page, 0),
-                Math.min(size, 50),
-                Sort.by(Sort.Direction.DESC, "createdAt")
-        );
+                Pageable pageable = PageRequest.of(
+                                Math.max(page, 0),
+                                Math.min(size, 50),
+                                Sort.by(Sort.Direction.DESC, "createdAt"));
 
-        // 내 상점: userUuid로 ProductSeller 찾고
-        ProductSeller seller = productSellerRepository.findByUserUuid(userUuid)
-                .orElseThrow(ProductSellerNotFoundException::new);
+                // 내 상점 조회: 만약 이벤트 유실이나 레거시 유저 등으로 인해 ProductSeller가 없다면 즉시 생성한다 (Defense in
+                // Depth / Fallback)
+                ProductSeller seller = productSellerRepository.findByUserUuid(userUuid)
+                                .orElseGet(() -> productSellerRepository
+                                                .save(ProductSeller.create(userUuid, "반가워요! 내 상점입니다.")));
 
-        // seller.userUuid == Product.sellerUuid
-        UUID sellerUserUuid = seller.getUserUuid();
+                // seller.userUuid == Product.sellerUuid
+                UUID sellerUserUuid = seller.getUserUuid();
 
-        Page<Product> result = (saleStatus == null)
-                ? productRepository.findBySellerUuidAndDeletedAtIsNull(sellerUserUuid, pageable)
-                : productRepository.findBySellerUuidAndSaleStatusAndDeletedAtIsNull(sellerUserUuid, saleStatus, pageable);
+                Page<Product> result = (saleStatus == null)
+                                ? productRepository.findBySellerUuidAndDeletedAtIsNull(sellerUserUuid, pageable)
+                                : productRepository.findBySellerUuidAndSaleStatusAndDeletedAtIsNull(sellerUserUuid,
+                                                saleStatus, pageable);
 
-        List<ProductListItemResponse> items = result.getContent().stream()
-                .map(ProductMapper::toListItem)
-                .toList();
+                List<ProductListItemResponse> items = result.getContent().stream()
+                                .map(ProductMapper::toListItem)
+                                .toList();
 
-        return ShopProductListResponse.from(result, items);
-    }
+                return ShopProductListResponse.from(result, items);
+        }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopUseCase.java
@@ -1,35 +1,67 @@
 package dukku.product.boundedContext.product.app.usecase.shop;
 
 import dukku.common.shared.product.dto.shop.ShopResponse;
+import dukku.common.shared.user.dto.UserProfileResponse;
+import dukku.common.shared.user.out.UserApiClient;
 import dukku.product.boundedContext.product.entity.ProductSeller;
+import dukku.product.boundedContext.product.entity.ProductUser;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FindMyShopUseCase {
 
     private final ProductSellerRepository productSellerRepository;
     private final ProductUserRepository productUserRepository;
+    private final UserApiClient userApiClient;
 
     @Transactional
     public ShopResponse execute(UUID userUuid) {
-        // 내 상점 조회: 만약 이벤트 유실이나 레거시 유저 등으로 인해 ProductSeller가 없다면 즉시 생성한다 (Defense in
-        // Depth / Fallback)
+        // 내 상점 조회: 이벤트 지연/누락으로 ProductSeller가 없으면 즉시 생성
         ProductSeller seller = productSellerRepository.findByUserUuid(userUuid)
                 .orElseGet(() -> productSellerRepository.save(ProductSeller.create(userUuid, "반가워요! 내 상점입니다.")));
 
-        String nickname = productUserRepository.findById(seller.getUserUuid())
-                .map(user -> user.getNickname())
-                .filter(StringUtils::hasText)
-                .orElseGet(() -> "이름없음");
+        String nickname = resolveNicknameWithBackfill(seller.getUserUuid());
 
         return ProductSeller.from(seller, nickname);
+    }
+
+    private String resolveNicknameWithBackfill(UUID userUuid) {
+        return productUserRepository.findById(userUuid)
+                .map(ProductUser::getNickname)
+                .filter(StringUtils::hasText)
+                .orElseGet(() -> fetchAndBackfillNickname(userUuid));
+    }
+
+    private String fetchAndBackfillNickname(UUID userUuid) {
+        try {
+            UserProfileResponse profile = userApiClient.getUserProfile(userUuid);
+            String nickname = profile == null ? null : profile.getNickname();
+            if (!StringUtils.hasText(nickname)) {
+                return "이름없음";
+            }
+
+            if (!productUserRepository.existsById(userUuid)) {
+                try {
+                    productUserRepository.save(ProductUser.create(userUuid, nickname));
+                } catch (Exception e) {
+                    log.warn("[FindMyShopUseCase] ProductUser 보정 저장 실패. userUuid={}", userUuid, e);
+                }
+            }
+
+            return nickname;
+        } catch (Exception e) {
+            log.warn("[FindMyShopUseCase] 유저 프로필 조회 실패로 기본 닉네임 사용. userUuid={}", userUuid, e);
+            return "이름없음";
+        }
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopUseCase.java
@@ -1,8 +1,6 @@
 package dukku.product.boundedContext.product.app.usecase.shop;
 
 import dukku.common.shared.product.dto.shop.ShopResponse;
-import dukku.common.shared.product.exception.ProductSellerNotFoundException;
-import dukku.common.shared.product.exception.ProductUserNotFoundException;
 import dukku.product.boundedContext.product.entity.ProductSeller;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
@@ -20,15 +18,17 @@ public class FindMyShopUseCase {
     private final ProductSellerRepository productSellerRepository;
     private final ProductUserRepository productUserRepository;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public ShopResponse execute(UUID userUuid) {
+        // 내 상점 조회: 만약 이벤트 유실이나 레거시 유저 등으로 인해 ProductSeller가 없다면 즉시 생성한다 (Defense in
+        // Depth / Fallback)
         ProductSeller seller = productSellerRepository.findByUserUuid(userUuid)
-                .orElseThrow(ProductSellerNotFoundException::new);
+                .orElseGet(() -> productSellerRepository.save(ProductSeller.create(userUuid, "반가워요! 내 상점입니다.")));
 
         String nickname = productUserRepository.findById(seller.getUserUuid())
                 .map(user -> user.getNickname())
                 .filter(StringUtils::hasText)
-                .orElseThrow(ProductUserNotFoundException::new);
+                .orElseGet(() -> "이름없음");
 
         return ProductSeller.from(seller, nickname);
     }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindShopUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindShopUseCase.java
@@ -2,7 +2,6 @@ package dukku.product.boundedContext.product.app.usecase.shop;
 
 import dukku.common.shared.product.dto.shop.ShopResponse;
 import dukku.common.shared.product.exception.ProductSellerNotFoundException;
-import dukku.common.shared.product.exception.ProductUserNotFoundException;
 import dukku.product.boundedContext.product.entity.ProductSeller;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
@@ -28,7 +27,7 @@ public class FindShopUseCase {
         String nickname = productUserRepository.findById(seller.getUserUuid())
                 .map(user -> user.getNickname())
                 .filter(StringUtils::hasText)
-                .orElseThrow(ProductUserNotFoundException::new);
+                .orElseGet(() -> "이름없음");
 
         return ProductSeller.from(seller, nickname);
     }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindShopUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindShopUseCase.java
@@ -2,33 +2,66 @@ package dukku.product.boundedContext.product.app.usecase.shop;
 
 import dukku.common.shared.product.dto.shop.ShopResponse;
 import dukku.common.shared.product.exception.ProductSellerNotFoundException;
+import dukku.common.shared.user.dto.UserProfileResponse;
+import dukku.common.shared.user.out.UserApiClient;
 import dukku.product.boundedContext.product.entity.ProductSeller;
+import dukku.product.boundedContext.product.entity.ProductUser;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FindShopUseCase {
 
     private final ProductSellerRepository productSellerRepository;
     private final ProductUserRepository productUserRepository;
+    private final UserApiClient userApiClient;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public ShopResponse execute(UUID shopUuid) {
         ProductSeller seller = productSellerRepository.findByUuid(shopUuid)
                 .orElseThrow(ProductSellerNotFoundException::new);
 
-        String nickname = productUserRepository.findById(seller.getUserUuid())
-                .map(user -> user.getNickname())
-                .filter(StringUtils::hasText)
-                .orElseGet(() -> "이름없음");
+        String nickname = resolveNicknameWithBackfill(seller.getUserUuid());
 
         return ProductSeller.from(seller, nickname);
+    }
+
+    private String resolveNicknameWithBackfill(UUID userUuid) {
+        return productUserRepository.findById(userUuid)
+                .map(ProductUser::getNickname)
+                .filter(StringUtils::hasText)
+                .orElseGet(() -> fetchAndBackfillNickname(userUuid));
+    }
+
+    private String fetchAndBackfillNickname(UUID userUuid) {
+        try {
+            UserProfileResponse profile = userApiClient.getUserProfile(userUuid);
+            String nickname = profile == null ? null : profile.getNickname();
+            if (!StringUtils.hasText(nickname)) {
+                return "이름없음";
+            }
+
+            if (!productUserRepository.existsById(userUuid)) {
+                try {
+                    productUserRepository.save(ProductUser.create(userUuid, nickname));
+                } catch (Exception e) {
+                    log.warn("[FindShopUseCase] ProductUser 보정 저장 실패. userUuid={}", userUuid, e);
+                }
+            }
+
+            return nickname;
+        } catch (Exception e) {
+            log.warn("[FindShopUseCase] 유저 프로필 조회 실패로 기본 닉네임 사용. userUuid={}", userUuid, e);
+            return "이름없음";
+        }
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/UpdateMyShopUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/UpdateMyShopUseCase.java
@@ -3,23 +3,28 @@ package dukku.product.boundedContext.product.app.usecase.shop;
 import dukku.common.shared.product.dto.shop.ShopResponse;
 import dukku.common.shared.product.dto.shop.UpdateShopRequest;
 import dukku.common.shared.product.exception.ProductSellerNotFoundException;
-import dukku.common.shared.product.exception.ProductUserNotFoundException;
+import dukku.common.shared.user.dto.UserProfileResponse;
+import dukku.common.shared.user.out.UserApiClient;
 import dukku.product.boundedContext.product.entity.ProductSeller;
+import dukku.product.boundedContext.product.entity.ProductUser;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UpdateMyShopUseCase {
 
     private final ProductSellerRepository productSellerRepository;
     private final ProductUserRepository productUserRepository;
+    private final UserApiClient userApiClient;
 
     @Transactional
     public ShopResponse execute(UUID userUuid, UpdateShopRequest request) {
@@ -31,11 +36,38 @@ public class UpdateMyShopUseCase {
             seller.changeIntro(request.getIntro());
         }
 
-        String nickname = productUserRepository.findById(seller.getUserUuid())
-                .map(user -> user.getNickname())
-                .filter(StringUtils::hasText)
-                .orElseThrow(ProductUserNotFoundException::new);
+        String nickname = resolveNicknameWithBackfill(seller.getUserUuid());
 
         return ProductSeller.from(seller, nickname);
+    }
+
+    private String resolveNicknameWithBackfill(UUID userUuid) {
+        return productUserRepository.findById(userUuid)
+                .map(ProductUser::getNickname)
+                .filter(StringUtils::hasText)
+                .orElseGet(() -> fetchAndBackfillNickname(userUuid));
+    }
+
+    private String fetchAndBackfillNickname(UUID userUuid) {
+        try {
+            UserProfileResponse profile = userApiClient.getUserProfile(userUuid);
+            String nickname = profile == null ? null : profile.getNickname();
+            if (!StringUtils.hasText(nickname)) {
+                return "이름없음";
+            }
+
+            if (!productUserRepository.existsById(userUuid)) {
+                try {
+                    productUserRepository.save(ProductUser.create(userUuid, nickname));
+                } catch (Exception e) {
+                    log.warn("[UpdateMyShopUseCase] ProductUser 보정 저장 실패. userUuid={}", userUuid, e);
+                }
+            }
+
+            return nickname;
+        } catch (Exception e) {
+            log.warn("[UpdateMyShopUseCase] 유저 프로필 조회 실패로 기본 닉네임 사용. userUuid={}", userUuid, e);
+            return "이름없음";
+        }
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductEventListener.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductEventListener.java
@@ -29,13 +29,11 @@ public class ProductEventListener {
     private final ReleaseProductReservationUseCase releaseProductReservationUseCase;
 
     private final ProductRepository productRepository;
-    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
-
+    // Kafka DTO 역직렬화 전략과 맞추기 위해 String 수신 대신 DTO 시그니처를 사용한다.
     // 1. 생성 동기화
     @KafkaListener(topics = "product.created", groupId = "${spring.application.name}-group")
-    public void syncCreate(String eventJson) {
+    public void syncCreate(ProductCreatedEvent event) {
         try {
-            ProductCreatedEvent event = objectMapper.readValue(eventJson, ProductCreatedEvent.class);
             Product product = productRepository.findById(event.productId())
                     .orElseThrow(); // Or handle gracefully
             saveToElasticSearchUseCase.execute(product, true);
@@ -46,9 +44,8 @@ public class ProductEventListener {
 
     // 2. 수정 동기화
     @KafkaListener(topics = "product.updated", groupId = "${spring.application.name}-group")
-    public void syncUpdate(String eventJson) {
+    public void syncUpdate(ProductUpdatedEvent event) {
         try {
-            ProductUpdatedEvent event = objectMapper.readValue(eventJson, ProductUpdatedEvent.class);
             log.info("상품 업데이트 동기화: id={}", event.productId());
 
             Product product = productRepository.findById(event.productId())
@@ -61,9 +58,8 @@ public class ProductEventListener {
 
     // 3. 삭제 동기화
     @KafkaListener(topics = "product.deleted", groupId = "${spring.application.name}-group")
-    public void syncDelete(String eventJson) {
+    public void syncDelete(ProductDeletedEvent event) {
         try {
-            ProductDeletedEvent event = objectMapper.readValue(eventJson, ProductDeletedEvent.class);
             productSyncFacade.syncProductToElasticsearch(event.productId().longValue());
         } catch (Exception e) {
             log.error("product.deleted 이벤트 처리 실패", e);
@@ -72,9 +68,8 @@ public class ProductEventListener {
 
     // 4. 통계 동기화 (배치 작업 후 실행)
     @KafkaListener(topics = "product.stats-updated", groupId = "${spring.application.name}-group")
-    public void syncStats(String eventJson) {
+    public void syncStats(ProductStatsBulkUpdatedEvent event) {
         try {
-            ProductStatsBulkUpdatedEvent event = objectMapper.readValue(eventJson, ProductStatsBulkUpdatedEvent.class);
             syncSearchProductStatsUseCase.execute(event.getStats());
         } catch (Exception e) {
             log.error("product.stats-updated 이벤트 처리 실패", e);
@@ -85,9 +80,8 @@ public class ProductEventListener {
      * 1. 결제 완료 -> 판매 확정 처리 위임
      */
     @KafkaListener(topics = "order.product-sale-confirmed", groupId = "${spring.application.name}-group")
-    public void handleOrderConfirmed(String eventJson) {
+    public void handleOrderConfirmed(OrderProductSaleConfirmedEvent event) {
         try {
-            OrderProductSaleConfirmedEvent event = objectMapper.readValue(eventJson, OrderProductSaleConfirmedEvent.class);
             log.info("판매 확정 처리 트리거: orderUuid={}", event.orderUuid());
 
             confirmProductSaleUseCase.execute(event.orderUuid(), event.productUuids());
@@ -100,9 +94,8 @@ public class ProductEventListener {
      * 2. 결제 실패/취소 -> 예약 해제 처리 위임
      */
     @KafkaListener(topics = "order.product-sale-released", groupId = "${spring.application.name}-group")
-    public void handleOrderReleased(String eventJson) {
+    public void handleOrderReleased(OrderProductSaleReleasedEvent event) {
         try {
-            OrderProductSaleReleasedEvent event = objectMapper.readValue(eventJson, OrderProductSaleReleasedEvent.class);
             log.info("예약 해제 처리 트리거: orderUuid={}", event.orderUuid());
 
             releaseProductReservationUseCase.execute(event.orderUuid(), event.productUuids());

--- a/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductUserEventListener.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductUserEventListener.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
@@ -27,17 +28,17 @@ public class ProductUserEventListener {
     public void handleDepositInitialized(UserDepositInitializedEvent event) {
         try {
             UUID userUuid = event.userUuid();
+            String nickname = StringUtils.hasText(event.nickname()) ? event.nickname() : "이름없음";
 
-            if (productUserRepository.existsById(userUuid)) {
-                return;
+            if (!productUserRepository.existsById(userUuid)) {
+                productUserRepository.save(ProductUser.create(userUuid, nickname));
             }
-
-            productUserRepository.save(ProductUser.create(userUuid, event.nickname()));
 
             // 상점 정보(ProductSeller)도 자동 생성
             if (!productSellerRepository.findByUserUuid(userUuid).isPresent()) {
                 productSellerRepository.save(ProductSeller.create(userUuid, "반가워요! 내 상점입니다."));
             }
+
             log.info("[UserDepositInitializedEvent] 상품 도메인 유저 초기화 완료. userUuid={}", userUuid);
         } catch (Exception e) {
             publishProductInitFailed(event, e);
@@ -49,5 +50,4 @@ public class ProductUserEventListener {
         eventPublisher.publish(new UserProductInitializationFailedEvent(event.userUuid(), reason));
         log.error("[UserDepositInitializedEvent] 상품 도메인 유저 초기화 실패. userUuid={}", event.userUuid(), cause);
     }
-
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductUserEventListener.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductUserEventListener.java
@@ -3,7 +3,9 @@ package dukku.product.boundedContext.product.in.listener;
 import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.common.shared.user.event.UserDepositInitializedEvent;
 import dukku.common.shared.user.event.UserProductInitializationFailedEvent;
+import dukku.product.boundedContext.product.entity.ProductSeller;
 import dukku.product.boundedContext.product.entity.ProductUser;
+import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +20,7 @@ import java.util.UUID;
 public class ProductUserEventListener {
 
     private final ProductUserRepository productUserRepository;
+    private final ProductSellerRepository productSellerRepository;
     private final EventPublisher eventPublisher;
 
     @KafkaListener(topics = "user.deposit-initialized", groupId = "${spring.application.name}-group")
@@ -30,6 +33,11 @@ public class ProductUserEventListener {
             }
 
             productUserRepository.save(ProductUser.create(userUuid, event.nickname()));
+
+            // 상점 정보(ProductSeller)도 자동 생성
+            if (!productSellerRepository.findByUserUuid(userUuid).isPresent()) {
+                productSellerRepository.save(ProductSeller.create(userUuid, "반가워요! 내 상점입니다."));
+            }
             log.info("[UserDepositInitializedEvent] 상품 도메인 유저 초기화 완료. userUuid={}", userUuid);
         } catch (Exception e) {
             publishProductInitFailed(event, e);

--- a/product/src/main/java/dukku/product/boundedContext/product/out/ProductRepository.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/out/ProductRepository.java
@@ -11,28 +11,26 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import javax.swing.text.html.Option;
-import java.util.List;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ProductRepository extends JpaRepository<Product, Integer>, CustomProductRepository {
     @Query("""
-        select p.id
-        from Product p
-        where p.uuid = :productUuid
-          and p.deletedAt is null
-        """)
+            select p.id
+            from Product p
+            where p.uuid = :productUuid
+              and p.deletedAt is null
+            """)
     Optional<Integer> findIdByUuidAndDeletedAtIsNull(UUID productUuid);
 
     @Query("""
-select distinct p
-from Product p
-left join fetch p.images i
-left join fetch p.category c
-where p.uuid = :uuid
-""")
+            select distinct p
+            from Product p
+            left join fetch p.images i
+            left join fetch p.category c
+            where p.uuid = :uuid
+            """)
     Optional<Product> findByUuidWithImagesAndCategory(@Param("uuid") UUID uuid);
 
     Optional<Product> findByUuid(UUID productUuid);
@@ -49,20 +47,17 @@ where p.uuid = :uuid
 
     @EntityGraph(attributePaths = "images")
     Page<Product> findBySellerUuidAndSaleStatusAndDeletedAtIsNull(
-            UUID sellerUuid, SaleStatus saleStatus, Pageable pageable
-    );
+            UUID sellerUuid, SaleStatus saleStatus, Pageable pageable);
 
     // 1. 카테고리별 조회 (Fallback용) - 인덱스 필수! (category_id)
     Page<Product> findByCategory_IdInAndVisibilityStatusAndDeletedAtIsNull(
             List<Integer> categoryIds,
             VisibilityStatus visibilityStatus,
-            Pageable pageable
-    );
+            Pageable pageable);
 
     // 2. 전체 최신순 조회 (Fallback용)
     // 검색어가 들어와도 그냥 이걸로 돌려버립니다.
     Page<Product> findByVisibilityStatusAndDeletedAtIsNull(
             VisibilityStatus visibilityStatus,
-            Pageable pageable
-    );
+            Pageable pageable);
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/out/ProductSellerRepository.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/out/ProductSellerRepository.java
@@ -11,5 +11,7 @@ public interface ProductSellerRepository extends JpaRepository<ProductSeller, In
 
     Optional<ProductSeller> findByUuid(UUID shopUuid);
 
+    boolean existsByUserUuid(UUID userUuid);
+
     boolean existsByUuid(UUID sellerUuid);
 }

--- a/product/src/main/java/dukku/product/global/ProductInitData.java
+++ b/product/src/main/java/dukku/product/global/ProductInitData.java
@@ -230,7 +230,7 @@ public class ProductInitData {
         userMap.put(uId, uuid);
 
         // 2. ProductSeller 저장
-        if (!productSellerRepository.existsByUuid(uuid)) {
+        if (!productSellerRepository.existsByUserUuid(uuid)) {
             ProductSeller seller = ProductSeller.create(uuid, intro, sales, active);
             // 평점 등 추가 세팅이 필요하다면 여기서 setter 사용 (Entity에 setter가 있다면) 
             // 현재 create factory method는 rating을 초기화하므로, rating을 반영하려면 별도 메서드 필요하거나 무시

--- a/product/src/test/java/dukku/product/boundedContext/product/app/usecase/product/CreateProductUseCaseTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/app/usecase/product/CreateProductUseCaseTest.java
@@ -1,0 +1,111 @@
+package dukku.product.boundedContext.product.app.usecase.product;
+
+import dukku.common.global.event.DomainEvent;
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.product.dto.product.ProductCreateRequest;
+import dukku.common.shared.product.exception.ProductCategoryNotFoundException;
+import dukku.common.shared.product.type.ConditionStatus;
+import dukku.product.boundedContext.product.app.support.ProductSupport;
+import dukku.product.boundedContext.product.app.support.ProductTagSupport;
+import dukku.product.boundedContext.product.entity.Category;
+import dukku.product.boundedContext.product.entity.Product;
+import dukku.product.boundedContext.product.out.CategoryRepository;
+import dukku.product.boundedContext.product.out.ProductRepository;
+import dukku.product.global.event.ProductCreatedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CreateProductUseCaseTest {
+
+    @Mock
+    private ProductSupport productSupport;
+
+    @Mock
+    private ProductTagSupport productTagSupport;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @InjectMocks
+    private CreateProductUseCase useCase;
+
+    @Test
+    @DisplayName("카테고리가 없으면 ProductCategoryNotFoundException을 던진다")
+    void executeThrowsWhenCategoryDoesNotExist() {
+        ProductCreateRequest request = ProductCreateRequest.builder()
+                .categoryId(777)
+                .title("title")
+                .description("desc")
+                .price(1000L)
+                .shippingFee(0L)
+                .conditionStatus(ConditionStatus.SEALED)
+                .tags(List.of())
+                .build();
+
+        when(categoryRepository.findById(777)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> useCase.execute(UUID.randomUUID(), request))
+                .isInstanceOf(ProductCategoryNotFoundException.class);
+
+        verify(categoryRepository).findById(777);
+        verifyNoInteractions(productRepository, eventPublisher);
+    }
+
+    @Test
+    @DisplayName("정상 생성 시 카테고리를 즉시 로딩하고 created/sync 이벤트를 발행한다")
+    void executePublishesCreatedAndSyncEvents() {
+        UUID sellerUuid = UUID.randomUUID();
+        ProductCreateRequest request = ProductCreateRequest.builder()
+                .categoryId(3)
+                .title("title")
+                .description("desc")
+                .price(1000L)
+                .shippingFee(0L)
+                .conditionStatus(ConditionStatus.SEALED)
+                .tags(List.of())
+                .build();
+
+        Category category = org.mockito.Mockito.mock(Category.class);
+        when(category.getId()).thenReturn(3);
+        when(category.getDepth()).thenReturn(2);
+        when(category.getCategoryName()).thenReturn("디지털");
+
+        when(categoryRepository.findById(3)).thenReturn(Optional.of(category));
+        when(productTagSupport.getOrCreateTags(List.of())).thenReturn(List.of());
+        when(productRepository.save(any(Product.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        useCase.execute(sellerUuid, request);
+
+        ArgumentCaptor<DomainEvent> captor = ArgumentCaptor.forClass(DomainEvent.class);
+        verify(eventPublisher, times(2)).publish(captor.capture());
+        List<DomainEvent> published = captor.getAllValues();
+
+        assertThat(published.get(0)).isInstanceOf(ProductCreatedEvent.class);
+        assertThat(published.get(1).getTopic()).isEqualTo("product-events");
+        verify(categoryRepository).findById(3);
+    }
+}

--- a/product/src/test/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopUseCaseTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopUseCaseTest.java
@@ -1,0 +1,78 @@
+package dukku.product.boundedContext.product.app.usecase.shop;
+
+import dukku.common.shared.product.dto.shop.ShopResponse;
+import dukku.common.shared.user.dto.UserProfileResponse;
+import dukku.common.shared.user.out.UserApiClient;
+import dukku.product.boundedContext.product.entity.ProductSeller;
+import dukku.product.boundedContext.product.entity.ProductUser;
+import dukku.product.boundedContext.product.out.ProductSellerRepository;
+import dukku.product.boundedContext.product.out.ProductUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FindMyShopUseCaseTest {
+
+    @Mock
+    private ProductSellerRepository productSellerRepository;
+
+    @Mock
+    private ProductUserRepository productUserRepository;
+
+    @Mock
+    private UserApiClient userApiClient;
+
+    @InjectMocks
+    private FindMyShopUseCase useCase;
+
+    @Test
+    @DisplayName("ProductUser가 있으면 저장된 닉네임을 사용하고 외부 조회를 하지 않는다")
+    void usesExistingNicknameWithoutApiCall() {
+        UUID userUuid = UUID.randomUUID();
+        ProductSeller seller = ProductSeller.create(userUuid, "intro");
+        ProductUser productUser = ProductUser.create(userUuid, "stored-name");
+
+        when(productSellerRepository.findByUserUuid(userUuid)).thenReturn(Optional.of(seller));
+        when(productUserRepository.findById(userUuid)).thenReturn(Optional.of(productUser));
+
+        ShopResponse response = useCase.execute(userUuid);
+
+        assertThat(response.getNickname()).isEqualTo("stored-name");
+        verify(userApiClient, never()).getUserProfile(any());
+    }
+
+    @Test
+    @DisplayName("ProductUser가 없으면 User API 닉네임으로 백필 저장 후 반환한다")
+    void backfillsNicknameFromUserApiWhenMissingProductUser() {
+        UUID userUuid = UUID.randomUUID();
+        ProductSeller seller = ProductSeller.create(userUuid, "intro");
+
+        when(productSellerRepository.findByUserUuid(userUuid)).thenReturn(Optional.of(seller));
+        when(productUserRepository.findById(userUuid)).thenReturn(Optional.empty());
+        when(userApiClient.getUserProfile(userUuid))
+                .thenReturn(UserProfileResponse.builder().userUuid(userUuid).nickname("api-name").build());
+        when(productUserRepository.existsById(userUuid)).thenReturn(false);
+
+        ShopResponse response = useCase.execute(userUuid);
+
+        assertThat(response.getNickname()).isEqualTo("api-name");
+        ArgumentCaptor<ProductUser> captor = ArgumentCaptor.forClass(ProductUser.class);
+        verify(productUserRepository).save(captor.capture());
+        assertThat(captor.getValue().getNickname()).isEqualTo("api-name");
+    }
+}
+

--- a/product/src/test/java/dukku/product/boundedContext/product/app/usecase/shop/FindShopUseCaseTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/app/usecase/shop/FindShopUseCaseTest.java
@@ -1,0 +1,66 @@
+package dukku.product.boundedContext.product.app.usecase.shop;
+
+import dukku.common.shared.product.dto.shop.ShopResponse;
+import dukku.common.shared.user.dto.UserProfileResponse;
+import dukku.common.shared.user.out.UserApiClient;
+import dukku.product.boundedContext.product.entity.ProductSeller;
+import dukku.product.boundedContext.product.entity.ProductUser;
+import dukku.product.boundedContext.product.out.ProductSellerRepository;
+import dukku.product.boundedContext.product.out.ProductUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FindShopUseCaseTest {
+
+    @Mock
+    private ProductSellerRepository productSellerRepository;
+
+    @Mock
+    private ProductUserRepository productUserRepository;
+
+    @Mock
+    private UserApiClient userApiClient;
+
+    @InjectMocks
+    private FindShopUseCase useCase;
+
+    @Test
+    @DisplayName("ProductUser가 없으면 User API로 닉네임을 조회해 반환한다")
+    void resolvesNicknameFromUserApiWhenProductUserMissing() {
+        UUID userUuid = UUID.randomUUID();
+        UUID shopUuid = UUID.randomUUID();
+
+        ProductSeller seller = org.mockito.Mockito.mock(ProductSeller.class);
+        when(seller.getUserUuid()).thenReturn(userUuid);
+        when(seller.getUuid()).thenReturn(shopUuid);
+        when(seller.getIntro()).thenReturn("intro");
+        when(seller.getSalesCount()).thenReturn(0);
+        when(seller.getActiveListingCount()).thenReturn(0);
+        when(seller.getAverageRating()).thenReturn(java.math.BigDecimal.ZERO);
+        when(seller.getReviewCount()).thenReturn(0);
+
+        when(productSellerRepository.findByUuid(shopUuid)).thenReturn(Optional.of(seller));
+        when(productUserRepository.findById(userUuid)).thenReturn(Optional.empty());
+        when(productUserRepository.existsById(userUuid)).thenReturn(true);
+        when(userApiClient.getUserProfile(userUuid))
+                .thenReturn(UserProfileResponse.builder().userUuid(userUuid).nickname("seller-name").build());
+
+        ShopResponse response = useCase.execute(shopUuid);
+
+        assertThat(response.getNickname()).isEqualTo("seller-name");
+        verify(userApiClient).getUserProfile(userUuid);
+    }
+}
+

--- a/product/src/test/java/dukku/product/boundedContext/product/in/listener/ProductEventListenerTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/in/listener/ProductEventListenerTest.java
@@ -1,0 +1,117 @@
+package dukku.product.boundedContext.product.in.listener;
+
+import dukku.common.shared.order.event.OrderProductSaleConfirmedEvent;
+import dukku.common.shared.order.event.OrderProductSaleReleasedEvent;
+import dukku.common.shared.product.dto.cqrs.ProductStatDto;
+import dukku.common.shared.product.event.ProductStatsBulkUpdatedEvent;
+import dukku.product.boundedContext.product.app.cqrs.ProductSyncFacade;
+import dukku.product.boundedContext.product.app.cqrs.SaveToElasticSearchUseCase;
+import dukku.product.boundedContext.product.app.cqrs.SyncSearchProductStatsUseCase;
+import dukku.product.boundedContext.product.app.usecase.product.ConfirmProductSaleUseCase;
+import dukku.product.boundedContext.product.app.usecase.product.ReleaseProductReservationUseCase;
+import dukku.product.boundedContext.product.entity.Product;
+import dukku.product.boundedContext.product.out.ProductRepository;
+import dukku.product.global.event.ProductCreatedEvent;
+import dukku.product.global.event.ProductDeletedEvent;
+import dukku.product.global.event.ProductUpdatedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProductEventListenerTest {
+
+    @Mock
+    private ProductSyncFacade productSyncFacade;
+
+    @Mock
+    private SaveToElasticSearchUseCase saveToElasticSearchUseCase;
+
+    @Mock
+    private SyncSearchProductStatsUseCase syncSearchProductStatsUseCase;
+
+    @Mock
+    private ConfirmProductSaleUseCase confirmProductSaleUseCase;
+
+    @Mock
+    private ReleaseProductReservationUseCase releaseProductReservationUseCase;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ProductEventListener listener;
+
+    @Test
+    @DisplayName("product.created 이벤트 수신 시 상품을 조회해 ES 동기화를 호출한다")
+    void syncCreateDelegatesToSaveUseCase() {
+        Product product = mock(Product.class);
+        when(productRepository.findById(1)).thenReturn(Optional.of(product));
+
+        listener.syncCreate(new ProductCreatedEvent(1));
+
+        verify(saveToElasticSearchUseCase).execute(product, true);
+    }
+
+    @Test
+    @DisplayName("product.updated 이벤트 수신 시 category 변경 여부를 함께 전달한다")
+    void syncUpdateDelegatesWithCategoryChangedFlag() {
+        Product product = mock(Product.class);
+        when(productRepository.findById(2)).thenReturn(Optional.of(product));
+
+        listener.syncUpdate(new ProductUpdatedEvent(2, false));
+
+        verify(saveToElasticSearchUseCase).execute(product, false);
+    }
+
+    @Test
+    @DisplayName("product.deleted 이벤트 수신 시 삭제 동기화를 호출한다")
+    void syncDeleteDelegatesToSyncFacade() {
+        listener.syncDelete(new ProductDeletedEvent(3));
+
+        verify(productSyncFacade).syncProductToElasticsearch(3L);
+    }
+
+    @Test
+    @DisplayName("product.stats-updated 이벤트 수신 시 통계 동기화를 호출한다")
+    void syncStatsDelegatesToStatsUseCase() {
+        List<ProductStatDto> stats = List.of(new ProductStatDto(1, 10L, 2L, 1L));
+
+        listener.syncStats(new ProductStatsBulkUpdatedEvent(stats));
+
+        verify(syncSearchProductStatsUseCase).execute(stats);
+    }
+
+    @Test
+    @DisplayName("order.product-sale-confirmed 이벤트 수신 시 판매 확정 유스케이스를 호출한다")
+    void handleOrderConfirmedDelegatesToUseCase() {
+        UUID orderUuid = UUID.randomUUID();
+        List<UUID> productUuids = List.of(UUID.randomUUID());
+
+        listener.handleOrderConfirmed(new OrderProductSaleConfirmedEvent(orderUuid, productUuids));
+
+        verify(confirmProductSaleUseCase).execute(orderUuid, productUuids);
+    }
+
+    @Test
+    @DisplayName("order.product-sale-released 이벤트 수신 시 예약 해제 유스케이스를 호출한다")
+    void handleOrderReleasedDelegatesToUseCase() {
+        UUID orderUuid = UUID.randomUUID();
+        List<UUID> productUuids = List.of(UUID.randomUUID());
+
+        listener.handleOrderReleased(new OrderProductSaleReleasedEvent(orderUuid, productUuids));
+
+        verify(releaseProductReservationUseCase).execute(orderUuid, productUuids);
+    }
+}

--- a/product/src/test/java/dukku/product/boundedContext/product/in/listener/ProductUserEventListenerTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/in/listener/ProductUserEventListenerTest.java
@@ -1,0 +1,73 @@
+package dukku.product.boundedContext.product.in.listener;
+
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.user.event.UserDepositInitializedEvent;
+import dukku.product.boundedContext.product.entity.ProductSeller;
+import dukku.product.boundedContext.product.entity.ProductUser;
+import dukku.product.boundedContext.product.out.ProductSellerRepository;
+import dukku.product.boundedContext.product.out.ProductUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProductUserEventListenerTest {
+
+    @Mock
+    private ProductUserRepository productUserRepository;
+
+    @Mock
+    private ProductSellerRepository productSellerRepository;
+
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @InjectMocks
+    private ProductUserEventListener listener;
+
+    @Test
+    @DisplayName("ProductUser가 이미 있어도 ProductSeller가 없으면 상점을 생성한다")
+    void createsSellerEvenWhenUserAlreadyExists() {
+        UUID userUuid = UUID.randomUUID();
+        UserDepositInitializedEvent event = new UserDepositInitializedEvent(userUuid, "seller");
+
+        when(productUserRepository.existsById(userUuid)).thenReturn(true);
+        when(productSellerRepository.findByUserUuid(userUuid)).thenReturn(Optional.empty());
+
+        listener.handleDepositInitialized(event);
+
+        verify(productUserRepository, never()).save(any(ProductUser.class));
+        verify(productSellerRepository).save(any(ProductSeller.class));
+        verify(eventPublisher, never()).publish(any());
+    }
+
+    @Test
+    @DisplayName("이벤트 닉네임이 비어있으면 ProductUser를 이름없음으로 생성한다")
+    void savesDefaultNicknameWhenEventNicknameBlank() {
+        UUID userUuid = UUID.randomUUID();
+        UserDepositInitializedEvent event = new UserDepositInitializedEvent(userUuid, " ");
+
+        when(productUserRepository.existsById(userUuid)).thenReturn(false);
+        when(productSellerRepository.findByUserUuid(userUuid)).thenReturn(Optional.empty());
+
+        listener.handleDepositInitialized(event);
+
+        ArgumentCaptor<ProductUser> captor = ArgumentCaptor.forClass(ProductUser.class);
+        verify(productUserRepository).save(captor.capture());
+        assertThat(captor.getValue().getNickname()).isEqualTo("이름없음");
+    }
+}
+

--- a/user/src/main/java/dukku/user/global/UserInitData.java
+++ b/user/src/main/java/dukku/user/global/UserInitData.java
@@ -1,7 +1,6 @@
 package dukku.user.global;
-
-import dukku.user.boundedContext.user.entity.User;
 import dukku.common.shared.user.type.Role;
+import dukku.user.boundedContext.user.entity.User;
 import dukku.user.boundedContext.user.out.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,7 +36,6 @@ public class UserInitData {
                 }
             }
 
-            // [변경] 개발 환경에서 고정된 테스트 데이터 생성 (u1 ~ u20)
             if (isDev) {
                 createFixedUsers();
             }
@@ -47,30 +45,37 @@ public class UserInitData {
     private void createFixedUsers() {
         List<User> users = new ArrayList<>();
 
-        // 1. 관리자 (UUID ...0000)
-        users.add(createUser("admin@semicolon.com", "Admin123!", "admin", Role.ADMIN, 0));
+        addIfPresent(users, createUser("admin@semicolon.com", "Admin123!", "admin", Role.ADMIN, 0));
 
-        // 2. 일반 유저 (u1 ~ u20 -> UUID ...0001 ~ ...0020)
         for (int i = 1; i <= 20; i++) {
-            users.add(createUser("u" + i + "@company.com", "TestUser123!", "u" + i, Role.USER, i));
+            addIfPresent(users, createUser("u" + i + "@company.com", "TestUser123!", "u" + i, Role.USER, i));
+        }
+
+        if (users.isEmpty()) {
+            log.info("고정 테스트 사용자 생성 스킵: 이미 모든 계정이 존재함");
+            return;
         }
 
         userRepository.saveAll(users);
-        log.info("✅ 고정 테스트 유저 (admin, u1~u20) 생성 완료");
+        log.info("고정 테스트 사용자 {}명 생성 완료", users.size());
+    }
+
+    private void addIfPresent(List<User> users, User user) {
+        if (user != null) {
+            users.add(user);
+        }
     }
 
     private User createUser(String email, String rawPassword, String nickname, Role role, int seed) {
-        // 이미 존재하면 생성 안 함
         if (userRepository.findByEmail(email).isPresent()) {
             return null;
         }
 
-        // 고정 UUID 생성 (00000000-0000-0000-0000-0000000000xx)
         String uuidStr = String.format("00000000-0000-0000-0000-%012d", seed);
         java.util.UUID uuid = java.util.UUID.fromString(uuidStr);
 
         return User.builder()
-                .uuid(uuid) // SourceUser 필드에 직접 주입
+                .uuid(uuid)
                 .email(email)
                 .password(passwordEncoder.encode(rawPassword))
                 .nickname(nickname)


### PR DESCRIPTION
## PR 제목

[Product] 상품 판매 등록 시 발생하는 500 에러 수정 및 기동 이슈 수정 #251 #280

---

## 개요

#251 

**상품 판매 등록 시 발생하는 500 에러를 수정하여 정상적으로 상품 등록이 동작하게 수정**
- 로그 기준 주요 에러
```
org.hibernate.LazyInitializationException: Could not initialize proxy [Category#3] - no session
ConversionException: Failed to convert from JSON
Cannot deserialize value of type java.lang.String from Object value

```
- 현재 흐름에서 Category를 프록시(getReferenceById)로 들고 있다가, payload 생성 시 categoryName 접근으로 세션 밖 초기화가 발생하는 정황 확인.
- Kafka 리스너 경로에서는 record value 타입 기대(String)와 실제 전달 payload 형태 간 불일치 정황 확인.


#280 
**Product 모듈 기동 시 실패하는 현상 수정**
에러 메시지
```
Error creating bean with name 'entityManagerFactory' ... Unable to open JDBC Connection for DDL execution [FATAL: sorry, too many clients already]
Caused by: org.hibernate.exception.GenericJDBCException: Unable to open JDBC Connection for DDL execution [FATAL: sorry, too many clients already]
Caused by: org.postgresql.util.PSQLException: FATAL: sorry, too many clients already
```
원인
- 우리의 DB는 단일 머신 단일 인스턴스에 DB_NAME만 다르게 서비스 수만큼 DB를 띄우고 있음
- postgreSQL의 커넥션 한도는 서버 인스턴스 단위로 공유되고 디폴트 max 사이즈가 100인데, 이 사이즈를 초과해 커넥션 풀을 잡으려고 시도해 이슈가 발생

당시 세팅
```
hikari:
      minimum-idle: 5
      maximum-pool-size: 30
      idle-timeout: 30000
      connection-timeout: 30000
      max-lifetime: 1800000
```

- hikari는 커넥션 풀을 점유하고, idle로 유지되다가 연결이 발생할 때 재사용
- 시작 시 idle 사이즈로 시작해서 부하 상황에 maximum-pool-size까지 확장
- 점유 사이즈가 크게 잡혀 있어서 동시 부하 상황에서 한번 풀 사이즈가 늘어난 뒤 부하가 지속
- 부하로 인해 커넥션 한도를 초과해 발생한 이슈
- 터진 모듈은 product인데, product 모듈은 기동시 부하를 크게 주는 초기화 로직을 실행
- DDL 실행 중 부하가 지속되어 idle로 돌아가지 못하고 커넥션 풀이 확장된 상태를 유지해 문제가 된 것으로 예

---

## 상세 내용

caf2f12e product: 상품 상세/상점 조회 404 방어 및 복원력 강화
950d1d65 product: 유저 초기화 시 상점 자동 생성 + 상세 조회 폴백 문구 고도화
23d1b736 product: 상점 관련 로직 누락 방지 + 테스트 보완
9e7ae5cf product: ProductInitData 상점 중복 생성 조건 수정
acc4ebf3 common: 회원가입 닉네임 검증 규칙 강화
2156621c common: 공통 DB 풀/DDL 설정을 환경변수화
b0087694 user: 개발용 고정 사용자 시드 idempotent 처리
4614453e product: 상점 조회 시 유저 닉네임 보정 로직 강화
469b4ee5 test(product): 상점 조회/유저 초기화 보정 시나리오 추가
148ed139 coupon: 쿠폰 생성 응답에 저장 결과 반영
be91fdb5 test(coupon): 쿠폰 생성/상태 전이 단위 테스트 추가


---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [x] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [x] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
