### PR TITLE
[Product] 상품 상세 조회 응답에 Redis 통계 반영 #341

### DIFF
--- a/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/ProductStatsRedisSupport.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/cqrs/ProductStatsRedisSupport.java
@@ -14,48 +14,79 @@ public class ProductStatsRedisSupport {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    // Redis Key 상수 관리
     private static final String DIRTY_KEY = "product:stats:dirty";
     private static final String VIEW_KEY_PREFIX = "product:stats:view:";
     private static final String LIKE_KEY_PREFIX = "product:stats:like:";
     private static final String COMMENT_KEY_PREFIX = "product:stats:comment:";
 
-    /** [Write] 숫자 증가/감소 및 Dirty Marking */
+    // 좋아요 수를 1 증가
     public void incrementLike(int productId) {
         redisTemplate.opsForValue().increment(LIKE_KEY_PREFIX + productId);
         markDirty(String.valueOf(productId));
     }
 
+    // 좋아요 수를 1 감소
     public void decrementLike(int productId) {
         redisTemplate.opsForValue().decrement(LIKE_KEY_PREFIX + productId);
         markDirty(String.valueOf(productId));
     }
 
+    // 댓글 수를 1 증가
     public void incrementComment(int productId) {
         redisTemplate.opsForValue().increment(COMMENT_KEY_PREFIX + productId);
         markDirty(String.valueOf(productId));
     }
 
+    // 댓글 수를 1 감소
     public void decrementComment(int productId) {
         redisTemplate.opsForValue().decrement(COMMENT_KEY_PREFIX + productId);
         markDirty(String.valueOf(productId));
     }
 
+    // 조회수 1 증가
     public void incrementView(int productId) {
         redisTemplate.opsForValue().increment(VIEW_KEY_PREFIX + productId);
         markDirty(String.valueOf(productId));
     }
 
+    // 동기화가 필요한 상품 ID를 dirty 집합에 기록
     private void markDirty(String productId) {
         redisTemplate.opsForSet().add(DIRTY_KEY, productId);
     }
 
-    /** [Read] 변경된 ID 목록 조회 */
+    // Redis에서 현재 좋아요 카운트를 조회
+    public Long getLikeCount(int productId) {
+        Object value = redisTemplate.opsForValue().get(LIKE_KEY_PREFIX + productId);
+        if (value == null) {
+            return null;
+        }
+        return parseLongSafe(value);
+    }
+
+    // Redis에서 현재 조회수를 조회
+    public Long getViewCount(int productId) {
+        Object value = redisTemplate.opsForValue().get(VIEW_KEY_PREFIX + productId);
+        if (value == null) {
+            return null;
+        }
+        return parseLongSafe(value);
+    }
+
+    // Redis에서 현재 댓글 수를 조회
+    public Long getCommentCount(int productId) {
+        Object value = redisTemplate.opsForValue().get(COMMENT_KEY_PREFIX + productId);
+        if (value == null) {
+            return null;
+        }
+        return parseLongSafe(value);
+    }
+
+    // 동기화 대기 중인 상품 ID 목록 조회
     public Set<Object> getDirtyProductIds() {
         return redisTemplate.opsForSet().members(DIRTY_KEY);
     }
 
-    /** [Read] 여러 상품의 통계(조회/좋아요/댓글)를 한 번에 조회 (MGET) */
+    // 여러 상품의 view/like/comment 카운트를 한 번에 조회
     public List<Object> getMultiStats(List<Integer> productIds) {
         List<String> keys = new ArrayList<>();
         for (Integer id : productIds) {
@@ -67,15 +98,15 @@ public class ProductStatsRedisSupport {
         return redisTemplate.opsForValue().multiGet(keys);
     }
 
-    /** [Delete] 처리 완료된 Dirty Key 제거 */
     public void cleanupDirtyIds(Set<Object> processedIds) {
         redisTemplate.opsForSet().remove(DIRTY_KEY, processedIds.toArray());
     }
 
-    // 유틸: Null Safe Parsing
+    // Redis 값 타입이 Integer/Long/String 등으로 들어와도 안전하게 Long으로 변환
     public long parseLongSafe(Object value) {
-        if (value == null)
+        if (value == null) {
             return 0L;
+        }
         try {
             return Long.parseLong(String.valueOf(value));
         } catch (NumberFormatException e) {

--- a/product/src/main/java/dukku/product/boundedContext/product/app/support/ProductMapper.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/support/ProductMapper.java
@@ -12,10 +12,12 @@ import java.util.List;
 
 public class ProductMapper {
 
+    // 리스트 조회용 DTO 매핑(태그 기본 적용)
     public static ProductListItemResponse toListItem(Product p) {
         return toListItem(p, p.getTagNames());
     }
 
+    // 리스트 조회용 DTO 매핑(태그 목록 override)
     public static ProductListItemResponse toListItem(Product p, List<String> tagNames) {
         String thumb = p.getImages().stream().min(Comparator.comparingInt(ProductImage::getSortOrder))
                 .map(ProductImage::getImageUrl)
@@ -35,20 +37,36 @@ public class ProductMapper {
                 .build();
     }
 
+    // 상세 정보 매핑 (기본 스펙)
     public static ProductDetailResponse toDetail(Product p) {
         return toDetail(p, null, null);
     }
 
+    // 상세 정보 매핑 (판매자/닉네임 포함)
     public static ProductDetailResponse toDetail(Product p, ProductSeller seller, String nickname) {
         return toDetail(p, seller, nickname, null, null);
     }
 
+    // 상세 정보 매핑 (평점/리뷰 수 포함)
     public static ProductDetailResponse toDetail(
             Product p,
             ProductSeller seller,
             String nickname,
             BigDecimal averageRating,
             Integer reviewCount
+    ) {
+        return toDetail(p, seller, nickname, averageRating, reviewCount, null, null);
+    }
+
+    // 상세 정보 매핑 (좋아요/조회수 override 허용)
+    public static ProductDetailResponse toDetail(
+            Product p,
+            ProductSeller seller,
+            String nickname,
+            BigDecimal averageRating,
+            Integer reviewCount,
+            Integer likeCount,
+            Integer viewCount
     ) {
         List<String> imageUrls = p.getImages().stream()
                 .sorted(Comparator.comparingInt(ProductImage::getSortOrder))
@@ -70,8 +88,8 @@ public class ProductMapper {
                 .description(p.getDescription())
                 .price(p.getPrice())
                 .shippingFee(p.getShippingFee())
-                .likeCount(p.getLikeCount())
-                .viewCount(p.getViewCount())
+                .likeCount(likeCount != null ? likeCount : p.getLikeCount())
+                .viewCount(viewCount != null ? viewCount : p.getViewCount())
                 .imageUrls(imageUrls)
                 .conditionStatus(p.getConditionStatus())
                 .saleStatus(p.getSaleStatus())
@@ -93,18 +111,18 @@ public class ProductMapper {
                 .build();
     }
 
-    // 환경 변수 FRONTEND_BASE_URL 또는 시스템 속성 frontend.base.url을 사용해
-    // 상품 상세 페이지 URL을 생성합니다.
-    // 예: https://dukku.shop/products/{productUuid}
+    // 공유 URL 생성용 기본 도메인 조립
     public static String buildProductUrl(java.util.UUID productUuid) {
         String base = System.getenv("FRONTEND_BASE_URL");
         if (base == null || base.isBlank()) {
             base = System.getProperty("frontend.base.url");
         }
         if (base == null || base.isBlank()) {
-            base = "https://dukku.shop"; // 기본 폴백
+            base = "https://dukku.shop";
         }
-        if (base.endsWith("/")) base = base.substring(0, base.length() - 1);
-        return base + "/products/" + productUuid.toString();
+        if (base.endsWith("/")) {
+            base = base.substring(0, base.length() - 1);
+        }
+        return base + "/products/" + productUuid;
     }
 }

--- a/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
+++ b/product/src/main/java/dukku/product/boundedContext/product/app/usecase/product/FindProductDetailUseCase.java
@@ -35,48 +35,65 @@ public class FindProductDetailUseCase {
     private final SellerReviewRepository sellerReviewRepository;
     private final UserApiClient userApiClient;
 
+    // 상품 상세 조회 + 통계 캐시 반영 + 응답 DTO 조립
     @Transactional
     public ProductDetailResponse execute(UUID productUuid) {
-        log.info("[FindProductDetailUseCase] 상품 상세 조회 시작. productUuid={}", productUuid);
+        log.info("[FindProductDetailUseCase] Find product detail. productUuid={}", productUuid);
 
         Product product = productRepository.findByUuidWithImagesAndCategory(productUuid)
                 .or(() -> {
-                    log.warn("[FindProductDetailUseCase] 패치 조인 조회 실패, 기본 조회로 재시도. productUuid={}", productUuid);
+                    log.warn("[FindProductDetailUseCase] fallback fetch by uuid. productUuid={}", productUuid);
                     return productRepository.findByUuid(productUuid);
                 })
                 .orElseThrow(() -> {
-                    log.error("[FindProductDetailUseCase] 상품을 찾을 수 없습니다. productUuid={}", productUuid);
+                    log.error("[FindProductDetailUseCase] product not found. productUuid={}", productUuid);
                     return new ProductNotFoundException();
                 });
 
-        log.info("[FindProductDetailUseCase] 상품 조회 성공. title={}, sellerUuid={}", product.getTitle(), product.getSellerUuid());
+        log.info("[FindProductDetailUseCase] found product. title={}, sellerUuid={}", product.getTitle(), product.getSellerUuid());
 
         productStatsRedisSupport.incrementView(product.getId());
+        Long redisViewCount = productStatsRedisSupport.getViewCount(product.getId());
+        Long redisLikeCount = productStatsRedisSupport.getLikeCount(product.getId());
 
-        // Product.sellerUuid는 seller UUID이므로 sellerUuid 기준으로 먼저 조회한다.
         ProductSeller seller = productSellerRepository.findBySellerUuid(product.getSellerUuid())
-                // 과거 데이터 호환: sellerUuid에 userUuid가 들어간 레코드도 허용
                 .or(() -> productSellerRepository.findByUserUuid(product.getSellerUuid()))
                 .orElseGet(() -> {
-                    // 상세 조회(GET)에서 DB write를 유발하지 않도록 비영속 기본값만 사용한다.
-                    log.warn("[FindProductDetailUseCase] 상점 정보 누락. 기본값으로 응답합니다. sellerUuid={}, productUuid={}",
+                    log.warn("[FindProductDetailUseCase] seller not found, fallback. sellerUuid={}, productUuid={}",
                             product.getSellerUuid(), productUuid);
-                    return ProductSeller.create(product.getSellerUuid(), "판매 중인 상점입니다.");
+                    return ProductSeller.create(product.getSellerUuid(), "default-nickname");
                 });
 
-        log.info("[FindProductDetailUseCase] 상점 정보 조회 성공. sellerUserUuid={}", seller.getUserUuid());
+        log.info("[FindProductDetailUseCase] seller found. sellerUserUuid={}", seller.getUserUuid());
 
+        // 판매자 닉네임 조회 실패 시 사용자 서비스 조회로 보강
         String nickname = resolveNicknameWithBackfill(seller.getUserUuid());
         long reviewCountLong = sellerReviewRepository.countBySellerUuidAndDeletedAtIsNull(seller.getSellerUuid());
         int reviewCount = Math.toIntExact(reviewCountLong);
         BigDecimal averageRating = BigDecimal.valueOf(sellerReviewRepository.avgRating(seller.getSellerUuid()))
                 .setScale(2, RoundingMode.HALF_UP);
 
-        log.info("[FindProductDetailUseCase] 최종 조회 완료. nickname={}", nickname);
+        int resolvedLikeCount = redisLikeCount == null
+                ? product.getLikeCount()
+                : redisLikeCount.intValue();
+        int resolvedViewCount = redisViewCount == null
+                ? product.getViewCount()
+                : redisViewCount.intValue();
 
-        return ProductMapper.toDetail(product, seller, nickname, averageRating, reviewCount);
+        log.info("[FindProductDetailUseCase] completed. nickname={}", nickname);
+
+        return ProductMapper.toDetail(
+                product,
+                seller,
+                nickname,
+                averageRating,
+                reviewCount,
+                resolvedLikeCount,
+                resolvedViewCount
+        );
     }
 
+    // 로컬 사용자 테이블에 닉네임이 없으면 사용자 API로 보강 조회
     private String resolveNicknameWithBackfill(UUID userUuid) {
         return productUserRepository.findById(userUuid)
                 .map(ProductUser::getNickname)
@@ -84,26 +101,27 @@ public class FindProductDetailUseCase {
                 .orElseGet(() -> fetchAndBackfillNickname(userUuid));
     }
 
+    // 사용자 API에서 닉네임 조회, 실패 시 기본값 반환
     private String fetchAndBackfillNickname(UUID userUuid) {
         try {
             UserProfileResponse profile = userApiClient.getUserProfile(userUuid);
             String nickname = profile == null ? null : profile.getNickname();
             if (!StringUtils.hasText(nickname)) {
-                return "이름없음";
+                return "anonymous";
             }
 
             if (!productUserRepository.existsById(userUuid)) {
                 try {
                     productUserRepository.save(ProductUser.create(userUuid, nickname));
                 } catch (Exception e) {
-                    log.warn("[FindProductDetailUseCase] ProductUser 보정 저장 실패. userUuid={}", userUuid, e);
+                    log.warn("[FindProductDetailUseCase] ProductUser save failed. userUuid={}", userUuid, e);
                 }
             }
 
             return nickname;
         } catch (Exception e) {
-            log.warn("[FindProductDetailUseCase] 사용자 프로필 조회 실패로 기본 닉네임 사용. userUuid={}", userUuid, e);
-            return "이름없음";
+            log.warn("[FindProductDetailUseCase] lookup user profile failed. userUuid={}", userUuid, e);
+            return "anonymous";
         }
     }
 }


### PR DESCRIPTION
## PR 제목

- 상품 상세 조회 응답에 Redis 통계를 우선 반영해 실시간성을 개선

## Summary

- 상품 상세 조회 시점에 증가한 조회수/좋아요 수를 Redis 기준으로 응답에 반영하도록 정리했습니다.
- DB 반영 지연 구간에서 상세 화면 통계가 늦게 보이는 문제를 완화했습니다.
- 상세 DTO 매퍼 시그니처를 확장해 통계 오버라이드 값을 안전하게 주입하도록 변경했습니다.

## Details

### 백엔드
- `ProductStatsRedisSupport`
  - 상품별 좋아요/조회수/댓글 단건 조회 메서드(`getLikeCount`, `getViewCount`, `getCommentCount`) 추가
  - Redis 값 파싱 유틸 정리
- `ProductMapper`
  - `toDetail(...)` 오버로드 확장: `likeCount`, `viewCount` override 파라미터 추가
- `FindProductDetailUseCase`
  - 상세 조회 시 `incrementView` 이후 Redis 통계를 조회해 응답 조립에 우선 사용
  - Redis 값이 없을 때 DB 필드 fallback 처리
  - 판매자/닉네임 fallback 주석 및 로그 정리

## PR Type
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore
- [ ] Test
- [ ] Build/Infra
- [ ] Release

## PR Checklist
- [x] 기존 기능 동작 영향 범위를 파악했는가?
- [x] 도메인/도메인 정책을 위반하지 않았는가?
- [x] UseCase/Mapper/Support 레이어 경계를 유지했는가?
- [ ] 테스트를 추가/갱신했는가?

## Related Issues
Closes #341
Refs #323

## References
- branch: `feat/product-detail-redis-stats-341`
- commit: `2f2688d1`