### PR TITLE
[Settlement] SettlementController @RequestMapping 수정

### DIFF
--- a/settlement/src/main/java/dukku/settlement/boundedContext/settlement/in/SettlementController.java
+++ b/settlement/src/main/java/dukku/settlement/boundedContext/settlement/in/SettlementController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/admin/settlements")
+@RequestMapping("/api/v1/admin/settlements")
 @RequiredArgsConstructor
 @SettlementApiDocs.SettlementTag
 public class SettlementController {


### PR DESCRIPTION
## PR 제목

[Settlement] SettlementController @RequestMapping 수정

---

## 개요

ingress 라우팅 세팅에 맞춰,
기존 SettlementController `/admin/settlements` 에서
`/api/v1/admin/settlements`로 수정했습니다.

---

## 상세 내용

```bash
# Before #
@RequestMapping("/api/v1/admin/settlements")

# After #
@RequestMapping("/admin/settlements")
```

api-gateway-ingress.yml 내부 settlement-service 설정
```yml
         - path: /api/v1/settlements
            pathType: Prefix
            backend:
              service:
                name: settlement-service
                port:
                  number: 80
                  
         - path: /api/v1/admin/settlement
            pathType: Prefix
            backend:
              service:
                name: settlement-service
                port:
                  number: 80
```



---

## PR 유형 (라벨 지정 필수)

- [x] 코드 리팩토링 (Refactor)

---