### PR TITLE
[Product] 판매자 상점 평점이 의도와 다르게 표시 #330

### DIFF
--- a/ai/src/main/java/dukku/ai/global/AiInitData.java
+++ b/ai/src/main/java/dukku/ai/global/AiInitData.java
@@ -58,6 +58,10 @@ public class AiInitData {
 
     private void ensureVectorDimensions() {
         int dim = AiSimilarityPolicy.EMBEDDING_DIMENSION;
+        if (!isVectorTypeAvailable()) {
+            log.warn("[AiInitData] vector 타입 미지원 DB 환경 - AI 벡터 스키마 보정을 건너뜁니다.");
+            return;
+        }
 
         // PGroonga 확장 (미설치 환경에서는 키워드 검색 없이 벡터 검색만 동작)
         boolean pgroongaAvailable = false;
@@ -107,6 +111,19 @@ public class AiInitData {
             }
         } catch (Exception e) {
             log.warn("[AiInitData] ai_memory.embedding 차원 확인 실패 (무시): {}", e.getMessage());
+        }
+    }
+
+    private boolean isVectorTypeAvailable() {
+        try {
+            Integer exists = jdbcTemplate.queryForObject(
+                    "SELECT 1 FROM pg_type WHERE typname = 'vector' LIMIT 1",
+                    Integer.class
+            );
+            return exists != null && exists == 1;
+        } catch (Exception e) {
+            log.warn("[AiInitData] vector 타입 확인 실패 (무시): {}", e.getMessage());
+            return false;
         }
     }
 

--- a/common/src/main/java/dukku/common/shared/product/dto/follow/FollowedSellerCardResponse.java
+++ b/common/src/main/java/dukku/common/shared/product/dto/follow/FollowedSellerCardResponse.java
@@ -13,4 +13,25 @@ public record FollowedSellerCardResponse(
         long followerCount,
         boolean followed
 ) {
+    public FollowedSellerCardResponse(
+            UUID sellerUuid,
+            UUID shopUuid,
+            String nickname,
+            String intro,
+            Double averageRating,
+            Long reviewCount,
+            Long followerCount,
+            Boolean followed
+    ) {
+        this(
+                sellerUuid,
+                shopUuid,
+                nickname,
+                intro,
+                averageRating == null ? BigDecimal.ZERO : BigDecimal.valueOf(averageRating),
+                reviewCount == null ? 0 : Math.toIntExact(reviewCount),
+                followerCount == null ? 0L : followerCount,
+                followed != null && followed
+        );
+    }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
@@ -12,12 +12,15 @@ import dukku.product.boundedContext.product.entity.ProductUser;
 import dukku.product.boundedContext.product.out.ProductRepository;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
+import dukku.product.boundedContext.product.out.SellerReviewRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.UUID;
 
 @Slf4j
@@ -29,6 +32,7 @@ public class FindProductDetailUseCase {
     private final ProductStatsRedisSupport productStatsRedisSupport;
     private final ProductSellerRepository productSellerRepository;
     private final ProductUserRepository productUserRepository;
+    private final SellerReviewRepository sellerReviewRepository;
     private final UserApiClient userApiClient;
 
     @Transactional
@@ -63,10 +67,14 @@ public class FindProductDetailUseCase {
         log.info("[FindProductDetailUseCase] 상점 정보 조회 성공. sellerUserUuid={}", seller.getUserUuid());
 
         String nickname = resolveNicknameWithBackfill(seller.getUserUuid());
+        long reviewCountLong = sellerReviewRepository.countBySellerUuidAndDeletedAtIsNull(seller.getSellerUuid());
+        int reviewCount = Math.toIntExact(reviewCountLong);
+        BigDecimal averageRating = BigDecimal.valueOf(sellerReviewRepository.avgRating(seller.getSellerUuid()))
+                .setScale(2, RoundingMode.HALF_UP);
 
         log.info("[FindProductDetailUseCase] 최종 조회 완료. nickname={}", nickname);
 
-        return ProductMapper.toDetail(product, seller, nickname);
+        return ProductMapper.toDetail(product, seller, nickname, averageRating, reviewCount);
     }
 
     private String resolveNicknameWithBackfill(UUID userUuid) {

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindMyShopUseCase.java
@@ -7,12 +7,15 @@ import dukku.product.boundedContext.product.entity.ProductSeller;
 import dukku.product.boundedContext.product.entity.ProductUser;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
+import dukku.product.boundedContext.product.out.SellerReviewRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.UUID;
 
 @Slf4j
@@ -22,6 +25,7 @@ public class FindMyShopUseCase {
 
     private final ProductSellerRepository productSellerRepository;
     private final ProductUserRepository productUserRepository;
+    private final SellerReviewRepository sellerReviewRepository;
     private final UserApiClient userApiClient;
 
     @Transactional
@@ -31,8 +35,21 @@ public class FindMyShopUseCase {
                 .orElseGet(() -> productSellerRepository.save(ProductSeller.create(userUuid, "반가워요! 내 상점입니다.")));
 
         String nickname = resolveNicknameWithBackfill(seller.getUserUuid());
+        long reviewCountLong = sellerReviewRepository.countBySellerUuidAndDeletedAtIsNull(seller.getSellerUuid());
+        int reviewCount = Math.toIntExact(reviewCountLong);
+        BigDecimal averageRating = BigDecimal.valueOf(sellerReviewRepository.avgRating(seller.getSellerUuid()))
+                .setScale(2, RoundingMode.HALF_UP);
 
-        return ProductSeller.from(seller, nickname);
+        return ShopResponse.builder()
+                .shopUuid(seller.getUuid())
+                .sellerUuid(seller.getSellerUuid())
+                .nickname(nickname)
+                .intro(seller.getIntro())
+                .salesCount(seller.getSalesCount())
+                .activeListingCount(seller.getActiveListingCount())
+                .averageRating(averageRating)
+                .reviewCount(reviewCount)
+                .build();
     }
 
     private String resolveNicknameWithBackfill(UUID userUuid) {

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindShopUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/shop/FindShopUseCase.java
@@ -8,12 +8,15 @@ import dukku.product.boundedContext.product.entity.ProductSeller;
 import dukku.product.boundedContext.product.entity.ProductUser;
 import dukku.product.boundedContext.product.out.ProductSellerRepository;
 import dukku.product.boundedContext.product.out.ProductUserRepository;
+import dukku.product.boundedContext.product.out.SellerReviewRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.UUID;
 
 @Slf4j
@@ -23,6 +26,7 @@ public class FindShopUseCase {
 
     private final ProductSellerRepository productSellerRepository;
     private final ProductUserRepository productUserRepository;
+    private final SellerReviewRepository sellerReviewRepository;
     private final UserApiClient userApiClient;
 
     @Transactional
@@ -31,8 +35,21 @@ public class FindShopUseCase {
                 .orElseThrow(ProductSellerNotFoundException::new);
 
         String nickname = resolveNicknameWithBackfill(seller.getUserUuid());
+        long reviewCountLong = sellerReviewRepository.countBySellerUuidAndDeletedAtIsNull(seller.getSellerUuid());
+        int reviewCount = Math.toIntExact(reviewCountLong);
+        BigDecimal averageRating = BigDecimal.valueOf(sellerReviewRepository.avgRating(seller.getSellerUuid()))
+                .setScale(2, RoundingMode.HALF_UP);
 
-        return ProductSeller.from(seller, nickname);
+        return ShopResponse.builder()
+                .shopUuid(seller.getUuid())
+                .sellerUuid(seller.getSellerUuid())
+                .nickname(nickname)
+                .intro(seller.getIntro())
+                .salesCount(seller.getSalesCount())
+                .activeListingCount(seller.getActiveListingCount())
+                .averageRating(averageRating)
+                .reviewCount(reviewCount)
+                .build();
     }
 
     private String resolveNicknameWithBackfill(UUID userUuid) {


### PR DESCRIPTION
﻿## PR 제목

[Product] 판매자 상점 평점이 의도와 다르게 표시 #330

---

## 개요

리뷰가 없는데도 기본 평점이 보이던 문제를 수정했습니다.
상점/상품 상세의 판매자 평점을 리뷰 집계값(avg/count) 기반으로 조회하도록 변경했습니다.

---

## 상세 내용

**상점/상품 상세 평점 집계 로직 반영**
SHA : bd6a2e7c9c65369d039af7b9248980eb14481207
- 상품 상세 조회에서 판매자 평점을 SellerReview 집계값으로 계산하도록 변경했습니다.
- 내 상점/판매자 상점 조회에서도 동일한 집계 로직을 사용하도록 통일했습니다.
- 리뷰가 없을 때 기본 평점이 노출되지 않도록 null/0 처리 경계를 정리했습니다.

---

## PR 유형 (라벨 지정 필수)

- [ ] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [x] 커밋 메시지가 컨벤션에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [x] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [x] 메소드 역할과 책임이 적절하게 분리되었는가?
- [x] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [x] 기존 기능에 영향을 주지 않는가?
- [x] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**: 리뷰 0건 케이스에서 평점/건수 표기 규칙
- **고민했던 설계 포인트**: 조회 경로별 계산 차이를 없애고 단일 집계 규칙으로 맞춘 부분
- **리뷰 시 특히 피드백 받고 싶은 부분**: 평균 평점 반올림/표시 정책의 적절성

---

Closes #330
