### PR TITLE
[Order] 환불 완료 취소 경로에서 상품 판매복구 이벤트가 누락됨 #316

### DIFF
--- a/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
@@ -1,5 +1,7 @@
 package dukku.order.boundedContext.order.app;
 
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.order.event.OrderProductSaleReleasedEvent;
 import dukku.common.shared.order.exception.OrderRefundAmountOutOfRangeException;
 import dukku.common.shared.order.exception.OrderRefundRequestInvalidException;
 import dukku.common.shared.order.type.OrderItemStatus;
@@ -23,6 +25,7 @@ public class UpdateOrderRefundStatusUseCase {
 
     private final OrderSupport orderSupport;
     private final ReturnRequestRepository returnRequestRepository;
+    private final EventPublisher eventPublisher;
 
     /**
      * 환불 완료 이벤트 반영 처리
@@ -69,6 +72,7 @@ public class UpdateOrderRefundStatusUseCase {
 
         if (order.getRefundedAmount() >= order.getTotalAmount()) {
             order.updateOrderStatus(OrderStatus.CANCELED);
+            eventPublisher.publish(new OrderProductSaleReleasedEvent(order.getUuid(), order.getProductUuids()));
             return;
         }
 

--- a/order/src/test/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCaseHappyPathTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCaseHappyPathTest.java
@@ -1,13 +1,18 @@
 package dukku.order.boundedContext.order.app;
 
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.order.event.OrderProductSaleReleasedEvent;
 import dukku.common.shared.order.exception.OrderRefundAmountOutOfRangeException;
 import dukku.common.shared.order.exception.OrderRefundRequestInvalidException;
+import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.common.shared.order.type.OrderStatus;
 import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.entity.OrderItem;
 import dukku.order.boundedContext.order.out.ReturnRequestRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,13 +22,12 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- * 주문 환불 상태 갱신 유스케이스 정상/예외 경로 테스트.
- */
 @ExtendWith(MockitoExtension.class)
 class UpdateOrderRefundStatusUseCaseHappyPathTest {
 
@@ -33,12 +37,15 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
     @Mock
     private ReturnRequestRepository returnRequestRepository;
 
+    @Mock
+    private EventPublisher eventPublisher;
+
     @InjectMocks
     private UpdateOrderRefundStatusUseCase useCase;
 
     @Test
-    @DisplayName("전액 환불 시 환불 누적액이 갱신되고 상태가 CANCELED로 변경된다")
-    void 전액환불_상태변경() {
+    @DisplayName("전액 환불 시 환불 누적액이 갱신되고 상태가 CANCELED로 변경되며 판매 복구 이벤트를 발행한다")
+    void fullRefundPublishesSaleReleaseEvent() {
         // given: 전액 환불 이벤트와 PAID 상태 주문을 준비한다.
         UUID refundUuid = UUID.randomUUID();
         UUID orderUuid = UUID.randomUUID();
@@ -50,16 +57,23 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
         // when: 환불 갱신 유스케이스를 실행한다.
         useCase.updateRefund(refundUuid, orderUuid, 12_000L, List.of());
 
-        // then: 환불 누적액이 주문 총액과 같아지고 상태가 CANCELED가 된다.
+        // then: 주문 상태/누적 환불액이 갱신되고 판매 복구 이벤트가 발행된다.
         verify(orderSupport).findOrderByUuidWithItems(orderUuid);
         assertThat(order.getRefundedAmount()).isEqualTo(12_000);
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+
+        ArgumentCaptor<OrderProductSaleReleasedEvent> eventCaptor =
+                ArgumentCaptor.forClass(OrderProductSaleReleasedEvent.class);
+        verify(eventPublisher).publish(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().orderUuid()).isEqualTo(orderUuid);
+        assertThat(eventCaptor.getValue().productUuids())
+                .containsExactly(order.getOrderItems().get(0).getProductUuid());
     }
 
     @Test
-    @DisplayName("부분 환불이면 환불 누적액이 갱신되고 상태가 PARTIAL_REFUNDED로 변경된다")
-    void 주문_부분환불_상태변경() {
-        // given
+    @DisplayName("부분 환불 시 환불 누적액이 갱신되고 상태가 PARTIAL_REFUNDED로 변경되며 판매 복구 이벤트는 발행되지 않는다")
+    void partialRefundDoesNotPublishSaleReleaseEvent() {
+        // given: 부분 환불 이벤트와 PAID 상태 주문을 준비한다.
         UUID refundUuid = UUID.randomUUID();
         UUID orderUuid = UUID.randomUUID();
         Order order = newPaidOrder(orderUuid, 12_000);
@@ -70,15 +84,16 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
         // when: 환불 갱신 유스케이스를 실행한다.
         useCase.updateRefund(refundUuid, orderUuid, 5_000L, List.of());
 
-        // then: 환불 누적액이 증가하고 상태가 PARTIAL_REFUNDED가 된다.
+        // then: 주문 상태/누적 환불액이 부분 환불 기준으로 갱신된다.
         verify(orderSupport).findOrderByUuidWithItems(orderUuid);
         assertThat(order.getRefundedAmount()).isEqualTo(5_000);
         assertThat(order.getStatus()).isEqualTo(OrderStatus.PARTIAL_REFUNDED);
+        verify(eventPublisher, never()).publish(any());
     }
 
     @Test
     @DisplayName("환불 금액이 int 범위를 초과하면 OrderRefundAmountOutOfRangeException이 발생한다")
-    void 환불금액_범위초과_예외발생() {
+    void refundAmountOverIntThrowsException() {
         // given: int 범위를 초과하는 환불 금액을 준비한다.
         UUID refundUuid = UUID.randomUUID();
         UUID orderUuid = UUID.randomUUID();
@@ -88,39 +103,37 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
         when(orderSupport.tryMarkRefundCompleted(refundUuid, orderUuid, overInt)).thenReturn(true);
         when(orderSupport.findOrderByUuidWithItems(orderUuid)).thenReturn(order);
 
-        // when: 범위를 넘는 환불 금액으로 환불 갱신을 실행한다.
-        // then: OrderRefundAmountOutOfRangeException 예외가 발생한다.
+        // when/then: 범위를 넘는 환불 금액으로 환불 갱신 시 예외가 발생한다.
         assertThatThrownBy(() -> useCase.updateRefund(refundUuid, orderUuid, overInt, List.of()))
                 .isInstanceOf(OrderRefundAmountOutOfRangeException.class);
     }
 
     @Test
     @DisplayName("환불 이벤트 입력값이 유효하지 않으면 OrderRefundRequestInvalidException이 발생한다")
-    void 환불이벤트_입력값검증_실패() {
-        // given: refundUuid가 null인 잘못된 환불 이벤트를 준비한다.
-        // when: 환불 갱신 유스케이스를 실행한다.
-        // then: OrderRefundRequestInvalidException 예외가 발생한다.
+    void invalidInputThrowsException() {
         assertThatThrownBy(() -> useCase.updateRefund(null, UUID.randomUUID(), 1_000L, List.of()))
                 .isInstanceOf(OrderRefundRequestInvalidException.class);
     }
 
     @Test
-    @DisplayName("이미 처리된 환불 이벤트는 후속 처리를 건너뛴다")
-    void 환불이벤트_멱등처리_중복무시() {
+    @DisplayName("이미 처리된 환불 이벤트는 무시된다")
+    void duplicateRefundEventIsIgnored() {
         // given: 이미 처리된 환불 이벤트로 표시되도록 준비한다.
         UUID refundUuid = UUID.randomUUID();
         UUID orderUuid = UUID.randomUUID();
+
         when(orderSupport.tryMarkRefundCompleted(refundUuid, orderUuid, 1_000L)).thenReturn(false);
 
         // when: 동일한 환불 이벤트로 환불 갱신을 다시 호출한다.
         useCase.updateRefund(refundUuid, orderUuid, 1_000L, List.of());
 
-        // then: 후속 저장소 호출이 발생하지 않는다.
+        // then: 후속 저장소/이벤트 발행 호출이 발생하지 않는다.
         verifyNoInteractions(returnRequestRepository);
+        verifyNoInteractions(eventPublisher);
     }
 
     private Order newPaidOrder(UUID orderUuid, int totalAmount) {
-        return Order.builder()
+        Order order = Order.builder()
                 .uuid(orderUuid)
                 .userUuid(UUID.randomUUID())
                 .totalAmount(totalAmount)
@@ -130,5 +143,15 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
                 .refundedAmount(0)
                 .status(OrderStatus.PAID)
                 .build();
+
+        order.addOrderItem(OrderItem.builder()
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(UUID.randomUUID())
+                .productName("test-product")
+                .productPrice(totalAmount)
+                .status(OrderItemStatus.PAYMENT_COMPLETED)
+                .build());
+
+        return order;
     }
 }


### PR DESCRIPTION
## PR 제목

[Order] 환불 완료 취소 경로에서 상품 판매복구 이벤트가 누락됨 #316


---

## 개요

실제 운영 경로에서 취소가 CANCELED가 아닌 REFUND_COMPLETED 기반으로 종료되는 케이스 존재
해당 경로에서 판매복구 이벤트가 누락되어 상품 상태 불일치 발생 가능

---

## 상세 내용

**전액 환불 취소 전환 시 판매복구 이벤트 발행 추가**
SHA : 6205fc2adb7780cbe5886f88dc98fb72420f62b3
- 환불 누적 금액이 주문 총액 이상일 때 주문 상태를 CANCELED로 전환하는 지점에서 OrderProductSaleReleasedEvent를 발행하도록 추가했습니다.
- REFUND_COMPLETED 기반 취소 경로에서도 상품 판매 상태 복구 이벤트가 누락되지 않도록 보완했습니다.

**환불완료 판매복구 이벤트 발행 조건 검증 추가**
SHA : 1f2d83bfd5ac22ae216655ad57fa288ced89e34d
- 전액 환불 시 판매복구 이벤트가 발행되는지 검증을 추가했습니다.
- 부분 환불 시에는 판매복구 이벤트가 발행되지 않는 조건을 검증했습니다.

---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [ ] 커밋 메시지가 컨벤션에 맞는가?
- [ ] 변경 사항이 테스트되었는가?
- [ ] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [ ] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [ ] 메소드 역할과 책임이 적절하게 분리되었는가?
- [ ] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [ ] 기존 기능에 영향을 주지 않는가?
- [ ] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**:
- **고민했던 설계 포인트**:
- **리뷰 시 특히 피드백 받고 싶은 부분**:
