### PR TITLE
test(product): ES 비의존 테스트 환경 및 단위 테스트 안정화

### DIFF
--- a/product/src/test/java/dukku/product/ApplicationTests.java
+++ b/product/src/test/java/dukku/product/ApplicationTests.java
@@ -1,8 +1,10 @@
 package dukku.product;
 
+import dukku.product.boundedContext.product.out.ProductSearchRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @SpringBootTest(properties = {
         "spring.profiles.active=test",
@@ -19,6 +21,8 @@ import org.springframework.test.context.ActiveProfiles;
 })
 @ActiveProfiles("test")
 class ApplicationTests {
+    @MockitoBean
+    private ProductSearchRepository productSearchRepository;
 
     @Test
     void contextLoads() {

--- a/product/src/test/java/dukku/product/boundedContext/product/app/usecase/product/CreateProductUseCaseTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/app/usecase/product/CreateProductUseCaseTest.java
@@ -96,7 +96,11 @@ class CreateProductUseCaseTest {
 
         when(categoryRepository.findById(3)).thenReturn(Optional.of(category));
         when(productTagSupport.getOrCreateTags(List.of())).thenReturn(List.of());
-        when(productRepository.save(any(Product.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(productRepository.save(any(Product.class))).thenAnswer(invocation -> {
+            Product saved = invocation.getArgument(0);
+            saved.prePersist();
+            return saved;
+        });
 
         useCase.execute(sellerUuid, request);
 

--- a/product/src/test/java/dukku/product/boundedContext/product/in/listener/ProductEventListenerTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/in/listener/ProductEventListenerTest.java
@@ -57,10 +57,13 @@ class ProductEventListenerTest {
     @DisplayName("product.created 이벤트 수신 시 상품을 조회해 ES 동기화를 호출한다")
     void syncCreateDelegatesToSaveUseCase() {
         Product product = mock(Product.class);
-        when(productRepository.findById(1)).thenReturn(Optional.of(product));
+        when(productRepository.findByIdWithImagesAndCategory(1)).thenReturn(Optional.of(product));
+        when(productRepository.preloadProductTagsByProductId(1)).thenReturn(List.of(1L));
+        when(product.getTagNames()).thenReturn(List.of("tag"));
 
         listener.syncCreate(new ProductCreatedEvent(1));
 
+        verify(productRepository).preloadProductTagsByProductId(1);
         verify(saveToElasticSearchUseCase).execute(product, true);
     }
 
@@ -68,10 +71,13 @@ class ProductEventListenerTest {
     @DisplayName("product.updated 이벤트 수신 시 category 변경 여부를 함께 전달한다")
     void syncUpdateDelegatesWithCategoryChangedFlag() {
         Product product = mock(Product.class);
-        when(productRepository.findById(2)).thenReturn(Optional.of(product));
+        when(productRepository.findByIdWithImagesAndCategory(2)).thenReturn(Optional.of(product));
+        when(productRepository.preloadProductTagsByProductId(2)).thenReturn(List.of(1L));
+        when(product.getTagNames()).thenReturn(List.of("tag"));
 
         listener.syncUpdate(new ProductUpdatedEvent(2, false));
 
+        verify(productRepository).preloadProductTagsByProductId(2);
         verify(saveToElasticSearchUseCase).execute(product, false);
     }
 

--- a/product/src/test/resources/application-test.yml
+++ b/product/src/test/resources/application-test.yml
@@ -46,3 +46,8 @@ crypto:
 toss:
   api:
     secret-key: test-key
+
+product:
+  init:
+    enabled: false
+  reindex-on-startup: false


### PR DESCRIPTION
## 작업 내용
- application-test.yml에 product init reindex 비활성 기본값 추가
- ApplicationTests에서 ProductSearchRepository MockitoBean 대체
- CreateProductUseCaseTest prePersist 호출 반영
- ProductEventListenerTest preload 경로 정렬

## 연관 이슈
- closes #293