### PR TITLE
[Product] 상품 상세 조회 시 판매자 중복 생성으로 500 오류가 발생함 #317 Open

### DIFF
--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
@@ -37,26 +37,27 @@ public class FindProductDetailUseCase {
 
         Product product = productRepository.findByUuidWithImagesAndCategory(productUuid)
                 .or(() -> {
-                    log.warn("[FindProductDetailUseCase] 패치 조인 쿼리로 상품 조회 실패. 기본 조회(findByUuid)를 시도합니다. productUuid={}",
-                            productUuid);
+                    log.warn("[FindProductDetailUseCase] 패치 조인 조회 실패, 기본 조회로 재시도. productUuid={}", productUuid);
                     return productRepository.findByUuid(productUuid);
                 })
                 .orElseThrow(() -> {
-                    log.error("[FindProductDetailUseCase] 어떤 방식으로도 상품을 찾을 수 없습니다. productUuid={}", productUuid);
+                    log.error("[FindProductDetailUseCase] 상품을 찾을 수 없습니다. productUuid={}", productUuid);
                     return new ProductNotFoundException();
                 });
 
-        log.info("[FindProductDetailUseCase] 상품 조회 성공. title={}, sellerUuid={}", product.getTitle(),
-                product.getSellerUuid());
+        log.info("[FindProductDetailUseCase] 상품 조회 성공. title={}, sellerUuid={}", product.getTitle(), product.getSellerUuid());
 
         productStatsRedisSupport.incrementView(product.getId());
 
-        // 상점 정보 조회: 이벤트 지연/누락으로 ProductSeller가 없으면 즉시 생성
-        ProductSeller seller = productSellerRepository.findByUserUuid(product.getSellerUuid())
+        // Product.sellerUuid는 seller UUID이므로 sellerUuid 기준으로 먼저 조회한다.
+        ProductSeller seller = productSellerRepository.findBySellerUuid(product.getSellerUuid())
+                // 과거 데이터 호환: sellerUuid에 userUuid가 들어간 레코드도 허용
+                .or(() -> productSellerRepository.findByUserUuid(product.getSellerUuid()))
                 .orElseGet(() -> {
-                    log.warn("[FindProductDetailUseCase] 상점 정보(ProductSeller)가 없어 자동 생성합니다. userUuid={}, productUuid={}",
+                    // 상세 조회(GET)에서 DB write를 유발하지 않도록 비영속 기본값만 사용한다.
+                    log.warn("[FindProductDetailUseCase] 상점 정보 누락. 기본값으로 응답합니다. sellerUuid={}, productUuid={}",
                             product.getSellerUuid(), productUuid);
-                    return productSellerRepository.save(ProductSeller.create(product.getSellerUuid(), "반가워요! 내 상점입니다."));
+                    return ProductSeller.create(product.getSellerUuid(), "판매 중인 상점입니다.");
                 });
 
         log.info("[FindProductDetailUseCase] 상점 정보 조회 성공. sellerUserUuid={}", seller.getUserUuid());
@@ -93,7 +94,7 @@ public class FindProductDetailUseCase {
 
             return nickname;
         } catch (Exception e) {
-            log.warn("[FindProductDetailUseCase] 유저 프로필 조회 실패로 기본 닉네임 사용. userUuid={}", userUuid, e);
+            log.warn("[FindProductDetailUseCase] 사용자 프로필 조회 실패로 기본 닉네임 사용. userUuid={}", userUuid, e);
             return "이름없음";
         }
     }

--- a/product/src/main/java/dukku/product/boundedContext/product/out/ProductSellerRepository.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/out/ProductSellerRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface ProductSellerRepository extends JpaRepository<ProductSeller, Integer>, CustomProductSellerRepository {
+    Optional<ProductSeller> findBySellerUuid(UUID sellerUuid);
+
     Optional<ProductSeller> findByUserUuid(UUID userUuid);
 
     Optional<ProductSeller> findByUuid(UUID shopUuid);


### PR DESCRIPTION
## PR 제목

[Product] 상품 상세 조회 시 판매자 중복 생성으로 500 오류가 발생함 #317


---

## 개요

상품 상세 조회에서 seller 조회 실패 시 DB write가 발생하며 unique 충돌 가능
Product.sellerUuid 의미와 조회 기준(userUuid/sellerUuid)이 어긋난 구간 존재



---

## 상세 내용

**판매자 저장소에 sellerUuid 조회 메서드 추가**
SHA : 6d136a5c1369309da44886ec4b09eb5cc4524f33
- ProductSellerRepository에 findBySellerUuid(UUID) 메서드를 추가했습니다.
- 기존 userUuid 기반 조회와 병행할 수 있도록 조회 축을 확장했습니다.


**상품 상세 조회에서 sellerUuid 우선 조회 및 비영속 fallback 적용**
SHA : 892a01c4bbe7dd5656add20d061d85067ae973f1
- Product.sellerUuid를 sellerUuid 기준으로 먼저 조회하고, 과거 데이터 호환을 위해 userUuid fallback을 유지했습니다.
- 상세 조회(GET) 중 판매자 정보 누락 시 DB 저장을 수행하지 않고 기본 응답 객체로 대체하도록 변경했습니다.
- 관련 로그 메시지를 정리해 원인 추적을 용이하게 했습니다.


---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
