### PR TITLE
[Common] Authorization Resolver 회귀 테스트 보강 #343

### DIFF
--- a/common/src/test/java/dukku/common/global/auth/RequestAuthorizationHeaderResolverTest.java
+++ b/common/src/test/java/dukku/common/global/auth/RequestAuthorizationHeaderResolverTest.java
@@ -1,0 +1,54 @@
+package dukku.common.global.auth;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RequestAuthorizationHeaderResolverTest {
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 Bearer 접두어를 포함하면 그대로 반환한다")
+    void returnsBearerHeaderAsIs() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer token-value");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        String resolved = RequestAuthorizationHeaderResolver.resolve();
+
+        assertThat(resolved).isEqualTo("Bearer token-value");
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더에 Bearer 접두어가 없으면 자동으로 추가한다")
+    void addsBearerPrefixWhenMissing() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "token-value");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        String resolved = RequestAuthorizationHeaderResolver.resolve();
+
+        assertThat(resolved).isEqualTo("Bearer token-value");
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더 앞뒤 공백은 제거 후 Bearer 포맷으로 반환한다")
+    void trimsAuthorizationHeaderBeforeNormalization() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "   token-value   ");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        String resolved = RequestAuthorizationHeaderResolver.resolve();
+
+        assertThat(resolved).isEqualTo("Bearer token-value");
+    }
+}


### PR DESCRIPTION
﻿## PR 제목

- 내부 API 인증 헤더 해석 로직의 회귀를 막기 위해 Authorization Resolver 단위 테스트를 추가

## Summary

- 선행 변경(`ea3d91ed`)으로 내부 API 호출 인증 로직이 `RequestAuthorizationHeaderResolver`로 모이면서, 핵심 정규화 동작을 테스트로 고정했습니다.
- `Bearer` 접두어 처리와 공백 정리 규칙을 명시적으로 검증해 향후 리팩터링 시 401 회귀 가능성을 낮췄습니다.

## Details

### 백엔드
- `RequestAuthorizationHeaderResolverTest` 추가
  - `Authorization: Bearer <token>` 입력 시 원형 유지 검증
  - `Authorization: <token>` 입력 시 `Bearer ` 자동 접두어 부여 검증
  - 앞뒤 공백 포함 토큰 입력 시 trim + 정규화 검증

### 검증
- `./gradlew.bat :common:test --tests "*RequestAuthorizationHeaderResolverTest"` 통과

## PR Type
- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore
- [x] Test
- [ ] Build/Infra
- [ ] Release

## PR Checklist
- [x] 기존 기능 동작 영향 범위를 파악했는가?
- [x] 도메인/도메인 정책을 위반하지 않았는가?
- [x] UseCase/Mapper/Support 레이어 경계를 유지했는가?
- [x] 테스트를 추가/갱신했는가?

## Related Issues
Closes #343
Refs ea3d91ed

## References
- branch: `feat/common-auth-resolver-test-343`
- commit: `37c20101`
