### PR TITLE
[User] 마이페이지에 자기소개(상점소개) 텍스트가 노출되지 않음 #329

### DIFF
--- a/ai/src/main/java/dukku/ai/global/AiInitData.java
+++ b/ai/src/main/java/dukku/ai/global/AiInitData.java
@@ -58,6 +58,10 @@ public class AiInitData {
 
     private void ensureVectorDimensions() {
         int dim = AiSimilarityPolicy.EMBEDDING_DIMENSION;
+        if (!isVectorTypeAvailable()) {
+            log.warn("[AiInitData] vector 타입 미지원 DB 환경 - AI 벡터 스키마 보정을 건너뜁니다.");
+            return;
+        }
 
         // PGroonga 확장 (미설치 환경에서는 키워드 검색 없이 벡터 검색만 동작)
         boolean pgroongaAvailable = false;
@@ -107,6 +111,19 @@ public class AiInitData {
             }
         } catch (Exception e) {
             log.warn("[AiInitData] ai_memory.embedding 차원 확인 실패 (무시): {}", e.getMessage());
+        }
+    }
+
+    private boolean isVectorTypeAvailable() {
+        try {
+            Integer exists = jdbcTemplate.queryForObject(
+                    "SELECT 1 FROM pg_type WHERE typname = 'vector' LIMIT 1",
+                    Integer.class
+            );
+            return exists != null && exists == 1;
+        } catch (Exception e) {
+            log.warn("[AiInitData] vector 타입 확인 실패 (무시): {}", e.getMessage());
+            return false;
         }
     }
 

--- a/common/src/main/java/dukku/common/global/handler/GlobalExceptionHandler.java
+++ b/common/src/main/java/dukku/common/global/handler/GlobalExceptionHandler.java
@@ -10,6 +10,9 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * 전역 예외 처리 클래스.
@@ -62,6 +65,40 @@ public class GlobalExceptionHandler {
                 .body(errorResponse);
     }
 
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestPartException(
+            MissingServletRequestPartException ex
+    ) {
+        log.error("MissingServletRequestPartException: {}", ex.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "필수 파일 파트가 누락되었습니다.",
+                HttpStatus.BAD_REQUEST.value(),
+                ex.getMessage()
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(
+            MaxUploadSizeExceededException ex
+    ) {
+        log.error("MaxUploadSizeExceededException: {}", ex.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.PAYLOAD_TOO_LARGE.getReasonPhrase(),
+                "업로드 가능한 파일 크기를 초과했습니다.",
+                HttpStatus.PAYLOAD_TOO_LARGE.value(),
+                ex.getMessage()
+        );
+
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+                .body(errorResponse);
+    }
+
     /**
      * BaseException 계열 예외 처리.
      * 커스텀 예외에서 제공하는 상태 코드, 에러 코드, 메시지, 상세 정보를 포함하여 응답 생성.
@@ -76,6 +113,21 @@ public class GlobalExceptionHandler {
         ErrorResponse errorResponse = new ErrorResponse(ex.getCode(), ex.getMessage(), ex.getStatus().value(), ex.getDetails());
 
         return ResponseEntity.status(ex.getStatus())
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<ErrorResponse> handleResponseStatusException(ResponseStatusException ex) {
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+        log.error("ResponseStatusException [{}]: {}", status.value(), ex.getReason(), ex);
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                status.getReasonPhrase(),
+                ex.getReason() == null ? "요청 처리 중 오류가 발생했습니다." : ex.getReason(),
+                status.value()
+        );
+
+        return ResponseEntity.status(status)
                 .body(errorResponse);
     }
 

--- a/common/src/main/java/dukku/common/shared/product/dto/product/ImageUploadResponse.java
+++ b/common/src/main/java/dukku/common/shared/product/dto/product/ImageUploadResponse.java
@@ -1,0 +1,11 @@
+package dukku.common.shared.product.dto.product;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageUploadResponse {
+    private String url;
+}
+

--- a/common/src/main/java/dukku/common/shared/user/dto/UserResponse.java
+++ b/common/src/main/java/dukku/common/shared/user/dto/UserResponse.java
@@ -17,6 +17,7 @@ public class UserResponse {
     private UUID userUuid;
     private String email;
     private String nickname;
+    private String intro;
     private Role role;
     private UserStatus status;
     private String statusLabel;

--- a/common/src/main/java/dukku/common/shared/user/dto/UserUpdateRequest.java
+++ b/common/src/main/java/dukku/common/shared/user/dto/UserUpdateRequest.java
@@ -7,5 +7,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserUpdateRequest {
     private String name;
+    private String intro;
 
 }

--- a/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderItemStatusUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderItemStatusUseCase.java
@@ -2,13 +2,16 @@ package dukku.order.boundedContext.order.app;
 
 import dukku.common.global.UserUtil;
 import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.order.event.OrderItemCanceledEvent;
+import dukku.common.shared.order.event.OrderItemConfirmedEvent;
+import dukku.common.shared.order.event.OrderProductSaleReleasedEvent;
+import dukku.common.shared.order.event.OrderItemRefundRequestedEvent;
 import dukku.common.shared.order.exception.OrderAccessDeniedException;
 import dukku.common.shared.order.exception.OrderItemActionNotAllowedException;
 import dukku.common.shared.order.exception.OrderItemNotFoundException;
-import dukku.common.shared.order.event.OrderItemCanceledEvent;
-import dukku.common.shared.order.event.OrderItemConfirmedEvent;
-import dukku.common.shared.order.event.OrderItemRefundRequestedEvent;
 import dukku.common.shared.order.type.OrderItemStatus;
+import dukku.common.shared.order.type.OrderStatus;
+import dukku.order.boundedContext.order.entity.Order;
 import dukku.order.boundedContext.order.entity.OrderItem;
 import dukku.order.boundedContext.order.out.OrderItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Slf4j
@@ -34,31 +38,35 @@ public class UpdateOrderItemStatusUseCase {
         OrderItem orderItem = orderItemRepository.findByUuid(orderItemUuid)
                 .orElseThrow(OrderItemNotFoundException::new);
 
-        // 1) 권한 검증 (관리자 프리패스, 사용자 엄격 검증)
         checkPermission(orderItem, newStatus);
 
-        // 2) 상태 변경 (엔티티 내부에서 흐름 검증 수행 -> 실패 시 예외 발생)
-        orderItem.updateOrderStatus(newStatus);
+        // 배송 전 사용자 취소 요청(CANCEL_REQUESTED)은 즉시 취소(CANCELED)로 처리한다.
+        OrderItemStatus targetStatus = resolveTargetStatus(orderItem, newStatus);
 
-        // 3) 변경된 상태에 맞는 이벤트 발행 (알림, 정산, 재고 복구 등)
-        publishEvent(orderItem, newStatus);
+        orderItem.updateOrderStatus(targetStatus);
+        syncOrderStatusIfAllItemsCanceled(orderItem, targetStatus);
+        publishEvent(orderItem, targetStatus);
 
-        log.info("주문 상품 상태 변경 완료: uuid={}, status={}", orderItemUuid, newStatus);
+        log.info("Order item status updated. orderItemUuid={}, requestedStatus={}, appliedStatus={}",
+                orderItemUuid, newStatus, targetStatus);
+    }
+
+    private OrderItemStatus resolveTargetStatus(OrderItem orderItem, OrderItemStatus requestedStatus) {
+        if (requestedStatus == OrderItemStatus.CANCEL_REQUESTED) {
+            return OrderItemStatus.CANCELED;
+        }
+        return requestedStatus;
     }
 
     private void checkPermission(OrderItem orderItem, OrderItemStatus newStatus) {
-        // 관리자는 모든 권한 허용 (단, 엔티티의 논리적 흐름 검증은 통과해야 함)
         if (UserUtil.isAdmin()) {
             return;
         }
 
-        // 본인 주문 확인
         if (!orderItem.getOrder().getUserUuid().equals(UserUtil.getUserId())) {
             throw new OrderAccessDeniedException();
         }
 
-        // 사용자가 요청할 수 있는 상태인지 확인 (Enum 내 정의된 리스트 체크)
-        // ex: 사용자가 갑자기 status를 'SHIPPING(배송중)'으로 바꾸는 해킹 시도 방어
         if (!OrderItemStatus.isUserActionAllowed(newStatus)) {
             throw new OrderItemActionNotAllowedException();
         }
@@ -66,15 +74,36 @@ public class UpdateOrderItemStatusUseCase {
 
     private void publishEvent(OrderItem orderItem, OrderItemStatus newStatus) {
         switch (newStatus) {
-            case CANCELED ->
-                // 주문 취소: 상품 서비스에 '재고 복구(Increase Stock)' 요청 및 결제 서비스에 환불 로직 트리거
-                    eventPublisher.publish(new OrderItemCanceledEvent(orderItem.getUuid()));
-            case CONFIRMED ->
-                // 구매 확정: 정산 서비스에 '판매자 정산 대기' 등록 및 사용자에게 포인트 적립 트리거
-                    eventPublisher.publish(new OrderItemConfirmedEvent(orderItem.getUuid()));
-            case REFUND_REQUESTED ->
-                // 환불/반품 신청: 판매자에게 '반품 요청 알림' 발송 및 관리자 환불 검토 리스트 진입
-                    eventPublisher.publish(new OrderItemRefundRequestedEvent(orderItem.getUuid()));
+            case CANCELED -> {
+                eventPublisher.publish(new OrderItemCanceledEvent(orderItem.getUuid()));
+                // 배송 전 취소 시 상품 판매 상태를 즉시 복구한다.
+                eventPublisher.publish(new OrderProductSaleReleasedEvent(
+                        orderItem.getOrder().getUuid(),
+                        List.of(orderItem.getProductUuid())
+                ));
+            }
+            case CONFIRMED -> eventPublisher.publish(new OrderItemConfirmedEvent(orderItem.getUuid()));
+            case REFUND_REQUESTED -> eventPublisher.publish(new OrderItemRefundRequestedEvent(orderItem.getUuid()));
         }
+    }
+
+    private void syncOrderStatusIfAllItemsCanceled(OrderItem orderItem, OrderItemStatus targetStatus) {
+        if (targetStatus != OrderItemStatus.CANCELED) {
+            return;
+        }
+
+        Order order = orderItem.getOrder();
+        boolean allItemsCanceled = order.getOrderItems().stream()
+                .allMatch(item -> item.getStatus() == OrderItemStatus.CANCELED);
+
+        if (!allItemsCanceled) {
+            return;
+        }
+
+        if (order.getStatus() == OrderStatus.CANCELED) {
+            return;
+        }
+
+        order.updateOrderStatus(OrderStatus.CANCELED);
     }
 }

--- a/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
+++ b/order/src/main/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCase.java
@@ -1,5 +1,7 @@
 package dukku.order.boundedContext.order.app;
 
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.order.event.OrderProductSaleReleasedEvent;
 import dukku.common.shared.order.exception.OrderRefundAmountOutOfRangeException;
 import dukku.common.shared.order.exception.OrderRefundRequestInvalidException;
 import dukku.common.shared.order.type.OrderItemStatus;
@@ -23,6 +25,7 @@ public class UpdateOrderRefundStatusUseCase {
 
     private final OrderSupport orderSupport;
     private final ReturnRequestRepository returnRequestRepository;
+    private final EventPublisher eventPublisher;
 
     /**
      * 환불 완료 이벤트 반영 처리
@@ -69,6 +72,7 @@ public class UpdateOrderRefundStatusUseCase {
 
         if (order.getRefundedAmount() >= order.getTotalAmount()) {
             order.updateOrderStatus(OrderStatus.CANCELED);
+            eventPublisher.publish(new OrderProductSaleReleasedEvent(order.getUuid(), order.getProductUuids()));
             return;
         }
 

--- a/order/src/test/java/dukku/order/boundedContext/order/app/UpdateOrderItemStatusUseCaseTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/UpdateOrderItemStatusUseCaseTest.java
@@ -2,6 +2,9 @@ package dukku.order.boundedContext.order.app;
 
 import dukku.common.global.auth.detail.CustomUserDetails;
 import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.global.exception.ConflictException;
+import dukku.common.shared.order.event.OrderItemCanceledEvent;
+import dukku.common.shared.order.event.OrderProductSaleReleasedEvent;
 import dukku.common.shared.order.exception.OrderAccessDeniedException;
 import dukku.common.shared.order.exception.OrderItemActionNotAllowedException;
 import dukku.common.shared.order.type.OrderItemStatus;
@@ -24,7 +27,11 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -46,10 +53,10 @@ class UpdateOrderItemStatusUseCaseTest {
     }
 
     @Test
-    @DisplayName("주문 소유자가 아닌 사용자는 주문 상품 상태를 변경할 수 없다")
+    @DisplayName("owner가 아닌 사용자는 상태 변경할 수 없다")
     void failWhenNotOwner() {
         UUID orderItemUuid = UUID.randomUUID();
-        OrderItem orderItem = createOrderItem(orderItemUuid, UUID.randomUUID());
+        OrderItem orderItem = createOrderItem(orderItemUuid, UUID.randomUUID(), OrderItemStatus.DELIVERED);
 
         authenticate(UUID.randomUUID(), "USER");
         when(orderItemRepository.findByUuid(orderItemUuid)).thenReturn(Optional.of(orderItem));
@@ -61,11 +68,11 @@ class UpdateOrderItemStatusUseCaseTest {
     }
 
     @Test
-    @DisplayName("주문 소유자라도 허용되지 않은 상태 변경은 실패한다")
+    @DisplayName("일반 사용자가 허용되지 않은 상태를 요청하면 실패한다")
     void failWhenUserRequestsDisallowedStatus() {
         UUID userUuid = UUID.randomUUID();
         UUID orderItemUuid = UUID.randomUUID();
-        OrderItem orderItem = createOrderItem(orderItemUuid, userUuid);
+        OrderItem orderItem = createOrderItem(orderItemUuid, userUuid, OrderItemStatus.DELIVERED);
 
         authenticate(userUuid, "USER");
         when(orderItemRepository.findByUuid(orderItemUuid)).thenReturn(Optional.of(orderItem));
@@ -74,6 +81,71 @@ class UpdateOrderItemStatusUseCaseTest {
                 .isInstanceOf(OrderItemActionNotAllowedException.class);
 
         verifyNoInteractions(eventPublisher);
+    }
+
+    @Test
+    @DisplayName("배송 시작 전 CANCEL_REQUESTED는 즉시 CANCELED로 전환되고 취소 이벤트를 발행한다")
+    void cancelRequestedBeforeShipmentIsAppliedAsCanceled() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderItemUuid = UUID.randomUUID();
+        OrderItem orderItem = createOrderItem(orderItemUuid, userUuid, OrderItemStatus.PAYMENT_COMPLETED);
+
+        authenticate(userUuid, "USER");
+        when(orderItemRepository.findByUuid(orderItemUuid)).thenReturn(Optional.of(orderItem));
+
+        useCase.execute(orderItemUuid, OrderItemStatus.CANCEL_REQUESTED);
+
+        assertThat(orderItem.getStatus()).isEqualTo(OrderItemStatus.CANCELED);
+        assertThat(orderItem.getOrder().getStatus()).isEqualTo(OrderStatus.CANCELED);
+        verify(eventPublisher).publish(any(OrderItemCanceledEvent.class));
+        verify(eventPublisher).publish(any(OrderProductSaleReleasedEvent.class));
+    }
+
+    @Test
+    @DisplayName("여러 상품 중 일부만 취소되면 주문 상태는 유지된다")
+    void keepOrderStatusWhenOnlySomeItemsCanceled() {
+        UUID userUuid = UUID.randomUUID();
+        UUID targetOrderItemUuid = UUID.randomUUID();
+        OrderItem targetOrderItem = createOrderItem(targetOrderItemUuid, userUuid, OrderItemStatus.PAYMENT_COMPLETED);
+
+        OrderItem anotherOrderItem = OrderItem.builder()
+                .uuid(UUID.randomUUID())
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(UUID.randomUUID())
+                .productName("추가 상품")
+                .productPrice(20_000)
+                .status(OrderItemStatus.PAYMENT_COMPLETED)
+                .build();
+        targetOrderItem.getOrder().addOrderItem(anotherOrderItem);
+
+        authenticate(userUuid, "USER");
+        when(orderItemRepository.findByUuid(targetOrderItemUuid)).thenReturn(Optional.of(targetOrderItem));
+
+        useCase.execute(targetOrderItemUuid, OrderItemStatus.CANCEL_REQUESTED);
+
+        assertThat(targetOrderItem.getStatus()).isEqualTo(OrderItemStatus.CANCELED);
+        assertThat(anotherOrderItem.getStatus()).isEqualTo(OrderItemStatus.PAYMENT_COMPLETED);
+        assertThat(targetOrderItem.getOrder().getStatus()).isEqualTo(OrderStatus.PAID);
+        verify(eventPublisher).publish(any(OrderItemCanceledEvent.class));
+        verify(eventPublisher).publish(any(OrderProductSaleReleasedEvent.class));
+    }
+
+    @Test
+    @DisplayName("배송 시작 후 CANCEL_REQUESTED는 즉시 취소 시도되어 충돌 예외가 발생한다")
+    void cancelRequestedAfterShipmentFailsWithConflict() {
+        UUID userUuid = UUID.randomUUID();
+        UUID orderItemUuid = UUID.randomUUID();
+        OrderItem orderItem = createOrderItem(orderItemUuid, userUuid, OrderItemStatus.SHIPPED);
+
+        authenticate(userUuid, "USER");
+        when(orderItemRepository.findByUuid(orderItemUuid)).thenReturn(Optional.of(orderItem));
+
+        assertThatThrownBy(() -> useCase.execute(orderItemUuid, OrderItemStatus.CANCEL_REQUESTED))
+                .isInstanceOf(ConflictException.class);
+
+        assertThat(orderItem.getStatus()).isEqualTo(OrderItemStatus.SHIPPED);
+        verify(eventPublisher, never()).publish(any(OrderItemCanceledEvent.class));
+        verify(eventPublisher, never()).publish(any(OrderProductSaleReleasedEvent.class));
     }
 
     private void authenticate(UUID userUuid, String role) {
@@ -88,7 +160,7 @@ class UpdateOrderItemStatusUseCaseTest {
         SecurityContextHolder.setContext(context);
     }
 
-    private OrderItem createOrderItem(UUID orderItemUuid, UUID userUuid) {
+    private OrderItem createOrderItem(UUID orderItemUuid, UUID userUuid, OrderItemStatus currentStatus) {
         Order order = Order.builder()
                 .uuid(UUID.randomUUID())
                 .userUuid(userUuid)
@@ -106,7 +178,7 @@ class UpdateOrderItemStatusUseCaseTest {
                 .sellerUuid(UUID.randomUUID())
                 .productName("테스트 상품")
                 .productPrice(10_000)
-                .status(OrderItemStatus.DELIVERED)
+                .status(currentStatus)
                 .build();
         order.addOrderItem(orderItem);
         return orderItem;

--- a/order/src/test/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCaseHappyPathTest.java
+++ b/order/src/test/java/dukku/order/boundedContext/order/app/UpdateOrderRefundStatusUseCaseHappyPathTest.java
@@ -1,13 +1,18 @@
 package dukku.order.boundedContext.order.app;
 
+import dukku.common.global.eventPublisher.EventPublisher;
+import dukku.common.shared.order.event.OrderProductSaleReleasedEvent;
 import dukku.common.shared.order.exception.OrderRefundAmountOutOfRangeException;
 import dukku.common.shared.order.exception.OrderRefundRequestInvalidException;
+import dukku.common.shared.order.type.OrderItemStatus;
 import dukku.common.shared.order.type.OrderStatus;
 import dukku.order.boundedContext.order.entity.Order;
+import dukku.order.boundedContext.order.entity.OrderItem;
 import dukku.order.boundedContext.order.out.ReturnRequestRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,13 +22,12 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-/**
- * 주문 환불 상태 갱신 유스케이스 정상/예외 경로 테스트.
- */
 @ExtendWith(MockitoExtension.class)
 class UpdateOrderRefundStatusUseCaseHappyPathTest {
 
@@ -33,12 +37,15 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
     @Mock
     private ReturnRequestRepository returnRequestRepository;
 
+    @Mock
+    private EventPublisher eventPublisher;
+
     @InjectMocks
     private UpdateOrderRefundStatusUseCase useCase;
 
     @Test
-    @DisplayName("전액 환불 시 환불 누적액이 갱신되고 상태가 CANCELED로 변경된다")
-    void 전액환불_상태변경() {
+    @DisplayName("전액 환불 시 환불 누적액이 갱신되고 상태가 CANCELED로 변경되며 판매 복구 이벤트를 발행한다")
+    void fullRefundPublishesSaleReleaseEvent() {
         // given: 전액 환불 이벤트와 PAID 상태 주문을 준비한다.
         UUID refundUuid = UUID.randomUUID();
         UUID orderUuid = UUID.randomUUID();
@@ -50,16 +57,23 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
         // when: 환불 갱신 유스케이스를 실행한다.
         useCase.updateRefund(refundUuid, orderUuid, 12_000L, List.of());
 
-        // then: 환불 누적액이 주문 총액과 같아지고 상태가 CANCELED가 된다.
+        // then: 주문 상태/누적 환불액이 갱신되고 판매 복구 이벤트가 발행된다.
         verify(orderSupport).findOrderByUuidWithItems(orderUuid);
         assertThat(order.getRefundedAmount()).isEqualTo(12_000);
         assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELED);
+
+        ArgumentCaptor<OrderProductSaleReleasedEvent> eventCaptor =
+                ArgumentCaptor.forClass(OrderProductSaleReleasedEvent.class);
+        verify(eventPublisher).publish(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().orderUuid()).isEqualTo(orderUuid);
+        assertThat(eventCaptor.getValue().productUuids())
+                .containsExactly(order.getOrderItems().get(0).getProductUuid());
     }
 
     @Test
-    @DisplayName("부분 환불이면 환불 누적액이 갱신되고 상태가 PARTIAL_REFUNDED로 변경된다")
-    void 주문_부분환불_상태변경() {
-        // given
+    @DisplayName("부분 환불 시 환불 누적액이 갱신되고 상태가 PARTIAL_REFUNDED로 변경되며 판매 복구 이벤트는 발행되지 않는다")
+    void partialRefundDoesNotPublishSaleReleaseEvent() {
+        // given: 부분 환불 이벤트와 PAID 상태 주문을 준비한다.
         UUID refundUuid = UUID.randomUUID();
         UUID orderUuid = UUID.randomUUID();
         Order order = newPaidOrder(orderUuid, 12_000);
@@ -70,15 +84,16 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
         // when: 환불 갱신 유스케이스를 실행한다.
         useCase.updateRefund(refundUuid, orderUuid, 5_000L, List.of());
 
-        // then: 환불 누적액이 증가하고 상태가 PARTIAL_REFUNDED가 된다.
+        // then: 주문 상태/누적 환불액이 부분 환불 기준으로 갱신된다.
         verify(orderSupport).findOrderByUuidWithItems(orderUuid);
         assertThat(order.getRefundedAmount()).isEqualTo(5_000);
         assertThat(order.getStatus()).isEqualTo(OrderStatus.PARTIAL_REFUNDED);
+        verify(eventPublisher, never()).publish(any());
     }
 
     @Test
     @DisplayName("환불 금액이 int 범위를 초과하면 OrderRefundAmountOutOfRangeException이 발생한다")
-    void 환불금액_범위초과_예외발생() {
+    void refundAmountOverIntThrowsException() {
         // given: int 범위를 초과하는 환불 금액을 준비한다.
         UUID refundUuid = UUID.randomUUID();
         UUID orderUuid = UUID.randomUUID();
@@ -88,39 +103,37 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
         when(orderSupport.tryMarkRefundCompleted(refundUuid, orderUuid, overInt)).thenReturn(true);
         when(orderSupport.findOrderByUuidWithItems(orderUuid)).thenReturn(order);
 
-        // when: 범위를 넘는 환불 금액으로 환불 갱신을 실행한다.
-        // then: OrderRefundAmountOutOfRangeException 예외가 발생한다.
+        // when/then: 범위를 넘는 환불 금액으로 환불 갱신 시 예외가 발생한다.
         assertThatThrownBy(() -> useCase.updateRefund(refundUuid, orderUuid, overInt, List.of()))
                 .isInstanceOf(OrderRefundAmountOutOfRangeException.class);
     }
 
     @Test
     @DisplayName("환불 이벤트 입력값이 유효하지 않으면 OrderRefundRequestInvalidException이 발생한다")
-    void 환불이벤트_입력값검증_실패() {
-        // given: refundUuid가 null인 잘못된 환불 이벤트를 준비한다.
-        // when: 환불 갱신 유스케이스를 실행한다.
-        // then: OrderRefundRequestInvalidException 예외가 발생한다.
+    void invalidInputThrowsException() {
         assertThatThrownBy(() -> useCase.updateRefund(null, UUID.randomUUID(), 1_000L, List.of()))
                 .isInstanceOf(OrderRefundRequestInvalidException.class);
     }
 
     @Test
-    @DisplayName("이미 처리된 환불 이벤트는 후속 처리를 건너뛴다")
-    void 환불이벤트_멱등처리_중복무시() {
+    @DisplayName("이미 처리된 환불 이벤트는 무시된다")
+    void duplicateRefundEventIsIgnored() {
         // given: 이미 처리된 환불 이벤트로 표시되도록 준비한다.
         UUID refundUuid = UUID.randomUUID();
         UUID orderUuid = UUID.randomUUID();
+
         when(orderSupport.tryMarkRefundCompleted(refundUuid, orderUuid, 1_000L)).thenReturn(false);
 
         // when: 동일한 환불 이벤트로 환불 갱신을 다시 호출한다.
         useCase.updateRefund(refundUuid, orderUuid, 1_000L, List.of());
 
-        // then: 후속 저장소 호출이 발생하지 않는다.
+        // then: 후속 저장소/이벤트 발행 호출이 발생하지 않는다.
         verifyNoInteractions(returnRequestRepository);
+        verifyNoInteractions(eventPublisher);
     }
 
     private Order newPaidOrder(UUID orderUuid, int totalAmount) {
-        return Order.builder()
+        Order order = Order.builder()
                 .uuid(orderUuid)
                 .userUuid(UUID.randomUUID())
                 .totalAmount(totalAmount)
@@ -130,5 +143,15 @@ class UpdateOrderRefundStatusUseCaseHappyPathTest {
                 .refundedAmount(0)
                 .status(OrderStatus.PAID)
                 .build();
+
+        order.addOrderItem(OrderItem.builder()
+                .productUuid(UUID.randomUUID())
+                .sellerUuid(UUID.randomUUID())
+                .productName("test-product")
+                .productPrice(totalAmount)
+                .status(OrderItemStatus.PAYMENT_COMPLETED)
+                .build());
+
+        return order;
     }
 }

--- a/payment/src/main/java/dukku/payment/boundedContext/payment/app/HandleOrderItemCanceledEventUseCase.java
+++ b/payment/src/main/java/dukku/payment/boundedContext/payment/app/HandleOrderItemCanceledEventUseCase.java
@@ -4,6 +4,7 @@ import dukku.common.shared.order.event.OrderItemCanceledEvent;
 import dukku.common.shared.payment.dto.PaymentRefundRequest;
 import dukku.common.shared.payment.exception.PaymentNotFoundException;
 import dukku.common.shared.payment.exception.PaymentOrderItemNotFoundException;
+import dukku.common.shared.payment.type.PaymentHistoryType;
 import dukku.common.shared.payment.type.PaymentStatus;
 import dukku.payment.boundedContext.payment.entity.Payment;
 import dukku.payment.boundedContext.payment.entity.PaymentOrderItem;
@@ -24,48 +25,72 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HandleOrderItemCanceledEventUseCase {
 
-        private final PaymentSupport support;
-        private final RefundPaymentUseCase refundPaymentUseCase;
+    private final PaymentSupport support;
+    private final RefundPaymentUseCase refundPaymentUseCase;
 
-        @Transactional
-        public void execute(OrderItemCanceledEvent event) {
-                log.info("주문 상품 취소 이벤트 처리 시작 - orderItemUuid: {}", event.orderItemUuid());
+    @Transactional
+    public void execute(OrderItemCanceledEvent event) {
+        log.info("주문 상품 취소 이벤트 처리 시작 - orderItemUuid: {}", event.orderItemUuid());
 
-                // 1. 해당 주문 상품(OrderItemUuid)이 포함된 결제 내역 조회
-                Payment payment = support.findPaymentByOrderItemUuid(event.orderItemUuid())
-                                .orElseThrow(() -> {
-                                        log.error("해당 주문 상품에 대한 결제 내역을 찾을 수 없습니다. orderItemUuid: {}",
-                                                        event.orderItemUuid());
-                                        return new PaymentNotFoundException();
-                                });
+        // 1. 해당 주문 상품(OrderItemUuid)이 포함된 결제 내역 조회
+        Payment payment = support.findPaymentByOrderItemUuid(event.orderItemUuid())
+                .orElseThrow(() -> {
+                    log.error("해당 주문 상품에 대한 결제 내역을 찾을 수 없습니다. orderItemUuid: {}",
+                            event.orderItemUuid());
+                    return new PaymentNotFoundException();
+                });
 
-                // 2. 환불 가능 상태 확인 (이미 취소된 경우 중복 처리 방지)
-                if (payment.getPaymentStatus() == PaymentStatus.CANCELED) {
-                        log.warn("이미 전체 취소된 결제입니다. skip 처리. paymentUuid: {}", payment.getUuid());
-                        return;
-                }
-
-                // 3. 결제 항목 중 해당 OrderItem 찾기
-                PaymentOrderItem targetItem = payment.getItems().stream()
-                                .filter(item -> item.getOrderItemUuid().equals(event.orderItemUuid()))
-                                .findFirst()
-                                .orElseThrow(PaymentOrderItemNotFoundException::new);
-
-                // 4. 환불 요청 생성 (단일 상품 취소이므로 해당 상품 금액만큼)
-                PaymentRefundRequest request = PaymentRefundRequest.builder()
-                                .paymentUuid(payment.getUuid())
-                                .orderUuid(payment.getOrderUuid())
-                                .refundAmount(targetItem.getPrice())
-                                .reason("주문 전 상품 취소 (Item: " + event.orderItemUuid() + ")")
-                                .items(List.of(new PaymentRefundRequest.RefundItemInfo(
-                                                targetItem.getOrderItemUuid(),
-                                                targetItem.getPrice())))
-                                .build();
-
-                // 5. 환불 실행 (멱등성 키로 orderItemUuid 사용)
-                refundPaymentUseCase.execute(request, "CANCEL_" + event.orderItemUuid());
-
-                log.info("주문 상품 취소에 따른 환불 트리거 완료 - orderItemUuid: {}, paymentUuid: {}",
-                                event.orderItemUuid(), payment.getUuid());
+        // 2. 이미 전체 취소된 결제는 중복 처리하지 않는다.
+        if (payment.getPaymentStatus() == PaymentStatus.CANCELED) {
+            log.warn("이미 전체 취소된 결제입니다. skip 처리. paymentUuid: {}", payment.getUuid());
+            return;
         }
+
+        // 3. PENDING 상태는 승인 전이므로 환불 플로우 없이 즉시 취소 처리한다.
+        if (payment.getPaymentStatus() == PaymentStatus.PENDING) {
+            PaymentStatus originStatus = payment.getPaymentStatus();
+            Long originAmountPg = payment.getAmountPg();
+            Long originDeposit = payment.getPaymentDeposit();
+
+            payment.cancel();
+            support.savePayment(payment);
+            support.createHistory(payment, PaymentHistoryType.ORDER_CANCEL_SUCCESS,
+                    originStatus, originAmountPg, originDeposit);
+
+            log.info("승인 전 결제를 즉시 취소 처리했습니다. orderItemUuid: {}, paymentUuid: {}",
+                    event.orderItemUuid(), payment.getUuid());
+            return;
+        }
+
+        // 4. 환불 플로우는 DONE/PARTIAL_CANCELED 상태에서만 진행한다.
+        if (payment.getPaymentStatus() != PaymentStatus.DONE
+                && payment.getPaymentStatus() != PaymentStatus.PARTIAL_CANCELED) {
+            log.warn("환불 불가 상태입니다. skip 처리. paymentUuid: {}, status: {}",
+                    payment.getUuid(), payment.getPaymentStatus());
+            return;
+        }
+
+        // 5. 결제 항목 중 해당 OrderItem 찾기
+        PaymentOrderItem targetItem = payment.getItems().stream()
+                .filter(item -> item.getOrderItemUuid().equals(event.orderItemUuid()))
+                .findFirst()
+                .orElseThrow(PaymentOrderItemNotFoundException::new);
+
+        // 6. 환불 요청 생성 (단일 상품 취소이므로 해당 상품 금액만큼)
+        PaymentRefundRequest request = PaymentRefundRequest.builder()
+                .paymentUuid(payment.getUuid())
+                .orderUuid(payment.getOrderUuid())
+                .refundAmount(targetItem.getPrice())
+                .reason("주문 상품 취소 (Item: " + event.orderItemUuid() + ")")
+                .items(List.of(new PaymentRefundRequest.RefundItemInfo(
+                        targetItem.getOrderItemUuid(),
+                        targetItem.getPrice())))
+                .build();
+
+        // 7. 환불 실행 (멱등성 키로 orderItemUuid 사용)
+        refundPaymentUseCase.execute(request, "CANCEL_" + event.orderItemUuid());
+
+        log.info("주문 상품 취소에 따른 환불 트리거 완료 - orderItemUuid: {}, paymentUuid: {}",
+                event.orderItemUuid(), payment.getUuid());
+    }
 }

--- a/payment/src/test/java/dukku/payment/boundedContext/payment/app/HandleOrderItemCanceledEventUseCaseTest.java
+++ b/payment/src/test/java/dukku/payment/boundedContext/payment/app/HandleOrderItemCanceledEventUseCaseTest.java
@@ -1,0 +1,85 @@
+package dukku.payment.boundedContext.payment.app;
+
+import dukku.common.shared.order.event.OrderItemCanceledEvent;
+import dukku.common.shared.payment.dto.PaymentRefundRequest;
+import dukku.common.shared.payment.type.PaymentHistoryType;
+import dukku.common.shared.payment.type.PaymentStatus;
+import dukku.common.shared.payment.type.PaymentType;
+import dukku.payment.boundedContext.payment.entity.Payment;
+import dukku.payment.boundedContext.payment.entity.PaymentOrderItem;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HandleOrderItemCanceledEventUseCaseTest {
+
+    @Mock
+    private PaymentSupport support;
+
+    @Mock
+    private RefundPaymentUseCase refundPaymentUseCase;
+
+    @InjectMocks
+    private HandleOrderItemCanceledEventUseCase useCase;
+
+    @Test
+    @DisplayName("PENDING 결제에서 주문상품 취소 이벤트를 받으면 결제를 즉시 CANCELED로 전환한다")
+    void cancelPendingPaymentDirectly() {
+        UUID orderUuid = UUID.randomUUID();
+        UUID orderItemUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+
+        Payment payment = Payment.create(orderUuid, userUuid, 10_000L,
+                0L, 10_000L, 0L, PaymentType.NORMAL, "order-1");
+        PaymentOrderItem item = PaymentOrderItem.create(payment, orderUuid, orderItemUuid,
+                UUID.randomUUID(), "item", 10_000L, 0L, UUID.randomUUID(), 0L);
+        payment.addItem(item);
+
+        when(support.findPaymentByOrderItemUuid(orderItemUuid)).thenReturn(Optional.of(payment));
+
+        useCase.execute(new OrderItemCanceledEvent(orderItemUuid));
+
+        assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CANCELED);
+        verify(support).savePayment(payment);
+        verify(support).createHistory(payment, PaymentHistoryType.ORDER_CANCEL_SUCCESS,
+                PaymentStatus.PENDING, 10_000L, 0L);
+        verify(refundPaymentUseCase, never()).execute(any(PaymentRefundRequest.class), any(String.class));
+    }
+
+    @Test
+    @DisplayName("DONE 결제에서 주문상품 취소 이벤트를 받으면 환불 플로우를 호출한다")
+    void triggerRefundForDonePayment() {
+        UUID orderUuid = UUID.randomUUID();
+        UUID orderItemUuid = UUID.randomUUID();
+        UUID userUuid = UUID.randomUUID();
+
+        Payment payment = Payment.create(orderUuid, userUuid, 10_000L,
+                0L, 10_000L, 0L, PaymentType.NORMAL, "order-2");
+        payment.approve("pg-key");
+
+        PaymentOrderItem item = PaymentOrderItem.create(payment, orderUuid, orderItemUuid,
+                UUID.randomUUID(), "item", 10_000L, 0L, UUID.randomUUID(), 0L);
+        payment.addItem(item);
+
+        when(support.findPaymentByOrderItemUuid(orderItemUuid)).thenReturn(Optional.of(payment));
+
+        useCase.execute(new OrderItemCanceledEvent(orderItemUuid));
+
+        verify(refundPaymentUseCase).execute(any(PaymentRefundRequest.class), eq("CANCEL_" + orderItemUuid));
+        verify(support, never()).savePayment(any(Payment.class));
+    }
+}

--- a/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/DeleteProductSyncUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/DeleteProductSyncUseCase.java
@@ -7,6 +7,7 @@ import dukku.product.boundedContext.product.out.ProductRepository;
 import dukku.product.boundedContext.product.out.ProductSearchRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ import java.util.Optional;
 public class DeleteProductSyncUseCase {
     private final ProductSearchRepository productSearchRepository;
     private final ProductRepository productRepository;
+    private final ElasticsearchOperations elasticsearchOperations;
 
     @Transactional(readOnly = true)
     public void deletedProductToElasticsearch(Long productId) {
@@ -26,7 +28,7 @@ public class DeleteProductSyncUseCase {
 
         Optional<ProductDocument> existingDocument = productSearchRepository.findById(documentId);
         if (existingDocument.isEmpty()) {
-            log.info("Skip ES soft delete sync because document does not exist. productId={}", productId);
+            log.info("ES 문서가 없어 소프트 삭제 동기화를 건너뜁니다. productId={}", productId);
             return;
         }
 
@@ -35,8 +37,9 @@ public class DeleteProductSyncUseCase {
 
         ProductDocument updatedDocument = toSoftDeleted(existingDocument.get(), deletedAt);
         productSearchRepository.save(updatedDocument);
+        elasticsearchOperations.indexOps(ProductDocument.class).refresh();
 
-        log.info("Soft-deleted product document in Elasticsearch. productId={}", productId);
+        log.info("Elasticsearch 상품 문서를 소프트 삭제로 동기화했습니다. productId={}", productId);
     }
 
     private ProductDocument toSoftDeleted(ProductDocument source, LocalDateTime deletedAt) {

--- a/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/ReindexAllProductsUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/ReindexAllProductsUseCase.java
@@ -2,6 +2,7 @@ package dukku.product.boundedContext.product.app.cqrs;
 
 import dukku.product.boundedContext.product.entity.Product;
 import dukku.product.boundedContext.product.out.ProductRepository;
+import dukku.product.boundedContext.product.out.ProductSearchRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -17,6 +18,7 @@ public class ReindexAllProductsUseCase {
     private static final int BATCH_SIZE = 200;
 
     private final ProductRepository productRepository;
+    private final ProductSearchRepository productSearchRepository;
     private final SaveToElasticSearchUseCase saveToElasticSearchUseCase;
 
     @Transactional(readOnly = true)
@@ -26,6 +28,10 @@ public class ReindexAllProductsUseCase {
         int fail = 0;
 
         log.info("[Reindex] 전체 재색인 시작");
+
+        // 카테고리/검색 불일치를 막기 위해 기존 ES 문서를 먼저 정리한다.
+        productSearchRepository.deleteAll();
+        log.info("[Reindex] 기존 ES 문서 삭제 완료");
 
         while (true) {
             Pageable pageable = PageRequest.of(pageNo, BATCH_SIZE);

--- a/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/SaveToElasticSearchUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/SaveToElasticSearchUseCase.java
@@ -71,12 +71,14 @@ public class SaveToElasticSearchUseCase {
 
         // 전체 저장은 Repository가 편합니다.
         productSearchRepository.save(document);
+        refreshProductIndex();
         log.info("[ES 동기화] 전체 저장 완료. productId={}", product.getId());
     }
 
     // [Case 2] 부분 업데이트 (ElasticsearchOperations 사용)
     private void updatePartialDocument(Product product) {
         String docId = String.valueOf(product.getId());
+        List<Integer> categoryPathIds = categoryRepository.findCategoryPathIds(product.getCategory().getId());
 
         if (!productSearchRepository.existsById(docId)) {
             log.warn("[ES 동기화] 부분 업데이트 대상 문서 없음 -> 전체 저장으로 전환. productId={}", product.getId());
@@ -88,6 +90,9 @@ public class SaveToElasticSearchUseCase {
         int sortPriority = (product.getSaleStatus() == SaleStatus.SOLD_OUT) ? 1 : 0;
 
         Document document = Document.create();
+        document.put("productUuid", product.getUuid().toString());
+        document.put("sellerUuid", product.getSellerUuid().toString());
+        document.put("categoryIds", categoryPathIds);
         document.put("title", product.getTitle());
         document.put("description", product.getDescription());
         document.put("price", product.getPrice());
@@ -109,8 +114,13 @@ public class SaveToElasticSearchUseCase {
                 updateQuery,
                 elasticsearchOperations.getIndexCoordinatesFor(ProductDocument.class)
         );
+        refreshProductIndex();
 
         log.info("[ES 동기화] 부분 업데이트 완료. productId={}", product.getId());
+    }
+
+    private void refreshProductIndex() {
+        elasticsearchOperations.indexOps(ProductDocument.class).refresh();
     }
 
     private String getThumbnailUrl(Product product) {

--- a/product/src/main/java/dukku/product/boundedContext/product/app/facade/ProductFacade.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/facade/ProductFacade.java
@@ -12,6 +12,7 @@ import dukku.product.boundedContext.product.app.usecase.product.FindCategoryList
 import dukku.product.boundedContext.product.app.usecase.product.FindFeaturedProductsUseCase;
 import dukku.product.boundedContext.product.app.usecase.product.FindProductDetailUseCase;
 import dukku.product.boundedContext.product.app.usecase.product.FindProductListUseCase;
+import dukku.product.boundedContext.product.app.usecase.product.ReleaseProductReservationUseCase;
 import dukku.product.boundedContext.product.app.usecase.product.ReserveProductUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,7 @@ public class ProductFacade {
     private final FindProductListUseCase findProductListUseCase;
     private final FindProductDetailUseCase findProductDetailUseCase;
     private final ReserveProductUseCase reserveProductUseCase;
+    private final ReleaseProductReservationUseCase releaseProductReservationUseCase;
     private final SearchProductUseCase searchProductUseCase;
 
     public List<CategoryCreateResponse> findCategories() {
@@ -83,5 +85,9 @@ public class ProductFacade {
 
     public void reserveProducts(ProductReserveRequest request) {
         reserveProductUseCase.execute(request);
+    }
+
+    public void releaseProducts(ProductReserveRequest request) {
+        releaseProductReservationUseCase.execute(request.orderUuid(), request.productUuids());
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
@@ -37,26 +37,27 @@ public class FindProductDetailUseCase {
 
         Product product = productRepository.findByUuidWithImagesAndCategory(productUuid)
                 .or(() -> {
-                    log.warn("[FindProductDetailUseCase] 패치 조인 쿼리로 상품 조회 실패. 기본 조회(findByUuid)를 시도합니다. productUuid={}",
-                            productUuid);
+                    log.warn("[FindProductDetailUseCase] 패치 조인 조회 실패, 기본 조회로 재시도. productUuid={}", productUuid);
                     return productRepository.findByUuid(productUuid);
                 })
                 .orElseThrow(() -> {
-                    log.error("[FindProductDetailUseCase] 어떤 방식으로도 상품을 찾을 수 없습니다. productUuid={}", productUuid);
+                    log.error("[FindProductDetailUseCase] 상품을 찾을 수 없습니다. productUuid={}", productUuid);
                     return new ProductNotFoundException();
                 });
 
-        log.info("[FindProductDetailUseCase] 상품 조회 성공. title={}, sellerUuid={}", product.getTitle(),
-                product.getSellerUuid());
+        log.info("[FindProductDetailUseCase] 상품 조회 성공. title={}, sellerUuid={}", product.getTitle(), product.getSellerUuid());
 
         productStatsRedisSupport.incrementView(product.getId());
 
-        // 상점 정보 조회: 이벤트 지연/누락으로 ProductSeller가 없으면 즉시 생성
-        ProductSeller seller = productSellerRepository.findByUserUuid(product.getSellerUuid())
+        // Product.sellerUuid는 seller UUID이므로 sellerUuid 기준으로 먼저 조회한다.
+        ProductSeller seller = productSellerRepository.findBySellerUuid(product.getSellerUuid())
+                // 과거 데이터 호환: sellerUuid에 userUuid가 들어간 레코드도 허용
+                .or(() -> productSellerRepository.findByUserUuid(product.getSellerUuid()))
                 .orElseGet(() -> {
-                    log.warn("[FindProductDetailUseCase] 상점 정보(ProductSeller)가 없어 자동 생성합니다. userUuid={}, productUuid={}",
+                    // 상세 조회(GET)에서 DB write를 유발하지 않도록 비영속 기본값만 사용한다.
+                    log.warn("[FindProductDetailUseCase] 상점 정보 누락. 기본값으로 응답합니다. sellerUuid={}, productUuid={}",
                             product.getSellerUuid(), productUuid);
-                    return productSellerRepository.save(ProductSeller.create(product.getSellerUuid(), "반가워요! 내 상점입니다."));
+                    return ProductSeller.create(product.getSellerUuid(), "판매 중인 상점입니다.");
                 });
 
         log.info("[FindProductDetailUseCase] 상점 정보 조회 성공. sellerUserUuid={}", seller.getUserUuid());
@@ -93,7 +94,7 @@ public class FindProductDetailUseCase {
 
             return nickname;
         } catch (Exception e) {
-            log.warn("[FindProductDetailUseCase] 유저 프로필 조회 실패로 기본 닉네임 사용. userUuid={}", userUuid, e);
+            log.warn("[FindProductDetailUseCase] 사용자 프로필 조회 실패로 기본 닉네임 사용. userUuid={}", userUuid, e);
             return "이름없음";
         }
     }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductListUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductListUseCase.java
@@ -25,7 +25,8 @@ public class FindProductListUseCase {
         if (categoryId == null) {
             result = productRepository.findByVisibilityStatusAndDeletedAtIsNull(VisibilityStatus.VISIBLE, pageable);
         } else {
-            List<Integer> categoryIds = categoryRepository.findCategoryPathIds(categoryId);
+            // ES와 동일하게 "선택 카테고리 + 하위 카테고리" 범위로 조회한다.
+            List<Integer> categoryIds = categoryRepository.findCategoryTreeIds(categoryId);
             result = productRepository.findByCategory_IdInAndVisibilityStatusAndDeletedAtIsNull(categoryIds, VisibilityStatus.VISIBLE, pageable);
         }
 

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/ReserveProductUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/ReserveProductUseCase.java
@@ -2,8 +2,10 @@ package dukku.product.boundedContext.product.app.usecase.product;
 
 import dukku.common.shared.product.dto.product.ProductReserveRequest;
 import dukku.common.shared.product.exception.PartialProductsNotFoundException;
+import dukku.common.global.eventPublisher.EventPublisher;
 import dukku.product.boundedContext.product.entity.Product;
 import dukku.product.boundedContext.product.out.ProductRepository;
+import dukku.product.global.event.ProductUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReserveProductUseCase {
     private final ProductRepository productRepository;
+    private final EventPublisher eventPublisher;
 
     @Transactional
     public void execute(ProductReserveRequest request) {
@@ -33,6 +36,7 @@ public class ReserveProductUseCase {
         // TODO: 이미 판매 또는 예약된 경우라면?
         for (Product product : products) {
             product.reserve(request.orderUuid());
+            eventPublisher.publish(new ProductUpdatedEvent(product.getId(), false));
         }
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/UploadImageUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/UploadImageUseCase.java
@@ -1,0 +1,207 @@
+package dukku.product.boundedContext.product.app.usecase.product;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class UploadImageUseCase {
+
+    private static final long MAX_IMAGE_SIZE_BYTES = 10L * 1024 * 1024;
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public String upload(MultipartFile file, UUID userId) {
+        if (!StringUtils.hasText(bucketName) || !StringUtils.hasText(region)) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 configuration is missing");
+        }
+
+        if (file == null || file.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Image file is required");
+        }
+
+        if (file.getSize() > MAX_IMAGE_SIZE_BYTES) {
+            throw new ResponseStatusException(HttpStatus.PAYLOAD_TOO_LARGE, "Image file is too large");
+        }
+
+        byte[] bytes;
+        try {
+            bytes = file.getBytes();
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to read image bytes", e);
+        }
+
+        String extension = detectExtension(bytes);
+        String contentType = contentTypeFor(extension);
+        String key = "products/" + userId + "/" + UUID.randomUUID() + "." + extension;
+
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        try {
+            s3Client.putObject(request, RequestBody.fromBytes(bytes));
+        } catch (S3Exception e) {
+            String awsCode = e.awsErrorDetails() == null ? null : e.awsErrorDetails().errorCode();
+            String reason = awsCode == null
+                    ? "Failed to upload image to S3"
+                    : "Failed to upload image to S3 (" + awsCode + ")";
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, reason, e);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to upload image to S3", e);
+        }
+
+        return key;
+    }
+
+    public S3ImageObject getImage(String key) {
+        if (!StringUtils.hasText(bucketName) || !StringUtils.hasText(region)) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 configuration is missing");
+        }
+
+        if (!StringUtils.hasText(key) || !key.startsWith("products/")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image key");
+        }
+
+        GetObjectRequest request = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+
+        try {
+            var responseBytes = s3Client.getObjectAsBytes(request);
+            String contentType = responseBytes.response().contentType();
+            if (!StringUtils.hasText(contentType)) {
+                contentType = "application/octet-stream";
+            }
+            return new S3ImageObject(responseBytes.asByteArray(), contentType);
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Image not found", e);
+            }
+            String awsCode = e.awsErrorDetails() == null ? null : e.awsErrorDetails().errorCode();
+            String reason = awsCode == null
+                    ? "Failed to read image from S3"
+                    : "Failed to read image from S3 (" + awsCode + ")";
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, reason, e);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to read image from S3", e);
+        }
+    }
+
+    public void deleteImage(String key, UUID userId) {
+        if (!StringUtils.hasText(bucketName) || !StringUtils.hasText(region)) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 configuration is missing");
+        }
+
+        if (!StringUtils.hasText(key) || !key.startsWith("products/")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image key");
+        }
+        String ownerPrefix = "products/" + userId + "/";
+        if (!key.startsWith(ownerPrefix)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "No permission to delete this image");
+        }
+
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+
+        try {
+            s3Client.deleteObject(request);
+        } catch (S3Exception e) {
+            String awsCode = e.awsErrorDetails() == null ? null : e.awsErrorDetails().errorCode();
+            String reason = awsCode == null
+                    ? "Failed to delete image from S3"
+                    : "Failed to delete image from S3 (" + awsCode + ")";
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, reason, e);
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to delete image from S3", e);
+        }
+    }
+
+    private String detectExtension(byte[] bytes) {
+        if (isJpeg(bytes)) return "jpg";
+        if (isPng(bytes)) return "png";
+        if (isGif(bytes)) return "gif";
+        if (isWebp(bytes)) return "webp";
+
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported image format");
+    }
+
+    private String contentTypeFor(String extension) {
+        return switch (extension) {
+            case "jpg" -> "image/jpeg";
+            case "png" -> "image/png";
+            case "gif" -> "image/gif";
+            case "webp" -> "image/webp";
+            default -> "application/octet-stream";
+        };
+    }
+
+    private boolean isJpeg(byte[] b) {
+        return b.length >= 3
+                && (b[0] & 0xFF) == 0xFF
+                && (b[1] & 0xFF) == 0xD8
+                && (b[2] & 0xFF) == 0xFF;
+    }
+
+    private boolean isPng(byte[] b) {
+        return b.length >= 8
+                && (b[0] & 0xFF) == 0x89
+                && b[1] == 0x50
+                && b[2] == 0x4E
+                && b[3] == 0x47
+                && b[4] == 0x0D
+                && b[5] == 0x0A
+                && b[6] == 0x1A
+                && b[7] == 0x0A;
+    }
+
+    private boolean isGif(byte[] b) {
+        return b.length >= 6
+                && b[0] == 0x47
+                && b[1] == 0x49
+                && b[2] == 0x46
+                && b[3] == 0x38
+                && (b[4] == 0x37 || b[4] == 0x39)
+                && b[5] == 0x61;
+    }
+
+    private boolean isWebp(byte[] b) {
+        return b.length >= 12
+                && b[0] == 0x52
+                && b[1] == 0x49
+                && b[2] == 0x46
+                && b[3] == 0x46
+                && b[8] == 0x57
+                && b[9] == 0x45
+                && b[10] == 0x42
+                && b[11] == 0x50;
+    }
+
+    public record S3ImageObject(byte[] bytes, String contentType) {
+    }
+}

--- a/product/src/main/java/dukku/product/boundedContext/product/entity/Product.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/entity/Product.java
@@ -229,10 +229,10 @@ public class Product extends BaseIdAndUUIDAndTime {
         }
     }
 
-    // 예약 해제 (RESERVED -> ON_SALE)
+    // 예약 해제 (RESERVED/SOLD_OUT -> ON_SALE)
     public void releaseReservation(UUID orderUuid) {
         // 내 주문이 맞는지 검증
-        if (this.saleStatus == SaleStatus.RESERVED &&
+        if ((this.saleStatus == SaleStatus.RESERVED || this.saleStatus == SaleStatus.SOLD_OUT) &&
                 this.reservedOrderUuid != null &&
                 this.reservedOrderUuid.equals(orderUuid)) {
 

--- a/product/src/main/java/dukku/product/boundedContext/product/entity/Product.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/entity/Product.java
@@ -22,8 +22,12 @@ import org.springframework.data.domain.Page;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Entity
 @Table(
@@ -165,14 +169,49 @@ public class Product extends BaseIdAndUUIDAndTime {
     @Builder.Default
     private List<ProductTag> productTags = new ArrayList<>();
 
-    // 태그 교체 (기존 싹 지우고 갈아끼우기)
+    // 태그 교체: 동일 태그 재삽입으로 인한 unique 충돌을 막기 위해 차집합만 반영
     public void replaceTags(List<Tag> tags) {
-        this.productTags.clear(); // orphanRemoval=true로 인해 DB에서도 삭제됨
-        if (tags != null && !tags.isEmpty()) {
-            for (Tag tag : tags) {
+        if (tags == null) {
+            this.productTags.clear();
+            return;
+        }
+
+        List<Tag> normalizedTags = tags.stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.collectingAndThen(
+                        Collectors.toMap(
+                                Product::tagKey,
+                                tag -> tag,
+                                (first, ignored) -> first,
+                                LinkedHashMap::new
+                        ),
+                        map -> new ArrayList<>(map.values())
+                ));
+
+        Set<String> desiredKeys = normalizedTags.stream()
+                .map(Product::tagKey)
+                .collect(Collectors.toSet());
+
+        this.productTags.removeIf(productTag -> !desiredKeys.contains(tagKey(productTag.getTag())));
+
+        Set<String> existingKeys = this.productTags.stream()
+                .map(productTag -> tagKey(productTag.getTag()))
+                .collect(Collectors.toSet());
+
+        for (Tag tag : normalizedTags) {
+            String key = tagKey(tag);
+            if (!existingKeys.contains(key)) {
                 this.productTags.add(ProductTag.create(this, tag));
+                existingKeys.add(key);
             }
         }
+    }
+
+    private static String tagKey(Tag tag) {
+        if (tag.getId() != null) {
+            return "id:" + tag.getId();
+        }
+        return "name:" + tag.getName();
     }
 
     // 읽기 전용으로 태그 이름 목록 반환 (ES 동기화용)

--- a/product/src/main/java/dukku/product/boundedContext/product/in/ProductController.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/in/ProductController.java
@@ -54,4 +54,9 @@ public class ProductController {
     public void reserveProducts(@RequestBody ProductReserveRequest request) {
         productFacade.reserveProducts(request);
     }
+
+    @PostMapping("/products/internal/release")
+    public void releaseProducts(@RequestBody ProductReserveRequest request) {
+        productFacade.releaseProducts(request);
+    }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/in/ProductImageController.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/in/ProductImageController.java
@@ -1,19 +1,34 @@
 package dukku.product.boundedContext.product.in;
 
+import dukku.common.global.UserUtil;
 import dukku.product.boundedContext.product.app.usecase.product.GeneratePresignedUrlUseCase;
+import dukku.product.boundedContext.product.app.usecase.product.UploadImageUseCase;
+import dukku.common.shared.product.dto.product.ImageUploadResponse;
 import dukku.common.shared.product.dto.product.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/products/images")
 public class ProductImageController {
     private final GeneratePresignedUrlUseCase generatePresignedUrlUseCase;
+    private final UploadImageUseCase uploadImageUseCase;
 
     @GetMapping("/presigned-url")
     public PresignedUrlResponse getPresignedUrl(
@@ -22,5 +37,39 @@ public class ProductImageController {
         String url = generatePresignedUrlUseCase.generatePresignedUrl(extension);
 
         return new PresignedUrlResponse(url);
+    }
+
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ImageUploadResponse uploadImage(
+            @RequestPart("file") MultipartFile file
+    ) {
+        UUID userId = UserUtil.getUserId();
+        String key = uploadImageUseCase.upload(file, userId);
+        String imageUrl = UriComponentsBuilder.fromPath("/api/v1/products/images/public")
+                .queryParam("key", key)
+                .build()
+                .toUriString();
+        return new ImageUploadResponse(imageUrl);
+    }
+
+    @GetMapping("/public")
+    public ResponseEntity<byte[]> getPublicImage(
+            @RequestParam("key") String key
+    ) {
+        UploadImageUseCase.S3ImageObject image = uploadImageUseCase.getImage(key);
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CACHE_CONTROL, CacheControl.maxAge(30, TimeUnit.DAYS).cachePublic().getHeaderValue())
+                .contentType(MediaType.parseMediaType(image.contentType()))
+                .body(image.bytes());
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteImage(
+            @RequestParam("key") String key
+    ) {
+        UUID userId = UserUtil.getUserId();
+        uploadImageUseCase.deleteImage(key, userId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/out/CategoryRepository.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/out/CategoryRepository.java
@@ -27,4 +27,20 @@ public interface CategoryRepository extends JpaRepository<Category, Integer> {
         SELECT id FROM category_path
     """, nativeQuery = true)
     List<Integer> findCategoryPathIds(@Param("categoryId") int categoryId);
+
+    @Query(value = """
+        WITH RECURSIVE category_tree AS (
+            SELECT id
+            FROM categories
+            WHERE id = :categoryId
+
+            UNION ALL
+
+            SELECT c.id
+            FROM categories c
+            INNER JOIN category_tree ct ON c.parent_id = ct.id
+        )
+        SELECT id FROM category_tree
+    """, nativeQuery = true)
+    List<Integer> findCategoryTreeIds(@Param("categoryId") int categoryId);
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/out/ProductSellerRepository.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/out/ProductSellerRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface ProductSellerRepository extends JpaRepository<ProductSeller, Integer>, CustomProductSellerRepository {
+    Optional<ProductSeller> findBySellerUuid(UUID sellerUuid);
+
     Optional<ProductSeller> findByUserUuid(UUID userUuid);
 
     Optional<ProductSeller> findByUuid(UUID shopUuid);

--- a/product/src/main/java/dukku/product/global/config/S3Config.java
+++ b/product/src/main/java/dukku/product/global/config/S3Config.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -25,6 +26,16 @@ public class S3Config {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(credentials))
                 .build();

--- a/product/src/main/java/dukku/product/global/config/SecurityDevConfig.java
+++ b/product/src/main/java/dukku/product/global/config/SecurityDevConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -21,8 +22,10 @@ import java.util.Arrays;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@Profile({"dev", "test"})  // 개발 환경 + 테스트 환경
+// 개발 환경 + 테스트 환경
+@Profile({"dev", "test"})
 public class SecurityDevConfig {
+
     @Value("${custom.security.cors.allowed-origins}")
     private String[] allowedOrigins;
 
@@ -31,7 +34,7 @@ public class SecurityDevConfig {
 
     /**
      * CSRF는 서버가 브라우저의 세션/쿠키를 신뢰할 때 공격 위험이 생김.
-     * JWT는 Authorization 헤더에 직접 담기 때문에 쿠키 자동 전송과 무관 → CSRF 공격 불가능.
+     * JWT는 Authorization 헤더에 직접 담기 때문에 쿠키 자동 전송과 무관 -> CSRF 공격 불가능.
      * REST API + JWT 조합은 주로 비동기 호출(fetch, axios) 사용.
      * 브라우저 폼 기반 요청이 아니므로 CSRF 보호 대상 아님.
      */
@@ -41,21 +44,21 @@ public class SecurityDevConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 /*
                   RESTful API는 무상태(stateless) 원칙
-                  JWT 기반 인증에서는 서버가 상태(session)를 보존하지 않음 → 클라이언트가 JWT를 매 요청마다 전송
+                  JWT 기반 인증에서는 서버가 상태(session)를 보존하지 않음 -> 클라이언트가 JWT를 매 요청마다 전송
                   그러므로 세션은 필요없음
                  */
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // 개발 환경: 모든 요청 허용
+                        .requestMatchers(HttpMethod.POST, "/api/v1/products/images/upload").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/products/images").authenticated()
+                        .anyRequest().permitAll()
                 )
                 .cors(cors -> cors.configurationSource(request -> {
                     var corsConfig = new org.springframework.web.cors.CorsConfiguration();
-                    corsConfig.setAllowedOrigins(
-                            Arrays.asList(allowedOrigins)
-                    );
-                    corsConfig.setAllowedMethods(Arrays.asList("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
-                    corsConfig.setAllowedHeaders(Arrays.asList("Authorization","Content-Type", "Idempotency-Key"));
+                    corsConfig.setAllowedOrigins(Arrays.asList(allowedOrigins));
+                    corsConfig.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+                    corsConfig.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Idempotency-Key"));
                     corsConfig.setAllowCredentials(true);
                     return corsConfig;
                 }))

--- a/product/src/main/java/dukku/product/global/config/SecurityReleaseConfig.java
+++ b/product/src/main/java/dukku/product/global/config/SecurityReleaseConfig.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -24,6 +25,7 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 @Profile("release")
 public class SecurityReleaseConfig {
+
     @Value("${custom.security.cors.allowed-origins}")
     private String[] allowedOrigins;
 
@@ -32,7 +34,7 @@ public class SecurityReleaseConfig {
 
     /**
      * CSRF는 서버가 브라우저의 세션/쿠키를 신뢰할 때 공격 위험이 생김.
-     * JWT는 Authorization 헤더에 직접 담기 때문에 쿠키 자동 전송과 무관 → CSRF 공격 불가능.
+     * JWT는 Authorization 헤더에 직접 담기 때문에 쿠키 자동 전송과 무관 -> CSRF 공격 불가능.
      * REST API + JWT 조합은 주로 비동기 호출(fetch, axios) 사용.
      * 브라우저 폼 기반 요청이 아니므로 CSRF 보호 대상 아님.
      */
@@ -42,22 +44,22 @@ public class SecurityReleaseConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 /*
                   RESTful API는 무상태(stateless) 원칙
-                  JWT 기반 인증에서는 서버가 상태(session)를 보존하지 않음 → 클라이언트가 JWT를 매 요청마다 전송
+                  JWT 기반 인증에서는 서버가 상태(session)를 보존하지 않음 -> 클라이언트가 JWT를 매 요청마다 전송
                   그러므로 세션은 필요없음
                  */
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(SecurityWhitelist.COMMON_PUBLIC)
-                                .permitAll()
+                        .requestMatchers(SecurityWhitelist.COMMON_PUBLIC).permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/products/images/upload").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/products/images").authenticated()
                         .requestMatchers(
-                                "/api/v1/categories", // GET: Public
-                                "/api/v1/products/featured", // GET: Public
-                                "/api/v1/products", // GET: Public
-                                "/api/v1/products/**", // GET: Public
-                                "/api/v1/shops/**" // GET: Public
-                        )
-                                .permitAll() // 인증 필요없음 -> filter 미실행
+                                "/api/v1/categories",
+                                "/api/v1/products/featured",
+                                "/api/v1/products",
+                                "/api/v1/products/**",
+                                "/api/v1/shops/**"
+                        ).permitAll() // 인증 필요없음 -> filter 미실행
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")// ADMIN만 접근
 //                        .requestMatchers("/actuator/**")
 //                        .access((auth, ctx) ->
@@ -65,16 +67,13 @@ public class SecurityReleaseConfig {
 //                                        "0.0.0.0".equals(ctx.getRequest().getRemoteAddr()) //로그 서버 컨테이너 IP
 //                                )
 //                        )
-
                         .anyRequest().authenticated() // 그 외는 인증 필요
                 )
                 .cors(cors -> cors.configurationSource(request -> {
                     var corsConfig = new org.springframework.web.cors.CorsConfiguration();
-                    corsConfig.setAllowedOrigins(
-                            Arrays.asList(allowedOrigins)
-                    );
-                    corsConfig.setAllowedMethods(Arrays.asList("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
-                    corsConfig.setAllowedHeaders(Arrays.asList("Authorization","Content-Type", "Idempotency-Key"));
+                    corsConfig.setAllowedOrigins(Arrays.asList(allowedOrigins));
+                    corsConfig.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+                    corsConfig.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "Idempotency-Key"));
                     corsConfig.setAllowCredentials(true);
                     return corsConfig;
                 }))

--- a/product/src/main/resources/application-release.yml
+++ b/product/src/main/resources/application-release.yml
@@ -1,4 +1,7 @@
 spring:
+  kafka:
+    listener:
+      auto-startup: true
   datasource:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
@@ -15,7 +18,7 @@ product:
   init:
     enabled: false
     clear-es-on-startup: false
-  reindex-on-startup: false
+  reindex-on-startup: true
 
 springdoc:
   api-docs:

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -20,12 +20,15 @@ spring:
     uris: ${ELASTICSEARCH_URL:http://elasticsearch:9200}
     socket-timeout: 30s
     connection-timeout: 5s
+  kafka:
+    listener:
+      auto-startup: true
 
 product:
   init:
     enabled: false
     clear-es-on-startup: false
-  reindex-on-startup: false
+  reindex-on-startup: true
 
 management:
   endpoints:

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -6,6 +6,10 @@ spring:
     import: classpath:application-common.yml
   application:
     name: product
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 20MB
 
   datasource:
     url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:product_service}?sslmode=${DB_SSLMODE:disable}

--- a/product/src/test/java/dukku/product/boundedContext/product/app/cqrs/DeleteProductSyncUseCaseTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/app/cqrs/DeleteProductSyncUseCaseTest.java
@@ -8,6 +8,8 @@ import dukku.product.boundedContext.product.out.ProductSearchRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -30,6 +32,12 @@ class DeleteProductSyncUseCaseTest {
     @Mock
     private ProductRepository productRepository;
 
+    @Mock
+    private ElasticsearchOperations elasticsearchOperations;
+
+    @Mock
+    private IndexOperations indexOperations;
+
     @InjectMocks
     private DeleteProductSyncUseCase useCase;
 
@@ -49,6 +57,7 @@ class DeleteProductSyncUseCaseTest {
 
         when(productSearchRepository.findById("42")).thenReturn(Optional.of(existing));
         when(productRepository.findById(42)).thenReturn(Optional.of(product));
+        when(elasticsearchOperations.indexOps(ProductDocument.class)).thenReturn(indexOperations);
 
         useCase.deletedProductToElasticsearch(42L);
 
@@ -59,6 +68,7 @@ class DeleteProductSyncUseCaseTest {
         assertThat(saved.getId()).isEqualTo("42");
         assertThat(saved.getVisibilityStatus()).isEqualTo(VisibilityStatus.HIDDEN);
         assertThat(saved.getDeletedAt()).isEqualTo(deletedAt);
+        verify(indexOperations).refresh();
     }
 
     @Test
@@ -70,5 +80,6 @@ class DeleteProductSyncUseCaseTest {
 
         verify(productRepository, never()).findById(42);
         verify(productSearchRepository, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(elasticsearchOperations, never()).indexOps(ProductDocument.class);
     }
 }

--- a/product/src/test/java/dukku/product/boundedContext/product/app/cqrs/SaveToElasticSearchUseCaseTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/app/cqrs/SaveToElasticSearchUseCaseTest.java
@@ -1,0 +1,106 @@
+package dukku.product.boundedContext.product.app.cqrs;
+
+import dukku.common.shared.product.type.SaleStatus;
+import dukku.common.shared.product.type.VisibilityStatus;
+import dukku.product.boundedContext.product.entity.Category;
+import dukku.product.boundedContext.product.entity.Product;
+import dukku.product.boundedContext.product.entity.query.ProductDocument;
+import dukku.product.boundedContext.product.out.CategoryRepository;
+import dukku.product.boundedContext.product.out.ProductSearchRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SaveToElasticSearchUseCaseTest {
+
+    @Mock
+    private ProductSearchRepository productSearchRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private ElasticsearchOperations elasticsearchOperations;
+
+    @Mock
+    private IndexOperations indexOperations;
+
+    @InjectMocks
+    private SaveToElasticSearchUseCase useCase;
+
+    @Test
+    @DisplayName("전체 저장 후 ES index refresh를 호출한다")
+    void refreshAfterFullSave() {
+        Product product = mock(Product.class);
+        Category category = mock(Category.class);
+        when(category.getId()).thenReturn(10);
+        when(product.getId()).thenReturn(42);
+        when(product.getUuid()).thenReturn(UUID.randomUUID());
+        when(product.getSellerUuid()).thenReturn(UUID.randomUUID());
+        when(product.getCategory()).thenReturn(category);
+        when(product.getTitle()).thenReturn("title");
+        when(product.getDescription()).thenReturn("desc");
+        when(product.getPrice()).thenReturn(1000L);
+        when(product.getShippingFee()).thenReturn(0L);
+        when(product.getConditionStatus()).thenReturn(null);
+        when(product.getSaleStatus()).thenReturn(SaleStatus.ON_SALE);
+        when(product.getVisibilityStatus()).thenReturn(VisibilityStatus.VISIBLE);
+        when(product.getLikeCount()).thenReturn(0);
+        when(product.getViewCount()).thenReturn(0);
+        when(product.getCommentCount()).thenReturn(0);
+        when(product.getCreatedAt()).thenReturn(LocalDateTime.now());
+        when(product.getDeletedAt()).thenReturn(null);
+        when(product.getImages()).thenReturn(List.of());
+        when(product.getTagNames()).thenReturn(List.of());
+
+        when(categoryRepository.findCategoryPathIds(10)).thenReturn(List.of(10));
+        when(elasticsearchOperations.indexOps(ProductDocument.class)).thenReturn(indexOperations);
+
+        useCase.execute(product, true);
+
+        verify(productSearchRepository).save(any(ProductDocument.class));
+        verify(indexOperations).refresh();
+    }
+
+    @Test
+    @DisplayName("부분 업데이트 후 ES index refresh를 호출한다")
+    void refreshAfterPartialUpdate() {
+        Product product = mock(Product.class);
+        when(product.getId()).thenReturn(42);
+        when(product.getTitle()).thenReturn("title");
+        when(product.getDescription()).thenReturn("desc");
+        when(product.getPrice()).thenReturn(1000L);
+        when(product.getShippingFee()).thenReturn(0L);
+        when(product.getConditionStatus()).thenReturn(null);
+        when(product.getSaleStatus()).thenReturn(SaleStatus.ON_SALE);
+        when(product.getVisibilityStatus()).thenReturn(VisibilityStatus.VISIBLE);
+        when(product.getImages()).thenReturn(List.of());
+        when(product.getTagNames()).thenReturn(List.of());
+
+        when(productSearchRepository.existsById("42")).thenReturn(true);
+        when(elasticsearchOperations.getIndexCoordinatesFor(ProductDocument.class))
+                .thenReturn(IndexCoordinates.of("products_v1"));
+        when(elasticsearchOperations.indexOps(ProductDocument.class)).thenReturn(indexOperations);
+
+        useCase.execute(product, false);
+
+        verify(elasticsearchOperations).update(any(), any(IndexCoordinates.class));
+        verify(indexOperations).refresh();
+    }
+}

--- a/product/src/test/java/dukku/product/boundedContext/product/entity/ProductReleaseReservationTest.java
+++ b/product/src/test/java/dukku/product/boundedContext/product/entity/ProductReleaseReservationTest.java
@@ -1,0 +1,58 @@
+package dukku.product.boundedContext.product.entity;
+
+import dukku.common.shared.product.type.ConditionStatus;
+import dukku.common.shared.product.type.SaleStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProductReleaseReservationTest {
+
+    @Test
+    @DisplayName("결제 확정 후 SOLD_OUT 상품도 동일 주문 취소 시 ON_SALE로 복구된다")
+    void releaseReservationShouldReopenSoldOutForSameOrder() {
+        UUID orderUuid = UUID.randomUUID();
+        Product product = createProduct();
+
+        product.reserve(orderUuid);
+        product.confirmSale(orderUuid);
+
+        assertThat(product.getSaleStatus()).isEqualTo(SaleStatus.SOLD_OUT);
+
+        product.releaseReservation(orderUuid);
+
+        assertThat(product.getSaleStatus()).isEqualTo(SaleStatus.ON_SALE);
+        assertThat(product.getReservedOrderUuid()).isNull();
+    }
+
+    @Test
+    @DisplayName("다른 주문 UUID로는 SOLD_OUT 복구되지 않는다")
+    void releaseReservationShouldIgnoreDifferentOrder() {
+        UUID reservedOrderUuid = UUID.randomUUID();
+        Product product = createProduct();
+
+        product.reserve(reservedOrderUuid);
+        product.confirmSale(reservedOrderUuid);
+
+        product.releaseReservation(UUID.randomUUID());
+
+        assertThat(product.getSaleStatus()).isEqualTo(SaleStatus.SOLD_OUT);
+        assertThat(product.getReservedOrderUuid()).isEqualTo(reservedOrderUuid);
+    }
+
+    private Product createProduct() {
+        Category category = Category.createRoot("전자기기");
+        return Product.create(
+                UUID.randomUUID(),
+                category,
+                "테스트 상품",
+                "설명",
+                10_000L,
+                0L,
+                ConditionStatus.NO_WEAR
+        );
+    }
+}

--- a/user/src/main/java/dukku/user/boundedContext/user/entity/User.java
+++ b/user/src/main/java/dukku/user/boundedContext/user/entity/User.java
@@ -39,6 +39,9 @@ public class User extends SourceUser {
     @Column(name = "withdrawal_nickname_backup", length = 100, comment = "탈퇴 시 백업된 닉네임(암호화)")
     private String withdrawalNicknameBackup;
 
+    @Column(length = 1000, comment = "유저 소개")
+    private String intro;
+
     @OneToMany(mappedBy = "user")
     private List<Address> addresses = new ArrayList<>();
 
@@ -54,6 +57,7 @@ public class User extends SourceUser {
 
     public void updateUser(UserUpdateRequest req) {
         this.setNickname(req.getName());
+        this.intro = req.getIntro();
     }
 
     public void updateRole(Role role) {
@@ -115,6 +119,7 @@ public class User extends SourceUser {
                 user.getUuid(),
                 user.getEmail(),
                 user.getNickname(),
+                user.getIntro(),
                 user.getRole(),
                 user.getStatus(),
                 user.getStatus().getLabel(),

--- a/user/src/main/resources/db/migration/user/V2__add_intro_to_users.sql
+++ b/user/src/main/resources/db/migration/user/V2__add_intro_to_users.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS intro varchar(1000);


### PR DESCRIPTION
﻿## PR 제목

[User] 마이페이지에 자기소개(상점소개) 텍스트가 노출되지 않음 #329

---

## 개요

마이페이지에서 자기소개(intro)가 저장/조회되지 않던 문제를 수정했습니다.
User 도메인/요청/응답 모델과 DB 스키마에 intro 필드를 반영했습니다.

---

## 상세 내용

**intro 필드 저장/조회 지원 추가**
SHA : 4b3835c5331a35346d16e08dd5c0afdd6ce984b2
- User 엔티티에 intro 컬럼을 추가하고 업데이트 로직에 반영했습니다.
- UserUpdateRequest/UserResponse에 intro 필드를 추가해 API 입출력을 확장했습니다.
- Flyway 마이그레이션(V2)으로 users 테이블 intro 컬럼을 추가했습니다.

---

## PR 유형 (라벨 지정 필수)

- [x] 새로운 기능 추가 (Feat)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 문서 수정 (Docs)
- [ ] 기타 작업 (Chore)  
      - 설정, 패키지, 잡일  
      - 주석 추가  
      - 파일/폴더 이름 변경 및 삭제
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/패키지/인프라 수정 (Build / Infra)
- [ ] 배포 작업 (Release)

---

## PR Checklist

### 기본 체크
- [x] 커밋 메시지가 컨벤션에 맞는가?
- [x] 변경 사항이 테스트되었는가?
- [x] 코드 스타일 가이드에 맞는가?

### 코드 품질 체크
- [x] 전체 흐름이 자연스러운가?  
      (컨트롤러 → 서비스 → 도메인)
- [x] 메소드 역할과 책임이 적절하게 분리되었는가?
- [x] 어노테이션 사용이 목적에 맞는가?
  - 예: `@Transactional`, `@Validated`, `@RequestBody` 등

### 안정성 체크
- [x] 기존 기능에 영향을 주지 않는가?
- [x] 불필요한 코드/로그가 남아있지 않은가?

---

## 리뷰어에게 요청 사항

> 리뷰어가 **어디를 중점적으로 보면 좋을지** 작성해주세요.

- **중점적으로 봐주면 좋은 부분**: 요청/응답 DTO와 엔티티 간 intro 매핑 누락 여부
- **고민했던 설계 포인트**: 기존 사용자 데이터와의 마이그레이션 호환성
- **리뷰 시 특히 피드백 받고 싶은 부분**: intro nullable 정책과 길이 제한 기준

---

Closes #329
