### PR TITLE
[Order] 주문 만료 주문이 PENDING 상태로 남아 상태 불일치가 발생함 #314

### DIFF
--- a/common/src/main/java/dukku/common/shared/order/dto/OrderResponse.java
+++ b/common/src/main/java/dukku/common/shared/order/dto/OrderResponse.java
@@ -3,8 +3,10 @@ package dukku.common.shared.order.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.common.shared.order.type.OrderStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +14,8 @@ import java.util.UUID;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class OrderResponse {
     private UUID orderUuid; // 주문 UUID
     private UUID userUuid; // 구매자 UUID
@@ -27,6 +31,8 @@ public class OrderResponse {
 
     @Getter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class OrderItemResponse {
         private UUID orderItemUuid; // 주문 상품 UUID
         private UUID productUuid;   // 상품 UUID

--- a/common/src/main/java/dukku/common/shared/order/out/OrderApiClient.java
+++ b/common/src/main/java/dukku/common/shared/order/out/OrderApiClient.java
@@ -53,6 +53,13 @@ public class OrderApiClient {
                 .body(OrderResponse.class);
     }
 
+    public void expireOrder(UUID orderUuid) {
+        restClient.post()
+                .uri("/{orderUuid}/expire", orderUuid)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
     // 특정 사용자의 주문 이력 조회 (AI 추천용)
     public List<OrderListResponse> findOrdersByUserUuid(UUID userUuid, String status, int limit) {
         return restClient.get()

--- a/common/src/main/resources/application-common.yml
+++ b/common/src/main/resources/application-common.yml
@@ -119,6 +119,7 @@ spring:
     redis:
       host: ${REDIS_HOST:redis}
 
+custom:
   global:
     internalBackUrl: ${INTERNAL_BACK_URL:http://auth:8081}
   client:

--- a/order/src/main/java/dukku/order/OrderApplication.java
+++ b/order/src/main/java/dukku/order/OrderApplication.java
@@ -5,8 +5,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.resilience.annotation.EnableResilientMethods;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableAsync
+@EnableScheduling
 @EnableResilientMethods
 @EnableJpaAuditing
 @SpringBootApplication(scanBasePackages = {

--- a/order/src/main/java/dukku/order/boundedContext/order/app/FindOrderByUuidUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/FindOrderByUuidUseCase.java
@@ -15,6 +15,6 @@ public class FindOrderByUuidUseCase {
 
     @Transactional(readOnly = true)
     public Order execute(UUID orderUuid) {
-        return orderSupport.findOrderByUuid(orderUuid);
+        return orderSupport.findOrderByUuidWithItems(orderUuid);
     }
 }

--- a/order/src/main/java/dukku/order/boundedContext/order/app/scheduler/PendingOrderExpirationScheduler.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/scheduler/PendingOrderExpirationScheduler.java
@@ -27,11 +27,15 @@ public class PendingOrderExpirationScheduler {
     @Scheduled(cron = "${order.pending-expiration.cron:0 */5 * * * *}")
     // 만료 기준을 지난 PENDING 주문을 실패 처리해 예약 상품을 해제한다.
     public void expirePendingOrders() {
+        expirePendingOrdersNow();
+    }
+
+    public int expirePendingOrdersNow() {
         LocalDateTime cutoff = LocalDateTime.now().minusMinutes(pendingExpirationMinutes);
         List<Order> expiredPendingOrders = orderRepository.findByStatusAndCreatedAtBefore(OrderStatus.PENDING, cutoff);
 
         if (expiredPendingOrders.isEmpty()) {
-            return;
+            return 0;
         }
 
         log.info("[PendingOrderExpiration] expiring {} orders. cutoff={}", expiredPendingOrders.size(), cutoff);
@@ -43,5 +47,7 @@ public class PendingOrderExpirationScheduler {
                 log.error("[PendingOrderExpiration] failed to expire orderUuid={}", order.getUuid(), e);
             }
         }
+
+        return expiredPendingOrders.size();
     }
 }

--- a/order/src/main/java/dukku/order/boundedContext/order/entity/Order.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/entity/Order.java
@@ -125,7 +125,7 @@ public class Order extends BaseIdAndUUIDAndTime {
     // 주문 상품 UUID 목록 추출
     public List<UUID> getProductUuids() {
         return orderItems.stream()
-                .map(BaseIdAndUUIDAndTime::getUuid)
+                .map(OrderItem::getProductUuid)
                 .toList();
     }
 

--- a/order/src/main/java/dukku/order/boundedContext/order/in/OrderInternalController.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/in/OrderInternalController.java
@@ -6,12 +6,20 @@ import dukku.common.shared.order.dto.OrderResponse;
 import dukku.common.shared.order.type.OrderStatus;
 import dukku.order.boundedContext.order.app.FindOrderByUuidUseCase;
 import dukku.order.boundedContext.order.app.OrderFacade;
+import dukku.order.boundedContext.order.app.UpdateOrderStatusUseCase;
+import dukku.order.boundedContext.order.app.scheduler.PendingOrderExpirationScheduler;
 import dukku.order.boundedContext.order.entity.Order;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @RestController
@@ -20,6 +28,8 @@ import java.util.UUID;
 public class OrderInternalController {
     private final OrderFacade orderFacade;
     private final FindOrderByUuidUseCase findOrderByUuidUseCase;
+    private final UpdateOrderStatusUseCase updateOrderStatusUseCase;
+    private final PendingOrderExpirationScheduler pendingOrderExpirationScheduler;
 
     @GetMapping("/items/confirmed")
     public List<ConfirmedOrderItemResponse> findConfirmedItems(
@@ -44,5 +54,16 @@ public class OrderInternalController {
     public OrderResponse findOrderByUuid(@PathVariable UUID orderUuid) {
         Order order = findOrderByUuidUseCase.execute(orderUuid);
         return Order.toOrderResponse(order);
+    }
+
+    @PostMapping("/{orderUuid}/expire")
+    public void expireOrder(@PathVariable UUID orderUuid) {
+        updateOrderStatusUseCase.failPayment(orderUuid);
+    }
+
+    @PostMapping("/expire-pending")
+    public Map<String, Integer> expirePendingOrders() {
+        int expiredCount = pendingOrderExpirationScheduler.expirePendingOrdersNow();
+        return Map.of("expiredCount", expiredCount);
     }
 }

--- a/order/src/test/java/dukku/order/boundedContext/order/entity/OrderProductUuidMappingTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/entity/OrderProductUuidMappingTest.java
@@ -1,0 +1,53 @@
+package dukku.order.boundedContext.order.entity;
+
+import dukku.common.shared.order.type.OrderStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderProductUuidMappingTest {
+
+    @Test
+    @DisplayName("getProductUuids 는 orderItemUuid 가 아니라 productUuid 를 반환한다")
+    void getProductUuidsReturnsProductUuid() {
+        UUID productUuid1 = UUID.randomUUID();
+        UUID productUuid2 = UUID.randomUUID();
+
+        Order order = Order.builder()
+                .userUuid(UUID.randomUUID())
+                .status(OrderStatus.PENDING)
+                .totalAmount(10_000)
+                .address("서울")
+                .recipient("구매자")
+                .contactNumber("010-0000-0000")
+                .refundedAmount(0)
+                .build();
+
+        OrderItem item1 = OrderItem.builder()
+                .uuid(UUID.randomUUID())
+                .productUuid(productUuid1)
+                .sellerUuid(UUID.randomUUID())
+                .productName("상품1")
+                .productPrice(5_000)
+                .build();
+
+        OrderItem item2 = OrderItem.builder()
+                .uuid(UUID.randomUUID())
+                .productUuid(productUuid2)
+                .sellerUuid(UUID.randomUUID())
+                .productName("상품2")
+                .productPrice(5_000)
+                .build();
+
+        order.addOrderItem(item1);
+        order.addOrderItem(item2);
+
+        List<UUID> productUuids = order.getProductUuids();
+
+        assertThat(productUuids).containsExactly(productUuid1, productUuid2);
+    }
+}

--- a/payment/src/main/java/dukku/payment/boundedContext/payment/app/ConfirmPaymentUseCase.java
+++ b/payment/src/main/java/dukku/payment/boundedContext/payment/app/ConfirmPaymentUseCase.java
@@ -231,6 +231,11 @@ public class ConfirmPaymentUseCase {
         LocalDateTime orderedAt = order.getOrderedAt();
         LocalDateTime expiresAt = orderedAt.plusMinutes(pendingExpirationMinutes);
         if (LocalDateTime.now().isAfter(expiresAt)) {
+            try {
+                orderApiClient.expireOrder(orderUuid);
+            } catch (Exception e) {
+                log.warn("만료 주문 즉시 종료 호출 실패. orderUuid={}", orderUuid, e);
+            }
             long orderAgeMinutes = ChronoUnit.MINUTES.between(orderedAt, LocalDateTime.now());
             throw new PaymentExpiredException(orderAgeMinutes, pendingExpirationMinutes);
         }

--- a/payment/src/main/java/dukku/payment/boundedContext/payment/app/RequestPaymentUseCase.java
+++ b/payment/src/main/java/dukku/payment/boundedContext/payment/app/RequestPaymentUseCase.java
@@ -433,6 +433,11 @@ public class RequestPaymentUseCase {
         LocalDateTime orderedAt = order.getOrderedAt();
         LocalDateTime expiresAt = orderedAt.plusMinutes(pendingExpirationMinutes);
         if (LocalDateTime.now().isAfter(expiresAt)) {
+            try {
+                orderApiClient.expireOrder(orderUuid);
+            } catch (Exception e) {
+                log.warn("만료 주문 즉시 종료 호출 실패. orderUuid={}", orderUuid, e);
+            }
             long orderAgeMinutes = ChronoUnit.MINUTES.between(orderedAt, LocalDateTime.now());
             throw new PaymentExpiredException(orderAgeMinutes, pendingExpirationMinutes);
         }


### PR DESCRIPTION
## PR 제목

[Order] 주문 만료 주문이 PENDING 상태로 남아 상태 불일치가 발생함 #314

---

## 개요

주문 만료가 스케줄러/결제 흐름에서 일관되게 반영되지 않아 PENDING 상태가 잔존하던 문제를 해결하기 위해, 주문 내부 만료 API와 결제단 즉시 호출 경로를 연결

---

## 상세 내용

**주문 만료 내부 실행 경로와 API 엔드포인트 추가**
SHA : 7ec25945d8cc1a742a3131904f16e3aaa48b50ab
- 주문 서비스에 스케줄 활성화 설정을 추가하고 만료 처리 유즈케이스를 즉시 실행 가능한 메서드로 분리했습니다.
- 내부 API에 주문 단건 만료와 만료 배치 수동 실행 엔드포인트를 추가했습니다.
- 내부 통신 클라이언트(OrderApiClient)에 주문 만료 호출 메서드를 추가했습니다.
- 주문 조회 시 상세 응답에서 아이템 로딩이 누락되지 않도록 조회 방식을 보완했습니다.

**결제 만료 감지 시 주문 즉시 만료 호출**
SHA : 8edf2f2963b55e782aea909061f03d4776ef134c
- 결제 요청/승인 시 주문 만료 시간을 초과한 경우 PaymentExpiredException 전에 주문 만료 API를 먼저 호출하도록 변경했습니다.
- 만료 호출 실패는 결제 흐름을 막지 않도록 warn 로그로 처리했습니다.

**주문 상품 UUID 매핑 오류 수정과 DTO 생성자 보강**
SHA : 0e5878d2879ce6eccc37979fc8800092fff392ad
- Order.getProductUuids가 주문아이템 UUID가 아닌 상품 UUID를 반환하도록 수정했습니다.
- 매핑 오류 회귀를 방지하기 위한 OrderProductUuidMappingTest를 추가했습니다.
- 내부 직렬화/역직렬화 호환성을 위해 OrderResponse와 하위 DTO에 기본/전체 생성자를 추가했습니다.



---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
