### PR TITLE
[User] 주소록 기능 확장 #296

### DIFF
--- a/user/src/main/java/dukku/user/boundedContext/user/app/address/AddAddressUseCase.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/app/address/AddAddressUseCase.java
@@ -29,7 +29,11 @@ public class AddAddressUseCase {
 
         Address address = Address.builder()
                 .user(user)
+                .name(request.getName())
+                .recipient(request.getRecipient())
+                .phone(request.getPhone())
                 .address(request.getAddress())
+                .detailAddress(request.getDetailAddress())
                 .zonecode(request.getZonecode())
                 .isDefault(isFirstAddress)
                 .build();

--- a/user/src/main/java/dukku/user/boundedContext/user/app/address/FindAddressUseCase.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/app/address/FindAddressUseCase.java
@@ -22,5 +22,11 @@ public class FindAddressUseCase {
                 .map(AddressResponse::from)
                 .toList();
     }
-}
 
+    @Transactional(readOnly = true)
+    public org.springframework.data.domain.Page<AddressResponse> execute(UUID userUuid,
+            org.springframework.data.domain.Pageable pageable) {
+        return addressRepository.findByUser_UuidOrderByIsDefaultDescIdDesc(userUuid, pageable)
+                .map(AddressResponse::from);
+    }
+}

--- a/user/src/main/java/dukku/user/boundedContext/user/app/address/UpdateAddressUseCase.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/app/address/UpdateAddressUseCase.java
@@ -21,7 +21,13 @@ public class UpdateAddressUseCase {
         Address address = addressRepository.findByIdAndUser_Uuid(addressId, userUuid)
                 .orElseThrow(UserAddressNotFoundException::new);
 
-        address.update(request.getAddress(), request.getZonecode());
+        address.update(
+                request.getName(),
+                request.getRecipient(),
+                request.getPhone(),
+                request.getAddress(),
+                request.getDetailAddress(),
+                request.getZonecode());
 
         return AddressResponse.from(address);
     }

--- a/user/src/main/java/dukku/user/boundedContext/user/entity/Address.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/entity/Address.java
@@ -27,8 +27,20 @@ public class Address {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Column(length = 50, comment = "배송지명")
+    private String name;
+
+    @Column(length = 50, comment = "수령인")
+    private String recipient;
+
+    @Column(length = 50, comment = "연락처")
+    private String phone;
+
     @Column(nullable = false)
     private String address;
+
+    @Column
+    private String detailAddress;
 
     @Column(nullable = false, length = 10)
     private String zonecode;
@@ -39,12 +51,19 @@ public class Address {
     @Builder
     public Address(
             User user,
+            String name,
+            String recipient,
+            String phone,
             String address,
+            String detailAddress,
             String zonecode,
-            boolean isDefault
-    ) {
+            boolean isDefault) {
         this.user = user;
+        this.name = name;
+        this.recipient = recipient;
+        this.phone = phone;
         this.address = address;
+        this.detailAddress = detailAddress;
         this.zonecode = zonecode;
         this.isDefault = isDefault;
     }
@@ -54,10 +73,17 @@ public class Address {
     }
 
     public void update(
+            String name,
+            String recipient,
+            String phone,
             String address,
-            String zonecode
-    ) {
+            String detailAddress,
+            String zonecode) {
+        this.name = name;
+        this.recipient = recipient;
+        this.phone = phone;
         this.address = address;
+        this.detailAddress = detailAddress;
         this.zonecode = zonecode;
     }
 }

--- a/user/src/main/java/dukku/user/boundedContext/user/in/AddressController.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/in/AddressController.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/users/me/addresses")
@@ -31,16 +30,17 @@ public class AddressController {
 
     @GetMapping
     @AddressApiDocs.GetMyAddresses
-    public List<AddressResponse> getMyAddresses() {
+    public org.springframework.data.domain.Page<AddressResponse> getMyAddresses(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
         UUID userUuid = UserUtil.getUserId();
-        return findAddressUseCase.execute(userUuid);
+        return findAddressUseCase.execute(userUuid, org.springframework.data.domain.PageRequest.of(page, size));
     }
 
     @PostMapping
     @AddressApiDocs.AddAddress
     public AddressResponse addAddress(
-            @RequestBody @Valid AddressRequest request
-    ) {
+            @RequestBody @Valid AddressRequest request) {
         UUID userUuid = UserUtil.getUserId();
         return addAddressUseCase.add(userUuid, request);
     }
@@ -49,8 +49,7 @@ public class AddressController {
     @AddressApiDocs.UpdateAddress
     public AddressResponse updateAddress(
             @PathVariable Long addressId,
-            @RequestBody @Valid AddressRequest request
-    ) {
+            @RequestBody @Valid AddressRequest request) {
         UUID userUuid = UserUtil.getUserId();
         return updateAddressUseCase.execute(userUuid, addressId, request);
     }

--- a/user/src/main/java/dukku/user/boundedContext/user/in/dto/AddressRequest.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/in/dto/AddressRequest.java
@@ -5,8 +5,19 @@ import lombok.Getter;
 
 @Getter
 public class AddressRequest {
+    private String name;
+
+    @NotBlank
+    private String recipient;
+
+    @NotBlank
+    private String phone;
+
     @NotBlank
     private String address;
+
+    @NotBlank
+    private String detailAddress;
 
     @NotBlank
     private String zonecode;

--- a/user/src/main/java/dukku/user/boundedContext/user/in/dto/AddressResponse.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/in/dto/AddressResponse.java
@@ -6,14 +6,23 @@ import lombok.Getter;
 @Getter
 public class AddressResponse {
     private Long id;
+    private String name;
+    private String recipient;
+    private String phone;
     private String address;
+    private String detailAddress;
     private String zonecode;
+    @com.fasterxml.jackson.annotation.JsonProperty("isDefault")
     private boolean isDefault;
 
     public static AddressResponse from(Address address) {
         AddressResponse res = new AddressResponse();
         res.id = address.getId();
+        res.name = address.getName();
+        res.recipient = address.getRecipient();
+        res.phone = address.getPhone();
         res.address = address.getAddress();
+        res.detailAddress = address.getDetailAddress();
         res.zonecode = address.getZonecode();
         res.isDefault = address.isDefault();
         return res;

--- a/user/src/main/java/dukku/user/boundedContext/user/out/AddressRepository.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/out/AddressRepository.java
@@ -11,6 +11,9 @@ public interface AddressRepository extends JpaRepository<Address, Long> {
 
     List<Address> findByUser_UuidOrderByIsDefaultDescIdDesc(UUID userUuid);
 
+    org.springframework.data.domain.Page<Address> findByUser_UuidOrderByIsDefaultDescIdDesc(UUID userUuid,
+            org.springframework.data.domain.Pageable pageable);
+
     Optional<Address> findByIdAndUser_Uuid(Long id, UUID userUuid);
 
     Optional<Address> findByUser_UuidAndIsDefaultTrue(UUID userUuid);

--- a/user/src/main/java/dukku/user/global/config/SecurityDevConfig.java
+++ b/user/src/main/java/dukku/user/global/config/SecurityDevConfig.java
@@ -21,53 +21,54 @@ import java.util.Arrays;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@Profile({"dev", "test"})  // 개발 환경 + 테스트 환경
+@Profile({ "dev", "test" }) // 개발 환경 + 테스트 환경
 public class SecurityDevConfig {
-    @Value("${custom.security.cors.allowed-origins}")
-    private String[] allowedOrigins;
+        @Value("${custom.security.cors.allowed-origins}")
+        private String[] allowedOrigins;
 
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
-    private final AuthenticationEntryPoint authenticationEntryPoint;
+        private final JwtAuthenticationFilter jwtAuthenticationFilter;
+        private final AuthenticationEntryPoint authenticationEntryPoint;
 
-    /**
-     * CSRF는 서버가 브라우저의 세션/쿠키를 신뢰할 때 공격 위험이 생김.
-     * JWT는 Authorization 헤더에 직접 담기 때문에 쿠키 자동 전송과 무관 → CSRF 공격 불가능.
-     * REST API + JWT 조합은 주로 비동기 호출(fetch, axios) 사용.
-     * 브라우저 폼 기반 요청이 아니므로 CSRF 보호 대상 아님.
-     */
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .csrf(AbstractHttpConfigurer::disable)
-                /*
-                  RESTful API는 무상태(stateless) 원칙
-                  JWT 기반 인증에서는 서버가 상태(session)를 보존하지 않음 → 클라이언트가 JWT를 매 요청마다 전송
-                  그러므로 세션은 필요없음
-                 */
-                .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // 개발 환경: 모든 요청 허용
-                )
-                .cors(cors -> cors.configurationSource(request -> {
-                    var corsConfig = new org.springframework.web.cors.CorsConfiguration();
-                    corsConfig.setAllowedOrigins(
-                            Arrays.asList(allowedOrigins)
-                    );
-                    corsConfig.setAllowedMethods(Arrays.asList("GET","POST","PUT","DELETE","OPTIONS"));
-                    corsConfig.setAllowedHeaders(Arrays.asList("Authorization","Content-Type", "Idempotency-Key"));
-                    corsConfig.setAllowCredentials(true);
-                    return corsConfig;
-                }))
-                .exceptionHandling(e -> e // 인증 실패시 예외 처리
-                        .authenticationEntryPoint(authenticationEntryPoint))
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        /**
+         * CSRF는 서버가 브라우저의 세션/쿠키를 신뢰할 때 공격 위험이 생김.
+         * JWT는 Authorization 헤더에 직접 담기 때문에 쿠키 자동 전송과 무관 → CSRF 공격 불가능.
+         * REST API + JWT 조합은 주로 비동기 호출(fetch, axios) 사용.
+         * 브라우저 폼 기반 요청이 아니므로 CSRF 보호 대상 아님.
+         */
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+                http
+                                .csrf(AbstractHttpConfigurer::disable)
+                                /*
+                                 * RESTful API는 무상태(stateless) 원칙
+                                 * JWT 기반 인증에서는 서버가 상태(session)를 보존하지 않음 → 클라이언트가 JWT를 매 요청마다 전송
+                                 * 그러므로 세션은 필요없음
+                                 */
+                                .sessionManagement(session -> session
+                                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                                .authorizeHttpRequests(auth -> auth
+                                                .anyRequest().permitAll() // 개발 환경: 모든 요청 허용
+                                )
+                                .cors(cors -> cors.configurationSource(request -> {
+                                        var corsConfig = new org.springframework.web.cors.CorsConfiguration();
+                                        corsConfig.setAllowedOrigins(
+                                                        Arrays.asList(allowedOrigins));
+                                        corsConfig.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH",
+                                                        "DELETE", "OPTIONS"));
+                                        corsConfig.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type",
+                                                        "Idempotency-Key"));
+                                        corsConfig.setAllowCredentials(true);
+                                        return corsConfig;
+                                }))
+                                .exceptionHandling(e -> e // 인증 실패시 예외 처리
+                                                .authenticationEntryPoint(authenticationEntryPoint))
+                                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
-        return http.build();
-    }
+                return http.build();
+        }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+        @Bean
+        public PasswordEncoder passwordEncoder() {
+                return new BCryptPasswordEncoder();
+        }
 }

--- a/user/src/main/resources/db/migration/user/V2__add_address_fields.sql
+++ b/user/src/main/resources/db/migration/user/V2__add_address_fields.sql
@@ -1,0 +1,7 @@
+-- V2__add_address_fields.sql
+-- V1에서 누락된 addresses 테이블 컬럼 추가
+
+ALTER TABLE addresses ADD COLUMN IF NOT EXISTS name VARCHAR(50);
+ALTER TABLE addresses ADD COLUMN IF NOT EXISTS recipient VARCHAR(50);
+ALTER TABLE addresses ADD COLUMN IF NOT EXISTS phone VARCHAR(50);
+ALTER TABLE addresses ADD COLUMN IF NOT EXISTS detail_address TEXT;


### PR DESCRIPTION


## PR 제목

[User] 주소록 기능 확장 #296


---

## 개요


주소 엔티티에 수령인 정보, 연락처 정보가 없는 상태 -> 해당 필드 추가
전체를 get으로 받아 프론트에서 필터하려고 했으나 제약을 두지 않을 경우 퍼포먼스 이슈가 발생할 여지가 있고 이상 패턴에 취약한 이슈가 있음 (수만 건의 주소를 매크로로 밀어넣는 등)
페이징 처리를 하고 무한스크롤로 불러오는 방향으로 확장


---

## 상세 내용

**배송지 상세 필드 추가 및 마이그레이션 적용**
SHA : a3c8d5c1229a3ee5827052fd77d0a8d479307047
- Address 엔티티에 name(배송지명), recipient(수령인), phone(연락처), detailAddress 필드 추가
- V2 마이그레이션으로 addresses 테이블에 누락 컬럼 IF NOT EXISTS 방식으로 추가
- AddressRequest/Response DTO에 신규 필드 반영
- AddAddressUseCase, UpdateAddressUseCase, FindAddressUseCase 신규 필드 처리 반영
- AddressController 엔드포인트 인자 정합 수정
- SecurityDevConfig 포맷 정리


---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
