### PR TITLE
[Infra] log-consumer-service 모듈 ingress 세팅 추가

### DIFF
--- a/common/src/main/java/dukku/common/shared/user/domain/BaseUser.java
+++ b/common/src/main/java/dukku/common/shared/user/domain/BaseUser.java
@@ -18,7 +18,6 @@ import lombok.experimental.SuperBuilder;
 
 public abstract class BaseUser extends BaseEntity<Integer> {
 
-
     @Column(length = 100, unique = true, nullable = false, comment = "이메일 (로그인 ID)")
     @Setter(AccessLevel.PROTECTED)
     private String email;

--- a/common/src/main/java/dukku/common/shared/user/domain/SourceUser.java
+++ b/common/src/main/java/dukku/common/shared/user/domain/SourceUser.java
@@ -26,10 +26,7 @@ public abstract class SourceUser extends BaseUser {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
-
-
     private Integer id;
-
 
     @JdbcTypeCode(SqlTypes.UUID)
     @Column(columnDefinition = "uuid", updatable = false, nullable = false, unique = true, comment = "유저 UUID")

--- a/k8s/semicolon/ingress/api-gateway-ingress.yml
+++ b/k8s/semicolon/ingress/api-gateway-ingress.yml
@@ -169,7 +169,7 @@ spec:
                   number: 80
 
           # =====================
-          # AI
+          # MONITORING
           # =====================
           - path: /api/v1/logs
             pathType: Prefix

--- a/k8s/semicolon/ingress/api-gateway-ingress.yml
+++ b/k8s/semicolon/ingress/api-gateway-ingress.yml
@@ -169,6 +169,25 @@ spec:
                   number: 80
 
           # =====================
+          # AI
+          # =====================
+          - path: /api/v1/logs
+            pathType: Prefix
+            backend:
+              service:
+                name: log-consumer-service
+                port:
+                  number: 80
+
+          - path: /api/v1/anomalies
+            pathType: Prefix
+            backend:
+              service:
+                name: log-consumer-service
+                port:
+                  number: 80
+
+          # =====================
           # ADMIN — 서비스별 분기
           # =====================
           - path: /api/v1/admin/users

--- a/user/src/main/java/dukku/user/boundedContext/user/entity/Address.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/entity/Address.java
@@ -1,14 +1,6 @@
 package dukku.user.boundedContext.user.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,16 +28,16 @@ public class Address {
     @Column(length = 50, comment = "연락처")
     private String phone;
 
-    @Column(nullable = false)
+    @Column(nullable = false, comment = "기본 주소")
     private String address;
 
-    @Column
+    @Column(comment = "상세 주소")
     private String detailAddress;
 
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, length = 10, comment = "우편번호(존 코드)")
     private String zonecode;
 
-    @Column(nullable = false)
+    @Column(nullable = false, comment = "기본 배송지 여부")
     private boolean isDefault;
 
     @Builder

--- a/user/src/main/java/dukku/user/boundedContext/user/entity/User.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/entity/User.java
@@ -6,24 +6,20 @@ import dukku.common.shared.user.dto.UserDto;
 import dukku.common.shared.user.dto.UserRegisterRequest;
 import dukku.common.shared.user.dto.UserResponse;
 import dukku.common.shared.user.dto.UserUpdateRequest;
-import dukku.common.shared.user.type.Role;
-import dukku.common.shared.user.type.UserStatus;
 import dukku.common.shared.user.exception.UserAlreadyWithdrawException;
 import dukku.common.shared.user.exception.UserWithdrawRestoreNotAllowedException;
-import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import dukku.common.shared.user.type.Role;
+import dukku.common.shared.user.type.UserStatus;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users")
@@ -36,11 +32,11 @@ public class User extends SourceUser {
     private String password;
 
     @Convert(converter = AesGcmConverter.class)
-    @Column(name = "withdrawal_email_backup", length = 255)
+    @Column(name = "withdrawal_email_backup", length = 255, comment = "탈퇴 시 백업된 이메일(암호화)")
     private String withdrawalEmailBackup;
 
     @Convert(converter = AesGcmConverter.class)
-    @Column(name = "withdrawal_nickname_backup", length = 100)
+    @Column(name = "withdrawal_nickname_backup", length = 100, comment = "탈퇴 시 백업된 닉네임(암호화)")
     private String withdrawalNicknameBackup;
 
     @OneToMany(mappedBy = "user")

--- a/user/src/main/java/dukku/user/boundedContext/user/entity/UserSanction.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/entity/UserSanction.java
@@ -4,14 +4,7 @@ import dukku.common.global.jpa.entity.BaseIdAndTime;
 import dukku.user.boundedContext.user.type.UserSanctionReasonCode;
 import dukku.user.boundedContext.user.type.UserSanctionStatus;
 import dukku.user.boundedContext.user.type.UserSanctionType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -36,38 +29,38 @@ public class UserSanction extends BaseIdAndTime {
     private User user;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "sanction_type", nullable = false, length = 30)
+    @Column(name = "sanction_type", nullable = false, length = 30, comment = "제재 유형 (예: WARNING, SUSPENSION, PERMANENT_BAN)")
     private UserSanctionType sanctionType;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "reason_code", nullable = false, length = 40)
+    @Column(name = "reason_code", nullable = false, length = 40, comment = "제재 사유 코드")
     private UserSanctionReasonCode reasonCode;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = 20, comment = "제재 상태 (예: ACTIVE, EXPIRED, REVOKED)")
     private UserSanctionStatus status;
 
-    @Column(length = 1000, nullable = false)
+    @Column(length = 1000, nullable = false, comment = "제재 메모")
     private String memo;
 
-    @Column(name = "evidence_url", length = 500)
+    @Column(name = "evidence_url", length = 500, comment = "증거 URL")
     private String evidenceUrl;
 
-    @Column(name = "start_at", nullable = false)
+    @Column(name = "start_at", nullable = false, comment = "제재 시작 시각")
     private LocalDateTime startAt;
 
-    @Column(name = "end_at")
+    @Column(name = "end_at", comment = "제재 종료 시각")
     private LocalDateTime endAt;
 
     @JdbcTypeCode(SqlTypes.UUID)
-    @Column(name = "created_by", columnDefinition = "uuid", nullable = false)
+    @Column(name = "created_by", columnDefinition = "uuid", nullable = false, comment = "제재 생성자 UUID")
     private UUID createdBy;
 
     @JdbcTypeCode(SqlTypes.UUID)
-    @Column(name = "revoked_by", columnDefinition = "uuid")
+    @Column(name = "revoked_by", columnDefinition = "uuid", comment = "제재 해제자 UUID")
     private UUID revokedBy;
 
-    @Column(name = "revoked_at")
+    @Column(name = "revoked_at", comment = "제재 해제 시각")
     private LocalDateTime revokedAt;
 
     public static UserSanction apply(

--- a/user/src/main/java/dukku/user/boundedContext/user/entity/UserSanctionAuditLog.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/entity/UserSanctionAuditLog.java
@@ -4,11 +4,7 @@ import dukku.common.global.jpa.entity.BaseIdAndTime;
 import dukku.user.boundedContext.user.type.UserSanctionAuditAction;
 import dukku.user.boundedContext.user.type.UserSanctionReasonCode;
 import dukku.user.boundedContext.user.type.UserSanctionType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -27,30 +23,30 @@ import java.util.UUID;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSanctionAuditLog extends BaseIdAndTime {
 
-    @Column(name = "sanction_id", nullable = false)
+    @Column(name = "sanction_id", nullable = false, comment = "관련 제재 ID")
     private Integer sanctionId;
 
     @JdbcTypeCode(SqlTypes.UUID)
-    @Column(name = "user_uuid", columnDefinition = "uuid", nullable = false)
+    @Column(name = "user_uuid", columnDefinition = "uuid", nullable = false, comment = "해당 유저 UUID")
     private UUID userUuid;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "action", nullable = false, length = 20)
+    @Column(name = "action", nullable = false, length = 20, comment = "감사 로그 액션 (예: APPLIED, REVOKED, EXPIRED)")
     private UserSanctionAuditAction action;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "sanction_type", nullable = false, length = 30)
+    @Column(name = "sanction_type", nullable = false, length = 30, comment = "제재 유형")
     private UserSanctionType sanctionType;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "reason_code", nullable = false, length = 40)
+    @Column(name = "reason_code", nullable = false, length = 40, comment = "제재 사유 코드")
     private UserSanctionReasonCode reasonCode;
 
-    @Column(name = "memo", length = 1000)
+    @Column(name = "memo", length = 1000, comment = "운영자 메모")
     private String memo;
 
     @JdbcTypeCode(SqlTypes.UUID)
-    @Column(name = "performed_by", columnDefinition = "uuid", nullable = false)
+    @Column(name = "performed_by", columnDefinition = "uuid", nullable = false, comment = "작업 수행자 UUID")
     private UUID performedBy;
 
     public static UserSanctionAuditLog create(


### PR DESCRIPTION
## PR 제목

[Infra] log-consumer-service 모듈 ingress 세팅 추가

---

## 개요

- api-gateway-ingress.yml 에 log-consumer-service 모듈 관련 prefix 추가

```java
  # =====================
  # MONITORING 
  # =====================
  - path: /api/v1/logs
    pathType: Prefix
    backend:
      service:
        name: log-consumer-service
        port:
          number: 80

  - path: /api/v1/anomalies
    pathType: Prefix
    backend:
      service:
        name: log-consumer-service
        port:
          number: 80
```

---

## PR 유형 (라벨 지정 필수)

- [x] 빌드/패키지/인프라 수정 (Build / Infra)