### PR TITLE
[Infra] 로컬 서비스 kill하는 bat파일 추가 #298

### DIFF
--- a/kill_project_apps.bat
+++ b/kill_project_apps.bat
@@ -1,0 +1,69 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+set "PORTS=8081 8082 8083 8084 8085 8086 8087 8088 8089 9000"
+set "TMP_FILE=%TEMP%\kill_project_apps_pids_%RANDOM%.tmp"
+set "DRY_RUN=0"
+
+if /I "%~1"=="DRYRUN" set "DRY_RUN=1"
+
+echo [INFO] Target ports: %PORTS%
+if "%DRY_RUN%"=="1" echo [INFO] Dry-run enabled. No process will be killed.
+
+del /q "%TMP_FILE%" >nul 2>&1
+
+for %%A in (%PORTS%) do (
+    for /f "tokens=5" %%P in ('netstat -ano ^| findstr /R /C:":%%A " ') do (
+        if not "%%P"=="0" if not "%%P"=="4" echo %%P>>"%TMP_FILE%"
+    )
+)
+
+if not exist "%TMP_FILE%" (
+    echo [INFO] No matching process found.
+    exit /b 0
+)
+
+set "FOUND=0"
+for /f %%P in ('sort "%TMP_FILE%" /unique') do (
+    call :handle_pid %%P
+)
+
+del /q "%TMP_FILE%" >nul 2>&1
+
+if "%FOUND%"=="0" (
+    echo [INFO] No matching java process found.
+) else (
+    echo [DONE] Completed.
+)
+
+exit /b 0
+
+:handle_pid
+set "PID=%~1"
+set "IMAGE="
+for /f "tokens=1 delims=," %%I in ('tasklist /FI "PID eq %PID%" /FO CSV /NH') do (
+    set "IMAGE=%%~I"
+)
+
+if not defined IMAGE exit /b 0
+if /I "%IMAGE%"=="INFO:" exit /b 0
+
+if /I not "%IMAGE%"=="java.exe" if /I not "%IMAGE%"=="javaw.exe" (
+    echo [SKIP] PID %PID% ^(%IMAGE%^) is not java/javaw.
+    exit /b 0
+)
+
+set "FOUND=1"
+if "%DRY_RUN%"=="1" (
+    echo [DRYRUN] PID %PID% ^(%IMAGE%^) would be killed.
+) else (
+    echo [INFO] Killing PID %PID% ^(%IMAGE%^) ...
+    taskkill /F /PID %PID% >nul 2>&1
+    if errorlevel 1 (
+        echo [WARN] Failed to kill PID %PID% ^(already exited or access denied^).
+    ) else (
+        echo [OK] Killed PID %PID%
+    )
+)
+
+exit /b 0


### PR DESCRIPTION

## PR 제목

[Infra] 로컬 서비스 kill하는 bat파일 추가 #298

IntelliJ에서 스프링 인스턴스를 띄웠다가 예기치 않게 종료될 경우 이전 프로세스가 포트를 점유하는 현상 발생
포트 특정하지 않고 범위 내 포트 프로세스를 정리해버리면 Intellij가 같이 꺼져버리는 문제 발생
프로젝트에서 사용하고 있는 8081~8089, 9000 포트를 명시적으로 지정해서 프로세스 존재 시 끄는 배치파일 작성

---

## 개요



---

## 상세 내용

**로컬 서비스 프로세스 일괄 종료 스크립트 추가**
SHA : b68dc56ce202da6c194df7eca838569a0a3f696d
- kill_project_apps.bat 추가
- 8081~8089, 9000 포트의 java/javaw 프로세스를 일괄 종료
- DRYRUN 인자 지원으로 실제 종료 전 대상 확인 가능


---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [ ] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [x] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
