### PR TITLE
[Order] 배송 전 주문상품 취소 시 상품 재고가 복구되지 않고 품절 상태가 됨 #315

### DIFF
--- a/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderItemStatusUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderItemStatusUseCase.java
@@ -2,13 +2,16 @@ package dukku.order.boundedContext.order.app;
 
 import dukku.common.global.UserUtil;
 import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.order.event.OrderItemCanceledEvent;
+import dukku.common.shared.order.event.OrderItemConfirmedEvent;
+import dukku.common.shared.order.event.OrderProductSaleReleasedEvent;
+import dukku.common.shared.order.event.OrderItemRefundRequestedEvent;
 import dukku.common.shared.order.exception.OrderAccessDeniedException;
 import dukku.common.shared.order.exception.OrderItemActionNotAllowedException;
 import dukku.common.shared.order.exception.OrderItemNotFoundException;
-import dukku.common.shared.order.event.OrderItemCanceledEvent;
-import dukku.common.shared.order.event.OrderItemConfirmedEvent;
-import dukku.common.shared.order.event.OrderItemRefundRequestedEvent;
 import dukku.common.shared.order.type.OrderItemStatus;
+import dukku.common.shared.order.type.OrderStatus;
+import dukku.order.boundedContext.order.entity.Order;
 import dukku.order.boundedContext.order.entity.OrderItem;
 import dukku.order.boundedContext.order.out.OrderItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -34,31 +38,35 @@ public class UpdateOrderItemStatusUseCase {
         OrderItem orderItem = orderItemRepository.findByUuid(orderItemUuid)
                 .orElseThrow(OrderItemNotFoundException::new);
 
-        // 1) 권한 검증 (관리자 프리패스, 사용자 엄격 검증)
         checkPermission(orderItem, newStatus);
 
-        // 2) 상태 변경 (엔티티 내부에서 흐름 검증 수행 -> 실패 시 예외 발생)
-        orderItem.updateOrderStatus(newStatus);
+        // 배송 전 사용자 취소 요청(CANCEL_REQUESTED)은 즉시 취소(CANCELED)로 처리한다.
+        OrderItemStatus targetStatus = resolveTargetStatus(orderItem, newStatus);
 
-        // 3) 변경된 상태에 맞는 이벤트 발행 (알림, 정산, 재고 복구 등)
-        publishEvent(orderItem, newStatus);
+        orderItem.updateOrderStatus(targetStatus);
+        syncOrderStatusIfAllItemsCanceled(orderItem, targetStatus);
+        publishEvent(orderItem, targetStatus);
 
-        log.info("주문 상품 상태 변경 완료: uuid={}, status={}", orderItemUuid, newStatus);
+        log.info("Order item status updated. orderItemUuid={}, requestedStatus={}, appliedStatus={}",
+                orderItemUuid, newStatus, targetStatus);
+    }
+
+    private OrderItemStatus resolveTargetStatus(OrderItem orderItem, OrderItemStatus requestedStatus) {
+        if (requestedStatus == OrderItemStatus.CANCEL_REQUESTED) {
+            return OrderItemStatus.CANCELED;
+        }
+        return requestedStatus;
     }
 
     private void checkPermission(OrderItem orderItem, OrderItemStatus newStatus) {
-        // 관리자는 모든 권한 허용 (단, 엔티티의 논리적 흐름 검증은 통과해야 함)
         if (UserUtil.isAdmin()) {
             return;
         }
 
-        // 본인 주문 확인
         if (!orderItem.getOrder().getUserUuid().equals(UserUtil.getUserId())) {
             throw new OrderAccessDeniedException();
         }
 
-        // 사용자가 요청할 수 있는 상태인지 확인 (Enum 내 정의된 리스트 체크)
-        // ex: 사용자가 갑자기 status를 'SHIPPING(배송중)'으로 바꾸는 해킹 시도 방어
         if (!OrderItemStatus.isUserActionAllowed(newStatus)) {
             throw new OrderItemActionNotAllowedException();
         }
@@ -66,15 +74,36 @@ public class UpdateOrderItemStatusUseCase {
 
     private void publishEvent(OrderItem orderItem, OrderItemStatus newStatus) {
         switch (newStatus) {
-            case CANCELED ->
-                // 주문 취소: 상품 서비스에 '재고 복구(Increase Stock)' 요청 및 결제 서비스에 환불 로직 트리거
-                    eventPublisher.publish(new OrderItemCanceledEvent(orderItem.getUuid()));
-            case CONFIRMED ->
-                // 구매 확정: 정산 서비스에 '판매자 정산 대기' 등록 및 사용자에게 포인트 적립 트리거
-                    eventPublisher.publish(new OrderItemConfirmedEvent(orderItem.getUuid()));
-            case REFUND_REQUESTED ->
-                // 환불/반품 신청: 판매자에게 '반품 요청 알림' 발송 및 관리자 환불 검토 리스트 진입
-                    eventPublisher.publish(new OrderItemRefundRequestedEvent(orderItem.getUuid()));
+            case CANCELED -> {
+                eventPublisher.publish(new OrderItemCanceledEvent(orderItem.getUuid()));
+                // 배송 전 취소 시 상품 판매 상태를 즉시 복구한다.
+                eventPublisher.publish(new OrderProductSaleReleasedEvent(
+                        orderItem.getOrder().getUuid(),
+                        List.of(orderItem.getProductUuid())
+                ));
+            }
+            case CONFIRMED -> eventPublisher.publish(new OrderItemConfirmedEvent(orderItem.getUuid()));
+            case REFUND_REQUESTED -> eventPublisher.publish(new OrderItemRefundRequestedEvent(orderItem.getUuid()));
         }
+    }
+
+    private void syncOrderStatusIfAllItemsCanceled(OrderItem orderItem, OrderItemStatus targetStatus) {
+        if (targetStatus != OrderItemStatus.CANCELED) {
+            return;
+        }
+
+        Order order = orderItem.getOrder();
+        boolean allItemsCanceled = order.getOrderItems().stream()
+                .allMatch(item -> item.getStatus() == OrderItemStatus.CANCELED);
+
+        if (!allItemsCanceled) {
+            return;
+        }
+
+        if (order.getStatus() == OrderStatus.CANCELED) {
+            return;
+        }
+
+        order.updateOrderStatus(OrderStatus.CANCELED);
     }
 }

--- a/order/src/test/java/dukku/order/boundedContext/order/app/UpdateOrderItemStatusUseCaseTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/UpdateOrderItemStatusUseCaseTest.java
@@ -2,6 +2,9 @@ package dukku.order.boundedContext.order.app;
 
 import dukku.common.global.auth.detail.CustomUserDetails;
 import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.global.exception.ConflictException;
+import dukku.common.shared.order.event.OrderItemCanceledEvent;
+import dukku.common.shared.order.event.OrderProductSaleReleasedEvent;
 import dukku.common.shared.order.exception.OrderAccessDeniedException;
 import dukku.common.shared.order.exception.OrderItemActionNotAllowedException;
 import dukku.common.shared.order.type.OrderItemStatus;
@@ -24,7 +27,11 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -46,10 +53,10 @@ class UpdateOrderItemStatusUseCaseTest {
     }
 
     @Test
-    @DisplayName("주문 소유자가 아닌 사용자는 주문 상품 상태를 변경할 수 없다")
+    @DisplayName("owner가 아닌 사용자는 상태 변경할 수 없다")
     void failWhenNotOwner() {
         UUID orderItemUuid = UUID.randomUUID();
-        OrderItem orderItem = createOrderItem(orderItemUuid, UUID.randomUUID());
+        OrderItem orderItem = createOrderItem(orderItemUuid, UUID.randomUUID(), OrderItemStatus.DELIVERED);
 
         authenticate(UUID.randomUUID(), "USER");
         when(orderItemRepository.findByUuid(orderItemUuid)).thenReturn(Optional.of(orderItem));
@@ -61,11 +68,11 @@ class UpdateOrderItemStatusUseCaseTest {
     }
 
     @Test
-    @DisplayName("주문 소유자라도 허용되지 않은 상태 변경은 실패한다")
+    @DisplayName("일반 사용자가 허용되지 않은 상태를 요청하면 실패한다")
     void failWhenUserRequestsDisallowedStatus() {
         UUID userUuid = UUID.randomUUID();
         UUID orderItemUuid = UUID.randomUUID();
-        OrderItem orderItem = createOrderItem(orderItemUuid, userUuid);
+        OrderItem orderItem = createOrderItem(orderItemUuid, userUuid, OrderItemStatus.DELIVERED);
 
         authenticate(userUuid, "USER");
         when(orderItemRepository.findByUuid(orderItemUuid)).thenReturn(Optional.of(orderItem));
@@ -74,6 +81,71 @@ class UpdateOrderItemStatusUseCaseTest {
                 .isInstanceOf(OrderItemActionNotAllowedException.class);
 
         verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    @DisplayName("배송 시작 전 CANCEL_REQUESTED는 즉시 CANCELED로 전환되고 취소 이벤트를 발행한다")
+    void cancelRequestedBeforeShipmentIsAppliedAsCanceled() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderItemUuid = UUID.randomUUID();
+        OrderItem orderItem = createOrderItem(orderItemUuid, userUuid, OrderItemStatus.PAYMENT_COMPLETED);
+
+        authenticate(userUuid, "USER");
+        when(orderItemRepository.findByUuid(orderItemUuid)).thenReturn(Optional.of(orderItem));
+
+        useCase.execute(orderItemUuid, OrderItemStatus.CANCEL_REQUESTED);
+
+        assertThat(orderItem.getStatus()).isEqualTo(OrderItemStatus.CANCELED);
+        assertThat(orderItem.getOrder().getStatus()).isEqualTo(OrderStatus.CANCELED);
+        verify(eventPublisher).publish(any(OrderItemCanceledEvent.class));
+        verify(eventPublisher).publish(any(OrderProductSaleReleasedEvent.class));
+    }
+
+    @Test
+    @DisplayName("여러 상품 중 일부만 취소되면 주문 상태는 유지된다")
+    void keepOrderStatusWhenOnlySomeItemsCanceled() {
+        UUID userUuid = UUID.randomUUID();
+        UUID targetOrderItemUuid = UUID.randomUUID();
+        OrderItem targetOrderItem = createOrderItem(targetOrderItemUuid, userUuid, OrderItemStatus.PAYMENT_COMPLETED);
+
+        OrderItem anotherOrderItem = OrderItem.builder()
+                .uuid(UUID.randomUUID())
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(UUID.randomUUID())
+                .productName("추가 상품")
+                .productPrice(20_000)
+                .status(OrderItemStatus.PAYMENT_COMPLETED)
+                .build();
+        targetOrderItem.getOrder().addOrderItem(anotherOrderItem);
+
+        authenticate(userUuid, "USER");
+        when(orderItemRepository.findByUuid(targetOrderItemUuid)).thenReturn(Optional.of(targetOrderItem));
+
+        useCase.execute(targetOrderItemUuid, OrderItemStatus.CANCEL_REQUESTED);
+
+        assertThat(targetOrderItem.getStatus()).isEqualTo(OrderItemStatus.CANCELED);
+        assertThat(anotherOrderItem.getStatus()).isEqualTo(OrderItemStatus.PAYMENT_COMPLETED);
+        assertThat(targetOrderItem.getOrder().getStatus()).isEqualTo(OrderStatus.PAID);
+        verify(eventPublisher).publish(any(OrderItemCanceledEvent.class));
+        verify(eventPublisher).publish(any(OrderProductSaleReleasedEvent.class));
+    }
+
+    @Test
+    @DisplayName("배송 시작 후 CANCEL_REQUESTED는 즉시 취소 시도되어 충돌 예외가 발생한다")
+    void cancelRequestedAfterShipmentFailsWithConflict() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderItemUuid = UUID.randomUUID();
+        OrderItem orderItem = createOrderItem(orderItemUuid, userUuid, OrderItemStatus.SHIPPED);
+
+        authenticate(userUuid, "USER");
+        when(orderItemRepository.findByUuid(orderItemUuid)).thenReturn(Optional.of(orderItem));
+
+        assertThatThrownBy(() -> useCase.execute(orderItemUuid, OrderItemStatus.CANCEL_REQUESTED))
+                .isInstanceOf(ConflictException.class);
+
+        assertThat(orderItem.getStatus()).isEqualTo(OrderItemStatus.SHIPPED);
+        verify(eventPublisher, never()).publish(any(OrderItemCanceledEvent.class));
+        verify(eventPublisher, never()).publish(any(OrderProductSaleReleasedEvent.class));
     }
 
     private void authenticate(UUID userUuid, String role) {
@@ -88,7 +160,7 @@ class UpdateOrderItemStatusUseCaseTest {
         SecurityContextHolder.setContext(context);
     }
 
-    private OrderItem createOrderItem(UUID orderItemUuid, UUID userUuid) {
+    private OrderItem createOrderItem(UUID orderItemUuid, UUID userUuid, OrderItemStatus currentStatus) {
         Order order = Order.builder()
                 .uuid(UUID.randomUUID())
                 .userUuid(userUuid)
@@ -106,7 +178,7 @@ class UpdateOrderItemStatusUseCaseTest {
                 .sellerUuid(UUID.randomUUID())
                 .productName("테스트 상품")
                 .productPrice(10_000)
-                .status(OrderItemStatus.DELIVERED)
+                .status(currentStatus)
                 .build();
         order.addOrderItem(orderItem);
         return orderItem;

--- a/payment/src/main/java/dukku/payment/boundedContext/payment/app/HandleOrderItemCanceledEventUseCase.java
+++ b/payment/src/main/java/dukku/payment/boundedContext/payment/app/HandleOrderItemCanceledEventUseCase.java
@@ -4,6 +4,7 @@ import dukku.common.shared.order.event.OrderItemCanceledEvent;
 import dukku.common.shared.payment.dto.PaymentRefundRequest;
 import dukku.common.shared.payment.exception.PaymentNotFoundException;
 import dukku.common.shared.payment.exception.PaymentOrderItemNotFoundException;
+import dukku.common.shared.payment.type.PaymentHistoryType;
 import dukku.common.shared.payment.type.PaymentStatus;
 import dukku.payment.boundedContext.payment.entity.Payment;
 import dukku.payment.boundedContext.payment.entity.PaymentOrderItem;
@@ -24,48 +25,72 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HandleOrderItemCanceledEventUseCase {
 
-        private final PaymentSupport support;
-        private final RefundPaymentUseCase refundPaymentUseCase;
+    private final PaymentSupport support;
+    private final RefundPaymentUseCase refundPaymentUseCase;
 
-        @Transactional
-        public void execute(OrderItemCanceledEvent event) {
-                log.info("주문 상품 취소 이벤트 처리 시작 - orderItemUuid: {}", event.orderItemUuid());
+    @Transactional
+    public void execute(OrderItemCanceledEvent event) {
+        log.info("주문 상품 취소 이벤트 처리 시작 - orderItemUuid: {}", event.orderItemUuid());
 
-                // 1. 해당 주문 상품(OrderItemUuid)이 포함된 결제 내역 조회
-                Payment payment = support.findPaymentByOrderItemUuid(event.orderItemUuid())
-                                .orElseThrow(() -> {
-                                        log.error("해당 주문 상품에 대한 결제 내역을 찾을 수 없습니다. orderItemUuid: {}",
-                                                        event.orderItemUuid());
-                                        return new PaymentNotFoundException();
-                                });
+        // 1. 해당 주문 상품(OrderItemUuid)이 포함된 결제 내역 조회
+        Payment payment = support.findPaymentByOrderItemUuid(event.orderItemUuid())
+                .orElseThrow(() -> {
+                    log.error("해당 주문 상품에 대한 결제 내역을 찾을 수 없습니다. orderItemUuid: {}",
+                            event.orderItemUuid());
+                    return new PaymentNotFoundException();
+                });
 
-                // 2. 환불 가능 상태 확인 (이미 취소된 경우 중복 처리 방지)
-                if (payment.getPaymentStatus() == PaymentStatus.CANCELED) {
-                        log.warn("이미 전체 취소된 결제입니다. skip 처리. paymentUuid: {}", payment.getUuid());
-                        return;
-                }
-
-                // 3. 결제 항목 중 해당 OrderItem 찾기
-                PaymentOrderItem targetItem = payment.getItems().stream()
-                                .filter(item -> item.getOrderItemUuid().equals(event.orderItemUuid()))
-                                .findFirst()
-                                .orElseThrow(PaymentOrderItemNotFoundException::new);
-
-                // 4. 환불 요청 생성 (단일 상품 취소이므로 해당 상품 금액만큼)
-                PaymentRefundRequest request = PaymentRefundRequest.builder()
-                                .paymentUuid(payment.getUuid())
-                                .orderUuid(payment.getOrderUuid())
-                                .refundAmount(targetItem.getPrice())
-                                .reason("주문 전 상품 취소 (Item: " + event.orderItemUuid() + ")")
-                                .items(List.of(new PaymentRefundRequest.RefundItemInfo(
-                                                targetItem.getOrderItemUuid(),
-                                                targetItem.getPrice())))
-                                .build();
-
-                // 5. 환불 실행 (멱등성 키로 orderItemUuid 사용)
-                refundPaymentUseCase.execute(request, "CANCEL_" + event.orderItemUuid());
-
-                log.info("주문 상품 취소에 따른 환불 트리거 완료 - orderItemUuid: {}, paymentUuid: {}",
-                                event.orderItemUuid(), payment.getUuid());
+        // 2. 이미 전체 취소된 결제는 중복 처리하지 않는다.
+        if (payment.getPaymentStatus() == PaymentStatus.CANCELED) {
+            log.warn("이미 전체 취소된 결제입니다. skip 처리. paymentUuid: {}", payment.getUuid());
+            return;
         }
+
+        // 3. PENDING 상태는 승인 전이므로 환불 플로우 없이 즉시 취소 처리한다.
+        if (payment.getPaymentStatus() == PaymentStatus.PENDING) {
+            PaymentStatus originStatus = payment.getPaymentStatus();
+            Long originAmountPg = payment.getAmountPg();
+            Long originDeposit = payment.getPaymentDeposit();
+
+            payment.cancel();
+            support.savePayment(payment);
+            support.createHistory(payment, PaymentHistoryType.ORDER_CANCEL_SUCCESS,
+                    originStatus, originAmountPg, originDeposit);
+
+            log.info("승인 전 결제를 즉시 취소 처리했습니다. orderItemUuid: {}, paymentUuid: {}",
+                    event.orderItemUuid(), payment.getUuid());
+            return;
+        }
+
+        // 4. 환불 플로우는 DONE/PARTIAL_CANCELED 상태에서만 진행한다.
+        if (payment.getPaymentStatus() != PaymentStatus.DONE
+                && payment.getPaymentStatus() != PaymentStatus.PARTIAL_CANCELED) {
+            log.warn("환불 불가 상태입니다. skip 처리. paymentUuid: {}, status: {}",
+                    payment.getUuid(), payment.getPaymentStatus());
+            return;
+        }
+
+        // 5. 결제 항목 중 해당 OrderItem 찾기
+        PaymentOrderItem targetItem = payment.getItems().stream()
+                .filter(item -> item.getOrderItemUuid().equals(event.orderItemUuid()))
+                .findFirst()
+                .orElseThrow(PaymentOrderItemNotFoundException::new);
+
+        // 6. 환불 요청 생성 (단일 상품 취소이므로 해당 상품 금액만큼)
+        PaymentRefundRequest request = PaymentRefundRequest.builder()
+                .paymentUuid(payment.getUuid())
+                .orderUuid(payment.getOrderUuid())
+                .refundAmount(targetItem.getPrice())
+                .reason("주문 상품 취소 (Item: " + event.orderItemUuid() + ")")
+                .items(List.of(new PaymentRefundRequest.RefundItemInfo(
+                        targetItem.getOrderItemUuid(),
+                        targetItem.getPrice())))
+                .build();
+
+        // 7. 환불 실행 (멱등성 키로 orderItemUuid 사용)
+        refundPaymentUseCase.execute(request, "CANCEL_" + event.orderItemUuid());
+
+        log.info("주문 상품 취소에 따른 환불 트리거 완료 - orderItemUuid: {}, paymentUuid: {}",
+                event.orderItemUuid(), payment.getUuid());
+    }
 }

--- a/payment/src/test/java/dukku/payment/boundedContext/payment/app/HandleOrderItemCanceledEventUseCaseTest.java
+++ b/payment/src/test/java/dukku/payment/boundedContext/payment/app/HandleOrderItemCanceledEventUseCaseTest.java
@@ -1,0 +1,85 @@
+package dukku.payment.boundedContext.payment.app;
+
+import dukku.common.shared.order.event.OrderItemCanceledEvent;
+import dukku.common.shared.payment.dto.PaymentRefundRequest;
+import dukku.common.shared.payment.type.PaymentHistoryType;
+import dukku.common.shared.payment.type.PaymentStatus;
+import dukku.common.shared.payment.type.PaymentType;
+import dukku.payment.boundedContext.payment.entity.Payment;
+import dukku.payment.boundedContext.payment.entity.PaymentOrderItem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HandleOrderItemCanceledEventUseCaseTest {
+
+    @Mock
+    private PaymentSupport support;
+
+    @Mock
+    private RefundPaymentUseCase refundPaymentUseCase;
+
+    @InjectMocks
+    private HandleOrderItemCanceledEventUseCase useCase;
+
+    @Test
+    @DisplayName("PENDING 결제에서 주문상품 취소 이벤트를 받으면 결제를 즉시 CANCELED로 전환한다")
+    void cancelPendingPaymentDirectly() {
+        UUID orderUuid = UUID.randomUUID();
+        UUID orderItemUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+
+        Payment payment = Payment.create(orderUuid, userUuid, 10_000L,
+                0L, 10_000L, 0L, PaymentType.NORMAL, "order-1");
+        PaymentOrderItem item = PaymentOrderItem.create(payment, orderUuid, orderItemUuid,
+                UUID.randomUUID(), "item", 10_000L, 0L, UUID.randomUUID(), 0L);
+        payment.addItem(item);
+
+        when(support.findPaymentByOrderItemUuid(orderItemUuid)).thenReturn(Optional.of(payment));
+
+        useCase.execute(new OrderItemCanceledEvent(orderItemUuid));
+
+        assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CANCELED);
+        verify(support).savePayment(payment);
+        verify(support).createHistory(payment, PaymentHistoryType.ORDER_CANCEL_SUCCESS,
+                PaymentStatus.PENDING, 10_000L, 0L);
+        verify(refundPaymentUseCase, never()).execute(any(PaymentRefundRequest.class), any(String.class));
+    }
+
+    @Test
+    @DisplayName("DONE 결제에서 주문상품 취소 이벤트를 받으면 환불 플로우를 호출한다")
+    void triggerRefundForDonePayment() {
+        UUID orderUuid = UUID.randomUUID();
+        UUID orderItemUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+
+        Payment payment = Payment.create(orderUuid, userUuid, 10_000L,
+                0L, 10_000L, 0L, PaymentType.NORMAL, "order-2");
+        payment.approve("pg-key");
+
+        PaymentOrderItem item = PaymentOrderItem.create(payment, orderUuid, orderItemUuid,
+                UUID.randomUUID(), "item", 10_000L, 0L, UUID.randomUUID(), 0L);
+        payment.addItem(item);
+
+        when(support.findPaymentByOrderItemUuid(orderItemUuid)).thenReturn(Optional.of(payment));
+
+        useCase.execute(new OrderItemCanceledEvent(orderItemUuid));
+
+        verify(refundPaymentUseCase).execute(any(PaymentRefundRequest.class), eq("CANCEL_" + orderItemUuid));
+        verify(support, never()).savePayment(any(Payment.class));
+    }
+}


### PR DESCRIPTION
## PR 제목

[Order] 배송 전 주문상품 취소 시 상품 재고가 복구되지 않고 품절 상태가 됨 #315

---

## 개요

CANCEL 요청이 실제 취소 처리와 이벤트 발행으로 자연스럽게 이어지지 않는 구간이 존재
결제 서비스에서 취소 이벤트 처리 시 상태별 분기(PENDING vs DONE/부분취소)가 불명확
판매복구 이벤트 누락 시 상품이 품절 상태로 고착될 수 있음

---

## 상세 내용

 **주문상품 취소 요청을 즉시 취소로 전환하고 판매복구 이벤트 발행**
SHA : dc6f5b51e974a25373071a1ae5035a9f9854af63
- 사용자 CANCEL_REQUESTED 요청을 CANCELED로 즉시 변환하도록 상태 적용 로직을 정리했습니다.
- CANCELED 처리 시 OrderItemCanceledEvent와 OrderProductSaleReleasedEvent를 함께 발행하도록 보완했습니다.
- 모든 주문 아이템이 취소된 경우 주문 상태를 CANCELED로 동기화하는 로직을 추가했습니다.

**결제 서비스 주문상품 취소 이벤트 상태 분기 정교화**
SHA : 690421d1eb976ec7d53a836885a58d9ddea553ce
- OrderItemCanceledEvent 처리 시 PENDING 결제는 환불 없이 즉시 CANCELED 처리하도록 분기했습니다.
- DONE/PARTIAL_CANCELED 상태에서만 환불 플로우를 트리거하도록 조건을 명확히 했습니다.
- 결제 히스토리 기록과 로그를 분기별로 정리해 추적 가능성을 높였습니다.

**주문상품 취소 Saga 경로 테스트 보강**
SHA : f77453e810f4de2d83fef5c16f6001fbf8ce8a37
- 주문 서비스 테스트에 취소 시 판매복구 이벤트 발행 검증을 추가했습니다.
- 결제 서비스 테스트에 PENDING 즉시 취소와 DONE 환불 트리거 분기 시나리오를 추가했습니다.



---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
