### PR TITLE
feat(product): ES 재색인 실행 경로 및 동기화 내구성 강화

### DIFF
--- a/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/ReindexAllProductsUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/ReindexAllProductsUseCase.java
@@ -1,0 +1,66 @@
+package dukku.product.boundedContext.product.app.cqrs;
+
+import dukku.product.boundedContext.product.entity.Product;
+import dukku.product.boundedContext.product.out.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReindexAllProductsUseCase {
+    private static final int BATCH_SIZE = 200;
+
+    private final ProductRepository productRepository;
+    private final SaveToElasticSearchUseCase saveToElasticSearchUseCase;
+
+    @Transactional(readOnly = true)
+    public void execute() {
+        int pageNo = 0;
+        int success = 0;
+        int fail = 0;
+
+        log.info("[Reindex] 전체 재색인 시작");
+
+        while (true) {
+            Pageable pageable = PageRequest.of(pageNo, BATCH_SIZE);
+            Page<Integer> idPage = productRepository.findActiveProductIds(pageable);
+
+            if (idPage.isEmpty()) {
+                break;
+            }
+
+            for (Integer productId : idPage.getContent()) {
+                try {
+                    Product product = productRepository.findByIdWithImagesAndCategory(productId)
+                            .orElse(null);
+
+                    if (product == null) {
+                        continue;
+                    }
+
+                    productRepository.preloadProductTagsByProductId(productId);
+                    product.getTagNames();
+                    saveToElasticSearchUseCase.execute(product, true);
+                    success++;
+                } catch (Exception e) {
+                    fail++;
+                    log.error("[Reindex] 상품 재색인 실패: productId={}", productId, e);
+                }
+            }
+
+            if (!idPage.hasNext()) {
+                break;
+            }
+
+            pageNo++;
+        }
+
+        log.info("[Reindex] 전체 재색인 완료: success={}, fail={}", success, fail);
+    }
+}

--- a/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/SaveToElasticSearchUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/SaveToElasticSearchUseCase.java
@@ -22,13 +22,16 @@ import java.util.List;
 public class SaveToElasticSearchUseCase {
     private final ProductSearchRepository productSearchRepository;
     private final CategoryRepository categoryRepository;
+    // 부분 업데이트(update)는 Repository가 아니라 Operations가 담당
     private final ElasticsearchOperations elasticsearchOperations;
 
+    // 생성 시 편의 메서드 (Create)
     @Transactional(readOnly = true)
     public void execute(Product product) {
         execute(product, true);
     }
 
+    // 수정 시 메인 메서드 (Update)
     @Transactional(readOnly = true)
     public void execute(Product product, boolean isCategoryUpdated) {
         if (isCategoryUpdated) {
@@ -38,6 +41,7 @@ public class SaveToElasticSearchUseCase {
         updatePartialDocument(product);
     }
 
+    // [Case 1] 전체 저장 (Repository 사용)
     private void saveFullDocument(Product product) {
         List<Integer> categoryPathIds = categoryRepository.findCategoryPathIds(product.getCategory().getId());
         String thumbnail = getThumbnailUrl(product);
@@ -65,10 +69,12 @@ public class SaveToElasticSearchUseCase {
                 .tags(product.getTagNames())
                 .build();
 
+        // 전체 저장은 Repository가 편합니다.
         productSearchRepository.save(document);
         log.info("[ES 동기화] 전체 저장 완료. productId={}", product.getId());
     }
 
+    // [Case 2] 부분 업데이트 (ElasticsearchOperations 사용)
     private void updatePartialDocument(Product product) {
         String docId = String.valueOf(product.getId());
 
@@ -98,6 +104,7 @@ public class SaveToElasticSearchUseCase {
                 .withDocAsUpsert(true)
                 .build();
 
+        // getIndexCoordinatesFor()를 사용해 인덱스 정보를 추출해서 전달
         elasticsearchOperations.update(
                 updateQuery,
                 elasticsearchOperations.getIndexCoordinatesFor(ProductDocument.class)

--- a/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/SaveToElasticSearchUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/SaveToElasticSearchUseCase.java
@@ -22,27 +22,22 @@ import java.util.List;
 public class SaveToElasticSearchUseCase {
     private final ProductSearchRepository productSearchRepository;
     private final CategoryRepository categoryRepository;
-
-    // 부분 업데이트(update)는 Repository가 아니라 Operations가 담당
     private final ElasticsearchOperations elasticsearchOperations;
 
-    // 생성 시 편의 메서드 (Create)
     @Transactional(readOnly = true)
     public void execute(Product product) {
         execute(product, true);
     }
 
-    // 수정 시 메인 메서드 (Update)
     @Transactional(readOnly = true)
     public void execute(Product product, boolean isCategoryUpdated) {
         if (isCategoryUpdated) {
             saveFullDocument(product);
-        } else {
-            updatePartialDocument(product);
+            return;
         }
+        updatePartialDocument(product);
     }
 
-    // [Case 1] 전체 저장 (Repository 사용)
     private void saveFullDocument(Product product) {
         List<Integer> categoryPathIds = categoryRepository.findCategoryPathIds(product.getCategory().getId());
         String thumbnail = getThumbnailUrl(product);
@@ -70,14 +65,19 @@ public class SaveToElasticSearchUseCase {
                 .tags(product.getTagNames())
                 .build();
 
-        // 전체 저장은 Repository가 편합니다.
         productSearchRepository.save(document);
-        log.info("전체 동기화 완료: 제품 ID={}", product.getId());
+        log.info("[ES 동기화] 전체 저장 완료. productId={}", product.getId());
     }
 
-    // [Case 2] 부분 업데이트 (ElasticsearchOperations 사용)
     private void updatePartialDocument(Product product) {
         String docId = String.valueOf(product.getId());
+
+        if (!productSearchRepository.existsById(docId)) {
+            log.warn("[ES 동기화] 부분 업데이트 대상 문서 없음 -> 전체 저장으로 전환. productId={}", product.getId());
+            saveFullDocument(product);
+            return;
+        }
+
         String thumbnail = getThumbnailUrl(product);
         int sortPriority = (product.getSaleStatus() == SaleStatus.SOLD_OUT) ? 1 : 0;
 
@@ -93,19 +93,17 @@ public class SaveToElasticSearchUseCase {
         document.put("thumbnailImageUrl", thumbnail);
         document.put("tags", product.getTagNames());
 
-        // deletedAt 등 변경 가능성 있는 다른 필드도 필요하면 추가
         UpdateQuery updateQuery = UpdateQuery.builder(docId)
                 .withDocument(document)
                 .withDocAsUpsert(true)
                 .build();
 
-        // getIndexCoordinatesFor()를 사용해 인덱스 정보를 추출해서 전달
         elasticsearchOperations.update(
                 updateQuery,
                 elasticsearchOperations.getIndexCoordinatesFor(ProductDocument.class)
         );
 
-        log.info("부분 동기화 완료: 제품 ID={}", product.getId());
+        log.info("[ES 동기화] 부분 업데이트 완료. productId={}", product.getId());
     }
 
     private String getThumbnailUrl(Product product) {

--- a/product/src/main/java/dukku/product/boundedContext/product/app/facade/ProductFacade.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/facade/ProductFacade.java
@@ -2,9 +2,17 @@ package dukku.product.boundedContext.product.app.facade;
 
 import dukku.common.shared.product.dto.cqrs.ProductSearchRequest;
 import dukku.common.shared.product.dto.cqrs.ProductSortType;
-import dukku.common.shared.product.dto.product.*;
+import dukku.common.shared.product.dto.product.CategoryCreateResponse;
+import dukku.common.shared.product.dto.product.ProductDetailResponse;
+import dukku.common.shared.product.dto.product.ProductListItemResponse;
+import dukku.common.shared.product.dto.product.ProductListResponse;
+import dukku.common.shared.product.dto.product.ProductReserveRequest;
 import dukku.product.boundedContext.product.app.cqrs.SearchProductUseCase;
-import dukku.product.boundedContext.product.app.usecase.product.*;
+import dukku.product.boundedContext.product.app.usecase.product.FindCategoryListUseCase;
+import dukku.product.boundedContext.product.app.usecase.product.FindFeaturedProductsUseCase;
+import dukku.product.boundedContext.product.app.usecase.product.FindProductDetailUseCase;
+import dukku.product.boundedContext.product.app.usecase.product.FindProductListUseCase;
+import dukku.product.boundedContext.product.app.usecase.product.ReserveProductUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -30,21 +38,21 @@ public class ProductFacade {
     }
 
     public List<ProductListItemResponse> findFeatured(int size) {
-        // 1. 인기순(LIKES) 검색 조건 생성
         ProductSearchRequest request = new ProductSearchRequest();
         request.setSortType(ProductSortType.LIKES);
-        // 키워드나 카테고리 없이 sortType만 세팅하면 전체 상품 대상 랭킹이 됨
 
         Pageable pageable = PageRequest.of(0, size);
 
         try {
-            // 2. ES 조회 시도
-            return searchProductUseCase.searchProducts(request, pageable)
-                    .getItems();
+            List<ProductListItemResponse> items = searchProductUseCase.searchProducts(request, pageable).getItems();
+            if (items.isEmpty()) {
+                log.warn("상품 조회 소스=DB 폴백 (featured, empty-result), size={}", size);
+                return findFeaturedProductsUseCase.execute(size);
+            }
+            log.info("상품 조회 소스=ES (featured), size={}, resultCount={}", size, items.size());
+            return items;
         } catch (Exception e) {
-            log.error("Elasticsearch 인기 상품 조회 실패, DB로 폴백합니다.", e);
-
-            // 3. 실패 시 DB 조회
+            log.warn("상품 조회 소스=DB 폴백 (featured), size={}", size, e);
             return findFeaturedProductsUseCase.execute(size);
         }
     }
@@ -53,12 +61,18 @@ public class ProductFacade {
         Pageable pageable = PageRequest.of(Math.max(page, 0), Math.min(size, 50));
 
         try {
-            return searchProductUseCase.searchProducts(request, pageable);
+            ProductListResponse response = searchProductUseCase.searchProducts(request, pageable);
+            if (response.getItems() == null || response.getItems().isEmpty()) {
+                log.warn("상품 조회 소스=DB 폴백 (empty-result), page={}, size={}, categoryId={}",
+                        pageable.getPageNumber(), pageable.getPageSize(), request.getCategoryId());
+                return findProductListUseCase.execute(request.getCategoryId(), pageable);
+            }
+            log.info("상품 조회 소스=ES, page={}, size={}, categoryId={}, totalCount={}",
+                    pageable.getPageNumber(), pageable.getPageSize(), request.getCategoryId(), response.getTotalCount());
+            return response;
         } catch (Exception e) {
-            // ElasticsearchException 뿐만 아니라 모든 에러 대비 (안전하게 Exception)
-            log.error("Elasticsearch 검색 실패. request={}", request, e);
-
-            // ES조회 실패 시 DB에서 단순 조회
+            log.warn("상품 조회 소스=DB 폴백, page={}, size={}, categoryId={}",
+                    pageable.getPageNumber(), pageable.getPageSize(), request.getCategoryId(), e);
             return findProductListUseCase.execute(request.getCategoryId(), pageable);
         }
     }

--- a/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductEventListener.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/in/listener/ProductEventListener.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -27,32 +28,43 @@ public class ProductEventListener {
     private final SyncSearchProductStatsUseCase syncSearchProductStatsUseCase;
     private final ConfirmProductSaleUseCase confirmProductSaleUseCase;
     private final ReleaseProductReservationUseCase releaseProductReservationUseCase;
-
     private final ProductRepository productRepository;
+
     // Kafka DTO 역직렬화 전략과 맞추기 위해 String 수신 대신 DTO 시그니처를 사용한다.
     // 1. 생성 동기화
+    @Transactional(readOnly = true)
     @KafkaListener(topics = "product.created", groupId = "${spring.application.name}-group")
     public void syncCreate(ProductCreatedEvent event) {
         try {
-            Product product = productRepository.findById(event.productId())
-                    .orElseThrow(); // Or handle gracefully
+            log.info("product.created 이벤트 수신: productId={}", event.productId());
+            Product product = productRepository.findByIdWithImagesAndCategory(event.productId())
+                    .orElseThrow();
+            productRepository.preloadProductTagsByProductId(event.productId());
+            product.getTagNames();
             saveToElasticSearchUseCase.execute(product, true);
+            log.info("product.created 이벤트 처리 완료: productId={}", event.productId());
         } catch (Exception e) {
-            log.error("product.created 이벤트 처리 실패", e);
+            log.error("product.created 이벤트 처리 실패: productId={}", event.productId(), e);
+            throw e;
         }
     }
 
     // 2. 수정 동기화
+    @Transactional(readOnly = true)
     @KafkaListener(topics = "product.updated", groupId = "${spring.application.name}-group")
     public void syncUpdate(ProductUpdatedEvent event) {
         try {
-            log.info("상품 업데이트 동기화: id={}", event.productId());
-
-            Product product = productRepository.findById(event.productId())
+            log.info("product.updated 이벤트 수신: productId={}, categoryChanged={}",
+                    event.productId(), event.isCategoryChanged());
+            Product product = productRepository.findByIdWithImagesAndCategory(event.productId())
                     .orElseThrow();
+            productRepository.preloadProductTagsByProductId(event.productId());
+            product.getTagNames();
             saveToElasticSearchUseCase.execute(product, event.isCategoryChanged());
+            log.info("product.updated 이벤트 처리 완료: productId={}", event.productId());
         } catch (Exception e) {
-            log.error("product.updated 이벤트 처리 실패", e);
+            log.error("product.updated 이벤트 처리 실패: productId={}", event.productId(), e);
+            throw e;
         }
     }
 
@@ -60,9 +72,12 @@ public class ProductEventListener {
     @KafkaListener(topics = "product.deleted", groupId = "${spring.application.name}-group")
     public void syncDelete(ProductDeletedEvent event) {
         try {
+            log.info("product.deleted 이벤트 수신: productId={}", event.productId());
             productSyncFacade.syncProductToElasticsearch(event.productId().longValue());
+            log.info("product.deleted 이벤트 처리 완료: productId={}", event.productId());
         } catch (Exception e) {
-            log.error("product.deleted 이벤트 처리 실패", e);
+            log.error("product.deleted 이벤트 처리 실패: productId={}", event.productId(), e);
+            throw e;
         }
     }
 
@@ -70,9 +85,13 @@ public class ProductEventListener {
     @KafkaListener(topics = "product.stats-updated", groupId = "${spring.application.name}-group")
     public void syncStats(ProductStatsBulkUpdatedEvent event) {
         try {
+            int size = event.getStats() == null ? 0 : event.getStats().size();
+            log.info("product.stats-updated 이벤트 수신: count={}", size);
             syncSearchProductStatsUseCase.execute(event.getStats());
+            log.info("product.stats-updated 이벤트 처리 완료: count={}", size);
         } catch (Exception e) {
             log.error("product.stats-updated 이벤트 처리 실패", e);
+            throw e;
         }
     }
 
@@ -82,11 +101,13 @@ public class ProductEventListener {
     @KafkaListener(topics = "order.product-sale-confirmed", groupId = "${spring.application.name}-group")
     public void handleOrderConfirmed(OrderProductSaleConfirmedEvent event) {
         try {
-            log.info("판매 확정 처리 트리거: orderUuid={}", event.orderUuid());
-
+            log.info("order.product-sale-confirmed 이벤트 수신: orderUuid={}, productCount={}",
+                    event.orderUuid(), event.productUuids() == null ? 0 : event.productUuids().size());
             confirmProductSaleUseCase.execute(event.orderUuid(), event.productUuids());
+            log.info("order.product-sale-confirmed 이벤트 처리 완료: orderUuid={}", event.orderUuid());
         } catch (Exception e) {
-            log.error("order.product-sale-confirmed 이벤트 처리 실패", e);
+            log.error("order.product-sale-confirmed 이벤트 처리 실패: orderUuid={}", event.orderUuid(), e);
+            throw e;
         }
     }
 
@@ -96,11 +117,13 @@ public class ProductEventListener {
     @KafkaListener(topics = "order.product-sale-released", groupId = "${spring.application.name}-group")
     public void handleOrderReleased(OrderProductSaleReleasedEvent event) {
         try {
-            log.info("예약 해제 처리 트리거: orderUuid={}", event.orderUuid());
-
+            log.info("order.product-sale-released 이벤트 수신: orderUuid={}, productCount={}",
+                    event.orderUuid(), event.productUuids() == null ? 0 : event.productUuids().size());
             releaseProductReservationUseCase.execute(event.orderUuid(), event.productUuids());
+            log.info("order.product-sale-released 이벤트 처리 완료: orderUuid={}", event.orderUuid());
         } catch (Exception e) {
-            log.error("order.product-sale-released 이벤트 처리 실패", e);
+            log.error("order.product-sale-released 이벤트 처리 실패: orderUuid={}", event.orderUuid(), e);
+            throw e;
         }
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/out/ProductRepository.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/out/ProductRepository.java
@@ -25,6 +25,14 @@ public interface ProductRepository extends JpaRepository<Product, Integer>, Cust
     Optional<Integer> findIdByUuidAndDeletedAtIsNull(UUID productUuid);
 
     @Query("""
+            select p.id
+            from Product p
+            where p.deletedAt is null
+            order by p.id asc
+            """)
+    Page<Integer> findActiveProductIds(Pageable pageable);
+
+    @Query("""
             select distinct p
             from Product p
             left join fetch p.images i
@@ -33,9 +41,29 @@ public interface ProductRepository extends JpaRepository<Product, Integer>, Cust
             """)
     Optional<Product> findByUuidWithImagesAndCategory(@Param("uuid") UUID uuid);
 
+    @Query("""
+            select distinct p
+            from Product p
+            left join fetch p.images i
+            left join fetch p.category c
+            where p.id = :id
+            """)
+    Optional<Product> findByIdWithImagesAndCategory(@Param("id") Integer id);
+
+    @Query("""
+            select pt.id
+            from ProductTag pt
+            join pt.tag t
+            where pt.product.id = :productId
+            """)
+    List<Long> preloadProductTagsByProductId(@Param("productId") Integer productId);
+
     Optional<Product> findByUuid(UUID productUuid);
 
     Optional<Product> findByUuidAndDeletedAtIsNull(UUID productUuid);
+
+    boolean existsBySellerUuidAndCategory_IdAndTitleAndPriceAndDeletedAtIsNull(
+            UUID sellerUuid, Integer categoryId, String title, Long price);
 
     List<Product> findAllByUuidIn(List<UUID> uuids);
 

--- a/product/src/main/java/dukku/product/global/ProductInitData.java
+++ b/product/src/main/java/dukku/product/global/ProductInitData.java
@@ -11,7 +11,9 @@ import dukku.product.boundedContext.product.entity.query.ProductDocument;
 import dukku.product.boundedContext.product.out.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -24,7 +26,7 @@ import java.util.*;
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
-@Order(2)
+@ConditionalOnProperty(name = "product.init.enabled", havingValue = "true", matchIfMissing = true)
 public class ProductInitData {
 
     private final ProductRepository productRepository;
@@ -32,6 +34,8 @@ public class ProductInitData {
     private final CategoryRepository categoryRepository;
     private final ProductUserRepository productUserRepository;
     private final ProductSearchRepository productSearchRepository;
+    @Value("${product.init.clear-es-on-startup:false}")
+    private boolean clearEsOnStartup;
 
     private final Map<String, UUID> userMap = new HashMap<>();
     private final Map<String, UUID> sellerMap = new HashMap<>();
@@ -50,6 +54,7 @@ public class ProductInitData {
     private static final String IMG_CAMERA = "https://images.unsplash.com/photo-1516035069371-29a1b244cc32?auto=format&fit=crop&q=80&w=500";
 
     @Bean
+    @Order(2)
     public CommandLineRunner initProducts() {
         return new CommandLineRunner() {
             @Override
@@ -57,12 +62,7 @@ public class ProductInitData {
             public void run(String... args) throws Exception {
                 log.info("🚀 [InitData] Data Initialization Started");
 
-                try {
-                    productSearchRepository.deleteAll();
-                    log.info("🗑️ Elasticsearch index cleared.");
-                } catch (Exception e) {
-                    log.warn("⚠️ Failed to clear Elasticsearch index: {}", e.getMessage());
-                }
+                clearSearchIndexIfNeeded();
 
                 userMap.clear();
                 sellerMap.clear();
@@ -77,6 +77,18 @@ public class ProductInitData {
                 log.info("✅ [InitData] Initialization Completed.");
             }
         };
+    }
+
+    private void clearSearchIndexIfNeeded() {
+        if (!clearEsOnStartup) {
+            return;
+        }
+        try {
+            productSearchRepository.deleteAll();
+            log.info("[InitData] Elasticsearch index cleared.");
+        } catch (Exception e) {
+            log.warn("[InitData] Failed to clear Elasticsearch index: {}", e.getMessage());
+        }
     }
 
     private void initCategoryHierarchy() {
@@ -246,6 +258,14 @@ public class ProductInitData {
         String categoryName = catNameMap.getOrDefault(catCode, "기타");
         Category category = categoryRepository.findByCategoryName(categoryName).orElseThrow(() -> new RuntimeException("Category not found: " + categoryName));
         UUID sellerUuid = sellerMap.get(sId);
+
+        boolean exists = productRepository.existsBySellerUuidAndCategory_IdAndTitleAndPriceAndDeletedAtIsNull(
+                sellerUuid, category.getId(), title, price);
+        if (exists) {
+            log.info("[InitData] 중복 상품 생성 스킵. sellerUuid={}, categoryId={}, title={}",
+                    sellerUuid, category.getId(), title);
+            return;
+        }
 
         Product product = Product.builder()
                 .sellerUuid(sellerUuid)

--- a/product/src/main/java/dukku/product/global/ProductReindexRunner.java
+++ b/product/src/main/java/dukku/product/global/ProductReindexRunner.java
@@ -1,0 +1,25 @@
+package dukku.product.global;
+
+import dukku.product.boundedContext.product.app.cqrs.ReindexAllProductsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Order(Ordered.LOWEST_PRECEDENCE)
+@ConditionalOnProperty(name = "product.reindex-on-startup", havingValue = "true")
+public class ProductReindexRunner implements CommandLineRunner {
+    private final ReindexAllProductsUseCase reindexAllProductsUseCase;
+
+    @Override
+    public void run(String... args) {
+        log.info("[ReindexRunner] product.reindex-on-startup=true 감지. 재색인을 수행합니다.");
+        reindexAllProductsUseCase.execute();
+    }
+}

--- a/product/src/main/resources/application-release.yml
+++ b/product/src/main/resources/application-release.yml
@@ -11,6 +11,12 @@ spring:
     hibernate:
       ddl-auto: validate
 
+product:
+  init:
+    enabled: false
+    clear-es-on-startup: false
+  reindex-on-startup: false
+
 springdoc:
   api-docs:
     enabled: false

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -21,6 +21,12 @@ spring:
     socket-timeout: 30s
     connection-timeout: 5s
 
+product:
+  init:
+    enabled: false
+    clear-es-on-startup: false
+  reindex-on-startup: false
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 작업 내용
- ReindexAllProductsUseCase ProductReindexRunner 추가
- product.init product.reindex-on-startup 설정 추가
- SaveToElasticSearchUseCase 문서 부재 시 full save fallback 추가
- ProductEventListener created updated 경로를 findByIdWithImagesAndCategory 기반으로 보강
- ProductRepository에 재색인 배치 조회 태그 preload 쿼리 추가
- SaveToElasticSearchUseCase 주석 복구

## 연관 이슈
- closes #291