### PR TITLE
[Product] 주문 취소/만료 후 상품 예약 해제가 누락되어 판매 상태가 복구되지 않음 #318

### DIFF
--- a/product/src/main/java/dukku/product/boundedContext/product/app/facade/ProductFacade.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/facade/ProductFacade.java
@@ -12,6 +12,7 @@ import dukku.product.boundedContext.product.app.usecase.product.FindCategoryList
 import dukku.product.boundedContext.product.app.usecase.product.FindFeaturedProductsUseCase;
 import dukku.product.boundedContext.product.app.usecase.product.FindProductDetailUseCase;
 import dukku.product.boundedContext.product.app.usecase.product.FindProductListUseCase;
+import dukku.product.boundedContext.product.app.usecase.product.ReleaseProductReservationUseCase;
 import dukku.product.boundedContext.product.app.usecase.product.ReserveProductUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,7 @@ public class ProductFacade {
     private final FindProductListUseCase findProductListUseCase;
     private final FindProductDetailUseCase findProductDetailUseCase;
     private final ReserveProductUseCase reserveProductUseCase;
+    private final ReleaseProductReservationUseCase releaseProductReservationUseCase;
     private final SearchProductUseCase searchProductUseCase;
 
     public List<CategoryCreateResponse> findCategories() {
@@ -83,5 +85,9 @@ public class ProductFacade {
 
     public void reserveProducts(ProductReserveRequest request) {
         reserveProductUseCase.execute(request);
+    }
+
+    public void releaseProducts(ProductReserveRequest request) {
+        releaseProductReservationUseCase.execute(request.orderUuid(), request.productUuids());
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/ReserveProductUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/ReserveProductUseCase.java
@@ -2,8 +2,10 @@ package dukku.product.boundedContext.product.app.usecase.product;
 
 import dukku.common.shared.product.dto.product.ProductReserveRequest;
 import dukku.common.shared.product.exception.PartialProductsNotFoundException;
+import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.product.boundedContext.product.entity.Product;
 import dukku.product.boundedContext.product.out.ProductRepository;
+import dukku.product.global.event.ProductUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReserveProductUseCase {
     private final ProductRepository productRepository;
+    private final EventPublisher eventPublisher;
 
     @Transactional
     public void execute(ProductReserveRequest request) {
@@ -33,6 +36,7 @@ public class ReserveProductUseCase {
         // TODO: 이미 판매 또는 예약된 경우라면?
         for (Product product : products) {
             product.reserve(request.orderUuid());
+            eventPublisher.publish(new ProductUpdatedEvent(product.getId(), false));
         }
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/entity/Product.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/entity/Product.java
@@ -229,10 +229,10 @@ public class Product extends BaseIdAndUUIDAndTime {
         }
     }
 
-    // 예약 해제 (RESERVED -> ON_SALE)
+    // 예약 해제 (RESERVED/SOLD_OUT -> ON_SALE)
     public void releaseReservation(UUID orderUuid) {
         // 내 주문이 맞는지 검증
-        if (this.saleStatus == SaleStatus.RESERVED &&
+        if ((this.saleStatus == SaleStatus.RESERVED || this.saleStatus == SaleStatus.SOLD_OUT) &&
                 this.reservedOrderUuid != null &&
                 this.reservedOrderUuid.equals(orderUuid)) {
 

--- a/product/src/main/java/dukku/product/boundedContext/product/in/ProductController.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/in/ProductController.java
@@ -54,4 +54,9 @@ public class ProductController {
     public void reserveProducts(@RequestBody ProductReserveRequest request) {
         productFacade.reserveProducts(request);
     }
+
+    @PostMapping("/products/internal/release")
+    public void releaseProducts(@RequestBody ProductReserveRequest request) {
+        productFacade.releaseProducts(request);
+    }
 }

--- a/product/src/test/java/dukku/product/boundedContext/product/entity/ProductReleaseReservationTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/entity/ProductReleaseReservationTest.java
@@ -1,0 +1,58 @@
+package dukku.product.boundedContext.product.entity;
+
+import dukku.common.shared.product.type.ConditionStatus;
+import dukku.common.shared.product.type.SaleStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductReleaseReservationTest {
+
+    @Test
+    @DisplayName("결제 확정 후 SOLD_OUT 상품도 동일 주문 취소 시 ON_SALE로 복구된다")
+    void releaseReservationShouldReopenSoldOutForSameOrder() {
+        UUID orderUuid = UUID.randomUUID();
+        Product product = createProduct();
+
+        product.reserve(orderUuid);
+        product.confirmSale(orderUuid);
+
+        assertThat(product.getSaleStatus()).isEqualTo(SaleStatus.SOLD_OUT);
+
+        product.releaseReservation(orderUuid);
+
+        assertThat(product.getSaleStatus()).isEqualTo(SaleStatus.ON_SALE);
+        assertThat(product.getReservedOrderUuid()).isNull();
+    }
+
+    @Test
+    @DisplayName("다른 주문 UUID로는 SOLD_OUT 복구되지 않는다")
+    void releaseReservationShouldIgnoreDifferentOrder() {
+        UUID reservedOrderUuid = UUID.randomUUID();
+        Product product = createProduct();
+
+        product.reserve(reservedOrderUuid);
+        product.confirmSale(reservedOrderUuid);
+
+        product.releaseReservation(UUID.randomUUID());
+
+        assertThat(product.getSaleStatus()).isEqualTo(SaleStatus.SOLD_OUT);
+        assertThat(product.getReservedOrderUuid()).isEqualTo(reservedOrderUuid);
+    }
+
+    private Product createProduct() {
+        Category category = Category.createRoot("전자기기");
+        return Product.create(
+                UUID.randomUUID(),
+                category,
+                "테스트 상품",
+                "설명",
+                10_000L,
+                0L,
+                ConditionStatus.NO_WEAR
+        );
+    }
+}


### PR DESCRIPTION
## PR 제목

[Order] 환불 완료 취소 경로에서 상품 판매복구 이벤트가 누락됨 #316


---

## 개요

주문 취소/만료 시 상품 예약 해제를 내부 API로 처리하고 상태 복구를 보장
주문/결제 서비스에서 상품 예약 해제를 일관되게 호출할 내부 진입점 필요
동일 주문 기준 SOLD_OUT 상태 복구가 제한되어 품절 고착 가능성 존재

---

## 상세 내용

**상품 예약 해제 내부 API 엔드포인트 추가**
SHA : fdfe7445727c63f77ec2e3c3d620cfff04054da6
- ProductFacade에 releaseProducts 진입점을 추가했습니다.
- ProductController에 /products/internal/release 엔드포인트를 추가해 내부 서비스에서 예약 해제를 호출할 수 있도록 했습니다.

**예약/해제 시 상품 상태 복구와 ES 갱신 이벤트 보강**
SHA : d973c7670fc8eef734a460176381e5b769a8989a
- ReserveProductUseCase에서 예약 처리 후 ProductUpdatedEvent를 발행하도록 추가했습니다.
- Product.releaseReservation이 동일 주문의 SOLD_OUT 상태도 ON_SALE로 복구할 수 있도록 확장했습니다.

**SOLD_OUT 예약 해제 복구 시나리오 추가**
SHA : 8149151b4d982b79ef38348141d01caeec72d073
- 동일 주문 UUID로 예약/판매 확정된 상품이 releaseReservation 호출 시 ON_SALE로 복구되는 시나리오를 검증했습니다.
- 다른 주문 UUID로는 복구되지 않는 보호 조건도 함께 검증했습니다.

---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
