### PR TITLE
[Product] ElasticSearch 인덱스 초기화 로직 개선 #297

### DIFF
--- a/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/DeleteProductSyncUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/DeleteProductSyncUseCase.java
@@ -1,29 +1,65 @@
 package dukku.product.boundedContext.product.app.cqrs;
 
-import dukku.common.shared.product.exception.ProductNotFoundException;
+import dukku.common.shared.product.type.VisibilityStatus;
+import dukku.product.boundedContext.product.entity.Product;
 import dukku.product.boundedContext.product.entity.query.ProductDocument;
+import dukku.product.boundedContext.product.out.ProductRepository;
 import dukku.product.boundedContext.product.out.ProductSearchRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DeleteProductSyncUseCase {
     private final ProductSearchRepository productSearchRepository;
+    private final ProductRepository productRepository;
 
     @Transactional(readOnly = true)
     public void deletedProductToElasticsearch(Long productId) {
-        // 3. Document 변환
-        // 이때 product의 visibilityStatus가 HIDDEN이거나 deletedAt이 있으면 그대로 ES 문서에 반영됨
-        ProductDocument document = productSearchRepository.findById(String.valueOf(productId))
-                .orElseThrow(ProductNotFoundException::new);
+        String documentId = String.valueOf(productId);
 
-        // 4. Elasticsearch 저장 (Upsert: 기존 ID가 있으면 덮어쓰기)
-        productSearchRepository.save(document);
+        Optional<ProductDocument> existingDocument = productSearchRepository.findById(documentId);
+        if (existingDocument.isEmpty()) {
+            log.info("Skip ES soft delete sync because document does not exist. productId={}", productId);
+            return;
+        }
 
-        log.info("제품을 ES에 성공적으로 동기화했습니다. ID: {}, 상태: {}", productId, document.getVisibilityStatus());
+        Optional<Product> product = productRepository.findById(productId.intValue());
+        LocalDateTime deletedAt = product.map(Product::getDeletedAt).orElse(LocalDateTime.now());
+
+        ProductDocument updatedDocument = toSoftDeleted(existingDocument.get(), deletedAt);
+        productSearchRepository.save(updatedDocument);
+
+        log.info("Soft-deleted product document in Elasticsearch. productId={}", productId);
+    }
+
+    private ProductDocument toSoftDeleted(ProductDocument source, LocalDateTime deletedAt) {
+        return ProductDocument.builder()
+                .id(source.getId())
+                .productUuid(source.getProductUuid())
+                .saleSortPriority(source.getSaleSortPriority())
+                .title(source.getTitle())
+                .description(source.getDescription())
+                .sellerUuid(source.getSellerUuid())
+                .categoryIds(source.getCategoryIds())
+                .saleStatus(source.getSaleStatus())
+                .visibilityStatus(VisibilityStatus.HIDDEN)
+                .price(source.getPrice())
+                .shippingFee(source.getShippingFee())
+                .viewCount(source.getViewCount())
+                .likeCount(source.getLikeCount())
+                .commentCount(source.getCommentCount())
+                .createdAt(source.getCreatedAt())
+                .thumbnailImageUrl(source.getThumbnailImageUrl())
+                .deletedAt(deletedAt)
+                .conditionStatus(source.getConditionStatus())
+                .tags(source.getTags())
+                .build();
     }
 }

--- a/product/src/main/java/dukku/product/global/ElasticsearchClearRunner.java
+++ b/product/src/main/java/dukku/product/global/ElasticsearchClearRunner.java
@@ -1,28 +1,30 @@
 package dukku.product.global;
 
-import dukku.product.boundedContext.product.app.cqrs.ReindexAllProductsUseCase;
 import dukku.product.boundedContext.product.out.ProductSearchRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@Order(Ordered.LOWEST_PRECEDENCE)
-@ConditionalOnProperty(name = "product.reindex-on-startup", havingValue = "true")
-public class ProductReindexRunner implements CommandLineRunner {
-    private final ReindexAllProductsUseCase reindexAllProductsUseCase;
+@Order(1)
+@ConditionalOnProperty(name = "product.clear-es-on-startup", havingValue = "true")
+public class ElasticsearchClearRunner implements CommandLineRunner {
+
     private final ProductSearchRepository productSearchRepository;
 
     @Override
     public void run(String... args) {
-        log.info("[ReindexRunner] ES 초기화 후 전체 재색인을 수행합니다.");
-        productSearchRepository.deleteAll();
-        reindexAllProductsUseCase.execute();
+        log.info("[ElasticsearchClearRunner] product.clear-es-on-startup=true 감지. ES 인덱스를 초기화합니다.");
+        try {
+            productSearchRepository.deleteAll();
+            log.info("[ElasticsearchClearRunner] ES 인덱스 초기화 완료.");
+        } catch (Exception e) {
+            log.warn("[ElasticsearchClearRunner] ES 인덱스 초기화 실패: {}", e.getMessage());
+        }
     }
 }

--- a/product/src/main/java/dukku/product/global/ProductInitData.java
+++ b/product/src/main/java/dukku/product/global/ProductInitData.java
@@ -11,7 +11,6 @@ import dukku.product.boundedContext.product.entity.query.ProductDocument;
 import dukku.product.boundedContext.product.out.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -34,8 +33,6 @@ public class ProductInitData {
     private final CategoryRepository categoryRepository;
     private final ProductUserRepository productUserRepository;
     private final ProductSearchRepository productSearchRepository;
-    @Value("${product.init.clear-es-on-startup:false}")
-    private boolean clearEsOnStartup;
 
     private final Map<String, UUID> userMap = new HashMap<>();
     private final Map<String, UUID> sellerMap = new HashMap<>();
@@ -62,8 +59,6 @@ public class ProductInitData {
             public void run(String... args) throws Exception {
                 log.info("🚀 [InitData] Data Initialization Started");
 
-                clearSearchIndexIfNeeded();
-
                 userMap.clear();
                 sellerMap.clear();
                 productMap.clear();
@@ -77,18 +72,6 @@ public class ProductInitData {
                 log.info("✅ [InitData] Initialization Completed.");
             }
         };
-    }
-
-    private void clearSearchIndexIfNeeded() {
-        if (!clearEsOnStartup) {
-            return;
-        }
-        try {
-            productSearchRepository.deleteAll();
-            log.info("[InitData] Elasticsearch index cleared.");
-        } catch (Exception e) {
-            log.warn("[InitData] Failed to clear Elasticsearch index: {}", e.getMessage());
-        }
     }
 
     private void initCategoryHierarchy() {

--- a/product/src/test/java/dukku/product/boundedContext/product/app/cqrs/DeleteProductSyncUseCaseTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/app/cqrs/DeleteProductSyncUseCaseTest.java
@@ -1,0 +1,74 @@
+package dukku.product.boundedContext.product.app.cqrs;
+
+import dukku.common.shared.product.type.VisibilityStatus;
+import dukku.product.boundedContext.product.entity.Product;
+import dukku.product.boundedContext.product.entity.query.ProductDocument;
+import dukku.product.boundedContext.product.out.ProductRepository;
+import dukku.product.boundedContext.product.out.ProductSearchRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteProductSyncUseCaseTest {
+
+    @Mock
+    private ProductSearchRepository productSearchRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private DeleteProductSyncUseCase useCase;
+
+    @Test
+    @DisplayName("Soft-deletes document when ES document exists")
+    void softDeleteWhenDocumentExists() {
+        LocalDateTime deletedAt = LocalDateTime.of(2026, 2, 25, 3, 0, 8);
+
+        ProductDocument existing = ProductDocument.builder()
+                .id("42")
+                .productUuid("019c8f6d-d692-7009-9300-f1241e7ad809")
+                .visibilityStatus(VisibilityStatus.VISIBLE)
+                .build();
+
+        Product product = org.mockito.Mockito.mock(Product.class);
+        when(product.getDeletedAt()).thenReturn(deletedAt);
+
+        when(productSearchRepository.findById("42")).thenReturn(Optional.of(existing));
+        when(productRepository.findById(42)).thenReturn(Optional.of(product));
+
+        useCase.deletedProductToElasticsearch(42L);
+
+        ArgumentCaptor<ProductDocument> captor = ArgumentCaptor.forClass(ProductDocument.class);
+        verify(productSearchRepository).save(captor.capture());
+
+        ProductDocument saved = captor.getValue();
+        assertThat(saved.getId()).isEqualTo("42");
+        assertThat(saved.getVisibilityStatus()).isEqualTo(VisibilityStatus.HIDDEN);
+        assertThat(saved.getDeletedAt()).isEqualTo(deletedAt);
+    }
+
+    @Test
+    @DisplayName("Skips sync when ES document is missing")
+    void skipWhenDocumentMissing() {
+        when(productSearchRepository.findById("42")).thenReturn(Optional.empty());
+
+        useCase.deletedProductToElasticsearch(42L);
+
+        verify(productRepository, never()).findById(42);
+        verify(productSearchRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+}


### PR DESCRIPTION
## PR 제목

[Product] ElasticSearch 인덱스 초기화 로직 개선 #297


---

## 개요

인덱스 초기화 시 유령 데이터가 발생지 않도록 개선
- 이전 개선에서 elasticsearch 초기화와 일반 초기화 로직을 분리하고 환경변수를 세팅
- elasticsearch 초기화와 인덱스 갱신이 덜 분리되어 db만 초기화하고 싶어 es초기화를 꺼버리면 인덱스 갱신도 되지 않음
- 저장은 DB, 표시는 ES 기준으로 이루어짐
- DB에 있는 데이터 초기화 후 새 데이터 생성 시 유령 ES 데이터가 남는 현상 발생

---

## 상세 내용

**ES 소프트 삭제 동기화 누락 및 예외 처리 보강**
SHA : d111898e1e0036657b92de561f9447f95cd1094a
- 삭제 이벤트 수신 시 ES 문서가 없으면 건너뛰는 방어 로직 추가
- DB에서 deletedAt을 조회하여 ES 문서에 정확히 반영
- visibilityStatus를 HIDDEN으로 설정하는 toSoftDeleted 메서드 분리
- 기존 코드가 ProductNotFoundException을 던지던 문제 제거

**ES 초기화 책임을 init 설정에서 분리하여 독립 Runner로 재설계**
SHA : 77465f38c5d20839ebd5094cfcbc2654ac4b2035
- ProductInitData에서 clearSearchIndexIfNeeded 제거
  - init.enabled=false일 때 clear-es 설정이 무시되는 구조적 문제 해결
- ElasticsearchClearRunner 신규 추가
  - product.clear-es-on-startup=true 시 독립적으로 ES 인덱스 초기화
  - init 활성화 여부와 완전히 독립된 제어 가능
- ProductReindexRunner에 ES 전체 초기화 후 재색인 적용
  - deleteAll() 선행 후 DB 기준 전체 upsert로 유령 도큐먼트 자동 제거

**DeleteProductSyncUseCase 단위 테스트 추가**
SHA : 6308c2d49130f50252da8cea50a28fb0cd03960f



---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [x] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
